### PR TITLE
fix in boussinesq term for double precision

### DIFF
--- a/src/flow/boussinesqterm_mod.F90
+++ b/src/flow/boussinesqterm_mod.F90
@@ -96,7 +96,7 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: kk, jj, ii
         REAL(realk), INTENT(inout) :: uo(kk, jj, ii), vo(kk, jj, ii), &
             wo(kk, jj, ii)
-        REAL, INTENT(in) :: t(kk, jj, ii)
+        REAL(realk), INTENT(in) :: t(kk, jj, ii)
         INTEGER(intk), INTENT(in) :: nfro, nbac, nrgt, nlft, nbot, ntop
 
         ! Local variables


### PR DESCRIPTION
Dear developers,

minor fix in the Boussinesq term to avoid compilation errors with double precision.

Best regards,

Simon