### PR TITLE
small fix to scalar boundary

### DIFF
--- a/src/scalar/bound_scalar_mod.F90
+++ b/src/scalar/bound_scalar_mod.F90
@@ -140,8 +140,8 @@ CONTAINS
                         END DO
                     END DO
                 ELSE
-                    DO j = 1, jj
-                        DO k = 1, kk
+                    DO j = 2, jj
+                        DO k = 2, kk
                             ! Setting the scalar flux with a wall model
                             ! Wall buffer tbuf contains set scalar value
                             area = ddy(j)*ddz(k)
@@ -330,8 +330,8 @@ CONTAINS
                         END DO
                     END DO
                 ELSE
-                    DO i = 1, ii
-                        DO k = 1, kk
+                    DO i = 2, ii
+                        DO k = 2, kk
                             ! Setting the scalar flux with a wall model
                             ! Wall buffer tbuf contains set scalar value
                             area = ddx(i)*ddz(k)
@@ -520,8 +520,8 @@ CONTAINS
                         END DO
                     END DO
                 ELSE
-                    DO i = 1, ii
-                        DO j = 1, jj
+                    DO i = 2, ii
+                        DO j = 2, jj
                             ! Setting the scalar flux with a wall model
                             ! Wall buffer tbuf contains set scalar value
                             area = ddx(i)*ddy(j)


### PR DESCRIPTION
Dear developers,

an "index-out-of-range" fix in the scalar boundary for LES. This is simply to make it run.

For documentation:

I am highly unsure if this boundary does what is designed to do, and if it's applicable to slip-walls. Therefore, I think that this boundary condition needs serious validation.

@fschwert : From your experience with scalar flux through smooth walls, do you happen to have any cheap test case in mind that could check this condition? That would be great.

Best regards,

Simon