### PR TITLE
adaptations for compilation with GCC-9 and OpenMPI-4.0.1

### DIFF
--- a/src/core/comms_mod.F90
+++ b/src/core/comms_mod.F90
@@ -19,16 +19,16 @@ MODULE comms_mod
     PRIVATE
 
     ! Communicator over shared memory space, i.e. one compute node
-    TYPE(MPI_Comm), PROTECTED :: shmcomm = MPI_COMM_NULL
+    TYPE(MPI_Comm), PROTECTED :: shmcomm
 
     ! Communicator with lowest ranks at each SHM segment (SHM masters)
-    TYPE(MPI_Comm), PROTECTED :: shm_masters_comm = MPI_COMM_NULL
+    TYPE(MPI_Comm), PROTECTED :: shm_masters_comm
 
     ! Communicator gropuping toghether processes associated with an IO process
-    TYPE(MPI_Comm), PROTECTED :: iogrcomm = MPI_COMM_NULL
+    TYPE(MPI_Comm), PROTECTED :: iogrcomm
 
     ! Communicator for processes participating in IO operations
-    TYPE(MPI_Comm), PROTECTED :: iocomm = MPI_COMM_NULL
+    TYPE(MPI_Comm), PROTECTED :: iocomm
 
     ! Rank and number of processes in node-local SHM communicator (shmcomm)
     INTEGER(int32), PROTECTED :: shmid = -1, shmprocs = -1
@@ -71,6 +71,12 @@ CONTAINS
         CHARACTER(len=32) :: serial
         INTEGER :: length, status
         CHARACTER(LEN=MPI_MAX_LIBRARY_VERSION_STRING) :: version
+
+        ! Initialization for deterministic behaviour
+        shmcomm = MPI_COMM_NULL
+        shm_masters_comm = MPI_COMM_NULL
+        iogrcomm = MPI_COMM_NULL
+        iocomm = MPI_COMM_NULL
 
         CALL MPI_Comm_rank(MPI_COMM_WORLD, myid)
         CALL MPI_Comm_size(MPI_COMM_WORLD, numprocs)

--- a/src/core/precision_mod.F90
+++ b/src/core/precision_mod.F90
@@ -11,12 +11,10 @@ MODULE precision_mod
 #ifdef _MGLET_DOUBLE_PRECISION_
     INTEGER(int32), PARAMETER :: realk = real64
     INTEGER(int32), PARAMETER :: c_realk = c_double
-    TYPE(MPI_Datatype), PARAMETER :: mglet_mpi_real = MPI_DOUBLE_PRECISION
     INTEGER(int32), PARAMETER :: real_bytes = 8
 #else
     INTEGER(int32), PARAMETER :: realk = real32
     INTEGER(int32), PARAMETER :: c_realk = c_float
-    TYPE(MPI_Datatype), PARAMETER :: mglet_mpi_real = MPI_REAL
     INTEGER(int32), PARAMETER :: real_bytes = 4
 #endif
 
@@ -24,14 +22,16 @@ MODULE precision_mod
 #ifdef _MGLET_INT64_
     INTEGER(int32), PARAMETER :: intk = int64
     INTEGER(int32), PARAMETER :: c_intk = c_long_long
-    TYPE(MPI_Datatype), PARAMETER :: mglet_mpi_int = MPI_INTEGER8
     INTEGER(int32), PARAMETER :: int_bytes = 8
 #else
     INTEGER(int32), PARAMETER :: intk = int32
     INTEGER(int32), PARAMETER :: c_intk = c_int
-    TYPE(MPI_Datatype), PARAMETER :: mglet_mpi_int = MPI_INTEGER
     INTEGER(int32), PARAMETER :: int_bytes = 4
 #endif
+
+    ! MPI data types for REAL and INTEGER
+    TYPE(MPI_Datatype), PROTECTED :: mglet_mpi_real
+    TYPE(MPI_Datatype), PROTECTED :: mglet_mpi_int
 
     ! HDF5 type for REAL and INTEGER
     INTEGER(HID_T), PROTECTED :: mglet_hdf5_real
@@ -83,6 +83,20 @@ CONTAINS
             WRITE(error_unit, '("precision_mod, unknown size: ", I0)') size
             STOP 255
         END IF
+
+        ! Set MPI data types
+#ifdef _MGLET_DOUBLE_PRECISION_
+        mglet_mpi_real = MPI_DOUBLE_PRECISION
+#else
+        mglet_mpi_real = MPI_REAL
+#endif
+
+#ifdef _MGLET_INT64_
+        mglet_mpi_int = MPI_INTEGER8
+#else
+        mglet_mpi_int = MPI_INTEGER
+#endif
+
     END SUBROUTINE init_precision
 
 


### PR DESCRIPTION
Dear developers,

as discussed, I am proposing the following changes, as MPI constants are apparently not recognized as constants for Gcc-9 and OpenMPI-4.0.1, which casues compile time errors.

Best regards,

Simon