### PR TITLE
Added integer field support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install 'gdb' and 'pidof'
       run: |
         source /opt/bashrc || true
-        yum ${{ contains(matrix.image, 'intel') && '--disablerepo=oneAPI' || '' }} -y install gdb sysvinit-tools
+        yum ${{ contains(matrix.image, 'intel') && '--disablerepo=oneAPI' || '' }} --disablerepo=ius -y install gdb sysvinit-tools
 
     - name: Run testcases
       run: |

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -16,7 +16,10 @@ add_library(core STATIC
     expression_mod.F90
     exprtk_wrapper.cxx
     fieldio2_mod.F90
-    field_mod.F90
+    field_t/basefield_mod.F90
+    field_t/field_mod.F90
+    field_t/intfield_mod.F90
+    field_t/realfield_mod.F90
     fields_mod.F90
     fort7_mod.F90
     gridio_mod.F90

--- a/src/core/checksum_mod.F90
+++ b/src/core/checksum_mod.F90
@@ -3,7 +3,7 @@ MODULE checksum_mod
     USE grids_mod, ONLY: mygridslvl, nmygridslvl, get_mgdims, &
         minlevel, maxlevel
     USE pointers_mod, ONLY: get_ip3, idim3d
-    USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_PTR, C_LOC, C_LONG, C_SIZEOF
+    USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_PTR, C_LOC, C_LONG
 
     IMPLICIT NONE(type, external)
     PRIVATE

--- a/src/core/commbuf_mod.F90
+++ b/src/core/commbuf_mod.F90
@@ -3,7 +3,7 @@ MODULE commbuf_mod
     USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_PTR, C_F_POINTER, C_LOC
     USE MPI_f08
 
-    USE precision_mod, ONLY: int64, intk, realk, int_bytes, real_bytes, int32
+    USE precision_mod, ONLY: int64, intk, realk, int_bytes, real_bytes
     USE pointers_mod, ONLY: idim2d, idim3d
 
     IMPLICIT NONE (type, external)

--- a/src/core/config_mod.F90
+++ b/src/core/config_mod.F90
@@ -671,7 +671,7 @@ CONTAINS
         c_key(LEN_TRIM(key)+1) = C_NULL_CHAR
 
         length = SIZE(arr)
-        CALL json_get_int_arr(this%handle, c_key, C_LOC(arr), length, ierr)
+        CALL json_get_int64_arr(this%handle, c_key, C_LOC(arr), length, ierr)
         IF (ierr /= 0) CALL errr(__FILE__, __LINE__)
 
         ! TODO: handle required

--- a/src/core/dlopen_mod.F90
+++ b/src/core/dlopen_mod.F90
@@ -19,7 +19,7 @@ MODULE dlopen_mod
     INTERFACE
         ! void * dlopen(const char *filename, int flag);
         FUNCTION dlopen(filename, mode) RESULT(handle) BIND(C, NAME='dlopen')
-            USE ISO_C_BINDING
+            IMPORT :: c_char, c_int, c_ptr
             CHARACTER(C_CHAR), DIMENSION(*), INTENT(IN) :: filename
             INTEGER(C_INT), VALUE :: mode
             TYPE(C_PTR) :: handle
@@ -27,7 +27,7 @@ MODULE dlopen_mod
 
         ! void *dlsym(void *handle, char *symbol);
         FUNCTION dlsym(handle, symbol) RESULT(funptr) BIND(C, NAME='dlsym')
-            USE ISO_C_BINDING
+            IMPORT :: c_char, c_funptr, c_ptr
             TYPE(C_PTR), VALUE :: handle
             CHARACTER(C_CHAR), DIMENSION(*), INTENT(IN) :: symbol
             TYPE(C_FUNPTR) :: funptr
@@ -36,7 +36,7 @@ MODULE dlopen_mod
         ! void *dlsym(void *handle, char *symbol);
         FUNCTION dlsym_ptr(handle, symbol) RESULT(ptr) BIND(C, NAME='dlsym')
             ! Returns a C_PTR instead of a C_FUNPTR
-            USE ISO_C_BINDING
+            IMPORT :: c_char, c_ptr
             TYPE(C_PTR), VALUE :: handle
             CHARACTER(C_CHAR), DIMENSION(*), INTENT(IN) :: symbol
             TYPE(C_PTR) :: ptr
@@ -44,21 +44,20 @@ MODULE dlopen_mod
 
         ! int dlclose(void *handle);
         FUNCTION dlclose(handle) RESULT(ierror) BIND(C, NAME='dlclose')
-            USE ISO_C_BINDING
+            IMPORT :: c_int, c_ptr
             TYPE(C_PTR), VALUE :: handle
             INTEGER(C_INT) :: ierror
         END FUNCTION
 
         ! char *dlerror(void);
         FUNCTION dlerror() RESULT(error) BIND(C, NAME='dlerror')
-            USE ISO_C_BINDING
+            IMPORT :: c_ptr
             TYPE(C_PTR) :: error
         END FUNCTION
     END INTERFACE
 
     PUBLIC :: shlib_load, finish_dlopen, shlib_get_fun, shlib_get_ptr, &
         init_dlopen
-
 
 CONTAINS
     SUBROUTINE init_dlopen()

--- a/src/core/err_mod.F90
+++ b/src/core/err_mod.F90
@@ -1,5 +1,5 @@
 MODULE err_mod
-    USE, INTRINSIC :: ISO_FORTRAN_ENV, ONLY: output_unit, error_unit
+    USE, INTRINSIC :: ISO_FORTRAN_ENV, ONLY: error_unit
 
     USE MPI_f08
 

--- a/src/core/field_mod.F90
+++ b/src/core/field_mod.F90
@@ -1,12 +1,8 @@
 MODULE field_mod
     USE HDF5
-    USE charfunc_mod, ONLY: lower
-    USE comms_mod, ONLY: myid
     USE err_mod, ONLY: errr
     USE grids_mod, ONLY: mygrids, nmygrids, minlevel, maxlevel, get_mgdims, &
         get_imygrid, level
-    USE hdf5common_mod, ONLY: hdf5common_open, hdf5common_close, &
-        hdf5common_group_open, hdf5common_group_close, hdf5common_attr_write
     USE pointers_mod, ONLY: get_len3, idim2d, get_ibb
     USE precision_mod, ONLY: intk, realk
     USE utils_mod, ONLY: get_stag_shift

--- a/src/core/field_t/basefield_mod.F90
+++ b/src/core/field_t/basefield_mod.F90
@@ -1,0 +1,349 @@
+MODULE basefield_mod
+    USE err_mod, ONLY: errr
+    USE grids_mod, ONLY: mygrids, nmygrids, minlevel, maxlevel, get_imygrid, &
+        level
+    USE pointers_mod, ONLY: get_len3, idim2d, get_ibb
+    USE precision_mod, ONLY: intk, realk
+
+
+    IMPLICIT NONE(type, external)
+    PRIVATE
+
+    INTEGER(intk), PARAMETER :: nchar_name = 16
+    INTEGER(intk), PARAMETER :: nchar_desc = 32
+    INTEGER(intk), PARAMETER :: nattr_max = 8
+
+    TYPE, ABSTRACT :: basefield_t
+        LOGICAL :: is_init = .FALSE.
+
+        CHARACTER(len=nchar_name) :: name = REPEAT(" ", nchar_name)
+        CHARACTER(len=nchar_desc) :: description = REPEAT(" ", nchar_desc)
+        INTEGER(intk) :: ndim = 3
+
+        INTEGER(intk) :: istag = 0
+        INTEGER(intk) :: jstag = 0
+        INTEGER(intk) :: kstag = 0
+        INTEGER(intk) :: units(7) = [0, 0, 0, 0, 0, 0, 0]
+
+        ! Try to read field
+        LOGICAL :: dread = .FALSE.
+
+        ! Requierd field: if dread = .TRUE. and not found, kill
+        LOGICAL :: required = .TRUE.
+
+        ! Write field
+        LOGICAL :: dwrite = .FALSE.
+
+        ! Allocated to minlevel:maxlevel and indicate which levels the field
+        ! is active on
+        LOGICAL, ALLOCATABLE :: active_level(:)
+
+        ! Pointers to procedures for getting the pointer and length
+        PROCEDURE(get_len_i), POINTER, NOPASS :: get_len => NULL()
+        INTEGER(intk), ALLOCATABLE :: ptr(:)
+
+        ! Length and actual data array can be allocated to anything
+        INTEGER(intk) :: idim = 0
+
+        ! Attributes
+        INTEGER(intk) :: n_iattr = 0
+        CHARACTER(len=nchar_name) :: iattr_key(nattr_max) = &
+            REPEAT(" ", nchar_name)
+        INTEGER(intk) :: iattr_val(nattr_max) = 0
+
+        INTEGER(intk) :: n_rattr = 0
+        CHARACTER(len=nchar_name) :: rattr_key(nattr_max) = &
+            REPEAT(" ", nchar_name)
+        REAL(realk) :: rattr_val(nattr_max) = 0.0
+    CONTAINS
+        PROCEDURE :: init_corefield
+
+        GENERIC, PUBLIC :: get_attr => get_rattr, get_iattr
+        PROCEDURE, PRIVATE :: get_rattr, get_iattr
+
+        GENERIC, PUBLIC :: set_attr => set_rattr, set_iattr
+        PROCEDURE, PRIVATE :: set_rattr, set_iattr
+
+        PROCEDURE :: get_ip
+
+        PROCEDURE :: finish_corefield
+    END TYPE basefield_t
+
+    ABSTRACT INTERFACE
+        SUBROUTINE get_len_i(len, igrid)
+            IMPORT :: intk
+            INTEGER(intk), INTENT(out) :: len
+            INTEGER(intk), INTENT(in) :: igrid
+        END SUBROUTINE get_len_i
+    END INTERFACE
+
+    PUBLIC :: basefield_t, get_len_i, nchar_name, nchar_desc, nattr_max
+
+CONTAINS
+    SUBROUTINE init_corefield(this, name, description, ndim, istag, &
+            jstag, kstag, units, dread, required, dwrite, active_level, get_len)
+        ! Subroutine arguments
+        CLASS(basefield_t), INTENT(out) :: this
+        CHARACTER(len=*), INTENT(in) :: name
+        CHARACTER(len=*), INTENT(in), OPTIONAL :: description
+        INTEGER(intk), INTENT(in), OPTIONAL :: ndim
+        INTEGER(intk), INTENT(in), OPTIONAL :: istag
+        INTEGER(intk), INTENT(in), OPTIONAL :: jstag
+        INTEGER(intk), INTENT(in), OPTIONAL :: kstag
+        INTEGER(intk), INTENT(in), OPTIONAL :: units(7)
+        LOGICAL, INTENT(in), OPTIONAL :: dread
+        LOGICAL, INTENT(in), OPTIONAL :: required
+        LOGICAL, INTENT(in), OPTIONAL :: dwrite
+        LOGICAL, INTENT(in), OPTIONAL :: active_level(:)
+        PROCEDURE(get_len_i), OPTIONAL :: get_len
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid, length
+
+        this%is_init = .TRUE.
+
+        IF (LEN_TRIM(name) > nchar_name) CALL errr(__FILE__, __LINE__)
+        this%name = name
+
+        this%description = name
+        IF (PRESENT(description)) THEN
+            IF (LEN_TRIM(description) > nchar_desc) THEN
+                CALL errr(__FILE__, __LINE__)
+            END IF
+            this%description = description
+        END IF
+
+        IF (PRESENT(ndim)) THEN
+            this%ndim = ndim
+        END IF
+
+        IF (PRESENT(istag)) THEN
+            this%istag = istag
+        END IF
+
+        IF (PRESENT(jstag)) THEN
+            this%jstag = jstag
+        END IF
+
+        IF (PRESENT(kstag)) THEN
+            this%kstag = kstag
+        END IF
+
+        IF (PRESENT(units)) THEN
+            this%units = units
+        END IF
+
+        IF (PRESENT(dread)) THEN
+            this%dread = dread
+        END IF
+
+        IF (PRESENT(required)) THEN
+            this%required = required
+        END IF
+
+        IF (PRESENT(dwrite)) THEN
+            this%dwrite = dwrite
+        END IF
+
+        ALLOCATE(this%active_level(minlevel:maxlevel))
+        this%active_level = .TRUE.
+        IF (PRESENT(active_level)) THEN
+            IF (SIZE(active_level) /= maxlevel-minlevel+1) THEN
+                CALL errr(__FILE__, __LINE__)
+            END IF
+            this%active_level(:) = active_level(:)
+        END IF
+
+        ! Only sets default pointers for 3D fields
+        IF (this%ndim == 3) THEN
+            this%get_len => get_len3
+        END IF
+        IF (PRESENT(get_len)) THEN
+            this%get_len => get_len
+        END IF
+        IF (.NOT. ASSOCIATED(this%get_len)) CALL errr(__FILE__, __LINE__)
+
+        ! Set pointers
+        ALLOCATE(this%ptr(nmygrids))
+        this%ptr = 0
+
+        this%idim = 0
+        DO i = 1, nmygrids
+            igrid = mygrids(i)
+            IF (.NOT. this%active_level(level(igrid))) CYCLE
+
+            CALL this%get_len(length, igrid)
+            this%ptr(i) = this%idim + 1
+            this%idim = this%idim + length
+        END DO
+    END SUBROUTINE init_corefield
+
+
+    ELEMENTAL SUBROUTINE finish_corefield(this)
+        CLASS(basefield_t), INTENT(inout) :: this
+
+        INTEGER(intk) :: i
+
+        IF (.NOT. this%is_init) RETURN
+        this%is_init = .FALSE.
+
+        this%name = REPEAT(" ", nchar_name)
+        this%description = REPEAT(" ", nchar_desc)
+        this%idim = 0
+        this%ndim = 3
+        this%istag = 0
+        this%jstag = 0
+        this%kstag = 0
+        this%units = 0
+        this%dread = .FALSE.
+        this%required = .FALSE.
+        this%dwrite = .FALSE.
+
+        DO i = 1, nattr_max
+            this%iattr_key = REPEAT(" ", nchar_name)
+            this%iattr_val = 0
+        END DO
+        this%n_iattr = 0
+
+        DO i = 1, nattr_max
+            this%rattr_key = REPEAT(" ", nchar_name)
+            this%rattr_val = 0.0
+        END DO
+        this%n_rattr = 0
+
+        DEALLOCATE(this%active_level)
+        DEALLOCATE(this%ptr)
+    END SUBROUTINE finish_corefield
+
+
+    SUBROUTINE get_ip(this, ip, igrid)
+        CLASS(basefield_t), INTENT(in) :: this
+        INTEGER(intk), INTENT(out) :: ip
+        INTEGER(intk), INTENT(in) :: igrid
+
+        INTEGER(intk) :: imygrid
+        ip = 0
+        CALL get_imygrid(imygrid, igrid)
+        ip = this%ptr(imygrid)
+    END SUBROUTINE get_ip
+
+
+    SUBROUTINE get_rattr(this, val, key)
+        ! Subroutine arguments
+        CLASS(basefield_t), INTENT(inout) :: this
+        REAL(realk), INTENT(inout) :: val
+        CHARACTER(len=*), INTENT(in) :: key
+
+        ! Local variables
+        INTEGER(intk) :: i
+        LOGICAL :: thisfound
+
+        IF (LEN_TRIM(key) > nchar_name) CALL errr(__FILE__, __LINE__)
+
+        thisfound = .FALSE.
+        DO i = 1, this%n_rattr
+            IF (TRIM(this%rattr_key(i)) == TRIM(key)) THEN
+                val = this%rattr_val(i)
+                thisfound = .TRUE.
+                EXIT
+            END IF
+        END DO
+
+        IF (.NOT. thisfound) THEN
+            WRITE(*, '("Attribute ", A, " does not exist!")') key
+            CALL errr(__FILE__, __LINE__)
+        END IF
+    END SUBROUTINE get_rattr
+
+
+    SUBROUTINE get_iattr(this, val, key)
+        ! Subroutine arguments
+        CLASS(basefield_t), INTENT(inout) :: this
+        INTEGER(intk), INTENT(inout) :: val
+        CHARACTER(len=*), INTENT(in) :: key
+
+        ! Local variables
+        INTEGER(intk) :: i
+        LOGICAL :: thisfound
+
+        IF (LEN_TRIM(key) > nchar_name) CALL errr(__FILE__, __LINE__)
+
+        thisfound = .FALSE.
+        DO i = 1, this%n_iattr
+            IF (TRIM(this%iattr_key(i)) == TRIM(key)) THEN
+                val = this%iattr_val(i)
+                thisfound = .TRUE.
+                EXIT
+            END IF
+        END DO
+
+        IF (.NOT. thisfound) THEN
+            WRITE(*, '("Attribute ", A, " does not exist!")') key
+            CALL errr(__FILE__, __LINE__)
+        END IF
+    END SUBROUTINE get_iattr
+
+
+    SUBROUTINE set_rattr(this, val, key)
+        ! Subroutine arguments
+        CLASS(basefield_t), INTENT(inout) :: this
+        REAL(realk), INTENT(in) :: val
+        CHARACTER(len=*), INTENT(in) :: key
+
+        ! Local variables
+        INTEGER(intk) :: i
+
+        IF (LEN_TRIM(key) > nchar_name) CALL errr(__FILE__, __LINE__)
+
+        ! First check if it exists already
+        DO i = 1, this%n_rattr
+            IF (TRIM(this%rattr_key(i)) == TRIM(key)) THEN
+                this%rattr_val(i) = val
+                RETURN
+            END IF
+        END DO
+
+        ! Not existing, is there space for another attribute?
+        IF (this%n_rattr + 1 > nattr_max) THEN
+            WRITE(*, '("Field ", A, " no space for attributes")') this%name
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        ! Insert attribute
+        this%n_rattr = this%n_rattr + 1
+        this%rattr_key(this%n_rattr) = TRIM(key)
+        this%rattr_val(this%n_rattr) = val
+    END SUBROUTINE set_rattr
+
+
+    SUBROUTINE set_iattr(this, val, key)
+        ! Subroutine arguments
+        CLASS(basefield_t), INTENT(inout) :: this
+        INTEGER(intk), INTENT(in) :: val
+        CHARACTER(len=*), INTENT(in) :: key
+
+        ! Local variables
+        INTEGER(intk) :: i
+
+        IF (LEN_TRIM(key) > nchar_name) CALL errr(__FILE__, __LINE__)
+
+        ! First check if it exists already
+        DO i = 1, this%n_iattr
+            IF (TRIM(this%iattr_key(i)) == TRIM(key)) THEN
+                this%iattr_val(i) = val
+                RETURN
+            END IF
+        END DO
+
+        ! Not existing, is there space for another attribute?
+        IF (this%n_rattr + 1 > nattr_max) THEN
+            WRITE(*, '("Field ", A, " no space for attributes")') this%name
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        ! Insert attribute
+        this%n_iattr = this%n_iattr + 1
+        this%iattr_key(this%n_iattr) = TRIM(key)
+        this%iattr_val(this%n_iattr) = val
+    END SUBROUTINE set_iattr
+END MODULE basefield_mod

--- a/src/core/field_t/field_mod.F90
+++ b/src/core/field_t/field_mod.F90
@@ -1,0 +1,13 @@
+MODULE field_mod
+    USE basefield_mod
+    USE realfield_mod
+    USE intfield_mod
+
+    IMPLICIT NONE(type, external)
+    PRIVATE
+
+    PUBLIC :: basefield_t, field_t, intfield_t, buffer_t, get_len_i, nchar_name
+
+CONTAINS
+
+END MODULE field_mod

--- a/src/core/field_t/intfield_mod.F90
+++ b/src/core/field_t/intfield_mod.F90
@@ -1,0 +1,111 @@
+MODULE intfield_mod
+    USE err_mod, ONLY: errr
+    USE grids_mod, ONLY: get_mgdims
+    USE precision_mod, ONLY: intk, realk, ifk
+    USE basefield_mod
+
+    IMPLICIT NONE(type, external)
+    PRIVATE
+
+    TYPE, EXTENDS(basefield_t) :: intfield_t
+        INTEGER(ifk), ALLOCATABLE :: arr(:)
+    CONTAINS
+        PROCEDURE :: init
+
+        GENERIC, PUBLIC :: get_ptr => get_grid1, get_grid3
+        PROCEDURE, PRIVATE :: get_grid1, get_grid3
+
+        PROCEDURE :: finish
+        FINAL :: destructor
+    END TYPE intfield_t
+
+    PUBLIC :: intfield_t
+
+CONTAINS
+    SUBROUTINE init(this, name, description, ndim, istag, jstag, kstag, &
+            units, dread, required, dwrite, active_level, get_len)
+        ! Subroutine arguments
+        CLASS(intfield_t), INTENT(out) :: this
+        CHARACTER(len=*), INTENT(in) :: name
+        CHARACTER(len=*), INTENT(in), OPTIONAL :: description
+        INTEGER(intk), INTENT(in), OPTIONAL :: ndim
+        INTEGER(intk), INTENT(in), OPTIONAL :: istag
+        INTEGER(intk), INTENT(in), OPTIONAL :: jstag
+        INTEGER(intk), INTENT(in), OPTIONAL :: kstag
+        INTEGER(intk), INTENT(in), OPTIONAL :: units(7)
+        LOGICAL, INTENT(in), OPTIONAL :: dread
+        LOGICAL, INTENT(in), OPTIONAL :: required
+        LOGICAL, INTENT(in), OPTIONAL :: dwrite
+        LOGICAL, INTENT(in), OPTIONAL :: active_level(:)
+        PROCEDURE(get_len_i), OPTIONAL :: get_len
+
+        ! Local variables
+        ! none...
+
+        CALL this%init_corefield(name, description, ndim, istag, jstag, kstag, &
+            units, dread, required, dwrite, active_level, get_len)
+
+        ALLOCATE(this%arr(this%idim))
+        this%arr = 0.0
+    END SUBROUTINE init
+
+
+    ELEMENTAL SUBROUTINE finish(this)
+        CLASS(intfield_t), INTENT(inout) :: this
+
+        IF (.NOT. this%is_init) RETURN
+        CALL this%finish_corefield()
+
+        DEALLOCATE(this%arr)
+    END SUBROUTINE finish
+
+
+    ELEMENTAL SUBROUTINE destructor(this)
+        TYPE(intfield_t), INTENT(inout) :: this
+
+        CALL this%finish()
+    END SUBROUTINE destructor
+
+
+    SUBROUTINE get_grid1(this, ptr, igrid)
+        ! Subroutine arguments
+        CLASS(intfield_t), INTENT(in), TARGET :: this
+        INTEGER(ifk), POINTER, CONTIGUOUS, INTENT(out) :: ptr(:)
+        INTEGER(intk), INTENT(in) :: igrid
+
+        ! Local variables
+        INTEGER(intk) :: ip, len
+
+        CALL this%get_ip(ip, igrid)
+        CALL this%get_len(len, igrid)
+        IF (len <= 0) CALL errr(__FILE__, __LINE__)
+
+        ptr(1:len) => this%arr(ip:ip+len-1)
+    END SUBROUTINE get_grid1
+
+
+    SUBROUTINE get_grid3(this, ptr, igrid)
+        ! Subroutine arguments
+        CLASS(intfield_t), INTENT(in), TARGET :: this
+        INTEGER(ifk), POINTER, CONTIGUOUS, INTENT(out) :: ptr(:, :, :)
+        INTEGER(intk), INTENT(in) :: igrid
+
+        ! Local variables
+        INTEGER(intk) :: kk, jj, ii, ip, len
+
+        IF (.NOT. this%ndim == 3) THEN
+            WRITE(*, '("Field ", A, " is not 3D!")') TRIM(this%name)
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        CALL this%get_ip(ip, igrid)
+        CALL this%get_len(len, igrid)
+        IF (len <= 0) CALL errr(__FILE__, __LINE__)
+
+        CALL get_mgdims(kk, jj, ii, igrid)
+        IF (len /= kk*jj*ii) CALL errr(__FILE__, __LINE__)
+
+        ptr(1:kk, 1:jj, 1:ii) => this%arr(ip:ip+kk*jj*ii-1)
+    END SUBROUTINE get_grid3
+
+END MODULE intfield_mod

--- a/src/core/field_t/realfield_mod.F90
+++ b/src/core/field_t/realfield_mod.F90
@@ -1,19 +1,14 @@
-MODULE field_mod
-    USE HDF5
+MODULE realfield_mod
     USE err_mod, ONLY: errr
-    USE grids_mod, ONLY: mygrids, nmygrids, minlevel, maxlevel, get_mgdims, &
-        get_imygrid, level
-    USE pointers_mod, ONLY: get_len3, idim2d, get_ibb
+    USE grids_mod, ONLY: get_mgdims, mygrids, nmygrids, level
+    USE pointers_mod, ONLY: idim2d, get_ibb
     USE precision_mod, ONLY: intk, realk
     USE utils_mod, ONLY: get_stag_shift
-
+    USE basefield_mod
+    USE commbuf_mod, ONLY: bigbuf
 
     IMPLICIT NONE(type, external)
     PRIVATE
-
-    INTEGER(intk), PARAMETER :: nchar_name = 16
-    INTEGER(intk), PARAMETER :: nchar_desc = 32
-    INTEGER(intk), PARAMETER :: nattr_max = 8
 
     TYPE :: buffer_t
         LOGICAL :: is_init = .FALSE.
@@ -34,62 +29,14 @@ MODULE field_mod
         GENERIC :: ASSIGNMENT(=) => copy_buffer
     END TYPE buffer_t
 
-    TYPE :: field_t
-        LOGICAL, PRIVATE :: is_init = .FALSE.
-
-        CHARACTER(len=nchar_name) :: name = REPEAT(" ", nchar_name)
-        CHARACTER(len=nchar_desc) :: description = REPEAT(" ", nchar_desc)
-        INTEGER(intk) :: ndim = 3
-
-        INTEGER(intk) :: istag = 0
-        INTEGER(intk) :: jstag = 0
-        INTEGER(intk) :: kstag = 0
-        INTEGER(intk) :: units(7) = [0, 0, 0, 0, 0, 0, 0]
-
-        ! Try to read field
-        LOGICAL :: dread = .FALSE.
-
-        ! Requierd field: if dread = .TRUE. and not found, kill
-        LOGICAL :: required = .TRUE.
-
-        ! Write field
-        LOGICAL :: dwrite = .FALSE.
-
-        ! Allocated to minlevel:maxlevel and indicate which levels the field
-        ! is active on
-        LOGICAL, ALLOCATABLE :: active_level(:)
-
-        ! Pointers to procedures for getting the pointer and length
-        PROCEDURE(get_len_i), POINTER, NOPASS :: get_len => NULL()
-        INTEGER(intk), ALLOCATABLE :: ptr(:)
-
-        ! Length and actual data array can be allocated to anything
-        INTEGER(intk) :: idim = 0
+    TYPE, EXTENDS(basefield_t) :: field_t
         REAL(realk), ALLOCATABLE :: arr(:)
-
         TYPE(buffer_t) :: buffers
-
-        ! Attributes
-        INTEGER(intk) :: n_iattr = 0
-        CHARACTER(len=nchar_name) :: iattr_key(nattr_max) = &
-            REPEAT(" ", nchar_name)
-        INTEGER(intk) :: iattr_val(nattr_max) = 0
-
-        INTEGER(intk) :: n_rattr = 0
-        CHARACTER(len=nchar_name) :: rattr_key(nattr_max) = &
-            REPEAT(" ", nchar_name)
-        REAL(realk) :: rattr_val(nattr_max) = 0.0
     CONTAINS
         PROCEDURE :: init
 
-        GENERIC, PUBLIC :: get_attr => get_rattr, get_iattr
-        PROCEDURE, PRIVATE :: get_rattr, get_iattr
-
-        GENERIC, PUBLIC :: set_attr => set_rattr, set_iattr
-        PROCEDURE, PRIVATE :: set_rattr, set_iattr
-
-        GENERIC, PUBLIC :: get_ptr => get_ip, get_grid1, get_grid3
-        PROCEDURE, PRIVATE :: get_ip, get_grid1, get_grid3
+        GENERIC, PUBLIC :: get_ptr => get_grid1, get_grid3
+        PROCEDURE, PRIVATE :: get_grid1, get_grid3
 
         PROCEDURE :: copy_from
         PROCEDURE :: multiply
@@ -103,19 +50,11 @@ MODULE field_mod
         GENERIC :: ASSIGNMENT(=) => set_const
     END TYPE field_t
 
-    ABSTRACT INTERFACE
-        SUBROUTINE get_len_i(len, igrid)
-            IMPORT :: intk
-            INTEGER(intk), INTENT(out) :: len
-            INTEGER(intk), INTENT(in) :: igrid
-        END SUBROUTINE get_len_i
-    END INTERFACE
-
-    PUBLIC :: field_t, buffer_t, get_len_i, nchar_name
+    PUBLIC :: field_t, buffer_t
 
 CONTAINS
-    SUBROUTINE init(this, name, description, ndim, istag, &
-            jstag, kstag, units, dread, required, dwrite, active_level, get_len)
+    SUBROUTINE init(this, name, description, ndim, istag, jstag, kstag, &
+            units, dread, required, dwrite, active_level, get_len)
         ! Subroutine arguments
         CLASS(field_t), INTENT(out) :: this
         CHARACTER(len=*), INTENT(in) :: name
@@ -132,84 +71,10 @@ CONTAINS
         PROCEDURE(get_len_i), OPTIONAL :: get_len
 
         ! Local variables
-        INTEGER(intk) :: i, igrid, length
+        ! none...
 
-        this%is_init = .TRUE.
-
-        IF (LEN_TRIM(name) > nchar_name) CALL errr(__FILE__, __LINE__)
-        this%name = name
-
-        this%description = name
-        IF (PRESENT(description)) THEN
-            IF (LEN_TRIM(description) > nchar_desc) THEN
-                CALL errr(__FILE__, __LINE__)
-            END IF
-            this%description = description
-        END IF
-
-        IF (PRESENT(ndim)) THEN
-            this%ndim = ndim
-        END IF
-
-        IF (PRESENT(istag)) THEN
-            this%istag = istag
-        END IF
-
-        IF (PRESENT(jstag)) THEN
-            this%jstag = jstag
-        END IF
-
-        IF (PRESENT(kstag)) THEN
-            this%kstag = kstag
-        END IF
-
-        IF (PRESENT(units)) THEN
-            this%units = units
-        END IF
-
-        IF (PRESENT(dread)) THEN
-            this%dread = dread
-        END IF
-
-        IF (PRESENT(required)) THEN
-            this%required = required
-        END IF
-
-        IF (PRESENT(dwrite)) THEN
-            this%dwrite = dwrite
-        END IF
-
-        ALLOCATE(this%active_level(minlevel:maxlevel))
-        this%active_level = .TRUE.
-        IF (PRESENT(active_level)) THEN
-            IF (SIZE(active_level) /= maxlevel-minlevel+1) THEN
-                CALL errr(__FILE__, __LINE__)
-            END IF
-            this%active_level(:) = active_level(:)
-        END IF
-
-        ! Only sets default pointers for 3D fields
-        IF (this%ndim == 3) THEN
-            this%get_len => get_len3
-        END IF
-        IF (PRESENT(get_len)) THEN
-            this%get_len => get_len
-        END IF
-        IF (.NOT. ASSOCIATED(this%get_len)) CALL errr(__FILE__, __LINE__)
-
-        ! Set pointers
-        ALLOCATE(this%ptr(nmygrids))
-        this%ptr = 0
-
-        this%idim = 0
-        DO i = 1, nmygrids
-            igrid = mygrids(i)
-            IF (.NOT. this%active_level(level(igrid))) CYCLE
-
-            CALL this%get_len(length, igrid)
-            this%ptr(i) = this%idim + 1
-            this%idim = this%idim + length
-        END DO
+        CALL this%init_corefield(name, description, ndim, istag, jstag, kstag, &
+            units, dread, required, dwrite, active_level, get_len)
 
         ALLOCATE(this%arr(this%idim))
         this%arr = 0.0
@@ -219,39 +84,10 @@ CONTAINS
     ELEMENTAL SUBROUTINE finish(this)
         CLASS(field_t), INTENT(inout) :: this
 
-        INTEGER(intk) :: i
-
         IF (.NOT. this%is_init) RETURN
-        this%is_init = .FALSE.
+        CALL this%finish_corefield()
 
-        this%name = REPEAT(" ", nchar_name)
-        this%description = REPEAT(" ", nchar_desc)
-        this%idim = 0
-        this%ndim = 3
-        this%istag = 0
-        this%jstag = 0
-        this%kstag = 0
-        this%units = 0
-        this%dread = .FALSE.
-        this%required = .FALSE.
-        this%dwrite = .FALSE.
-
-        DO i = 1, nattr_max
-            this%iattr_key = REPEAT(" ", nchar_name)
-            this%iattr_val = 0
-        END DO
-        this%n_iattr = 0
-
-        DO i = 1, nattr_max
-            this%rattr_key = REPEAT(" ", nchar_name)
-            this%rattr_val = 0.0
-        END DO
-        this%n_rattr = 0
-
-        DEALLOCATE(this%active_level)
-        DEALLOCATE(this%ptr)
         DEALLOCATE(this%arr)
-
         IF (this%buffers%is_init) CALL this%buffers%finish()
     END SUBROUTINE finish
 
@@ -261,18 +97,6 @@ CONTAINS
 
         CALL this%finish()
     END SUBROUTINE destructor
-
-
-    SUBROUTINE get_ip(this, ip, igrid)
-        CLASS(field_t), INTENT(in) :: this
-        INTEGER(intk), INTENT(out) :: ip
-        INTEGER(intk), INTENT(in) :: igrid
-
-        INTEGER(intk) :: imygrid
-        ip = 0
-        CALL get_imygrid(imygrid, igrid)
-        ip = this%ptr(imygrid)
-    END SUBROUTINE get_ip
 
 
     SUBROUTINE get_grid1(this, ptr, igrid)
@@ -315,126 +139,6 @@ CONTAINS
 
         ptr(1:kk, 1:jj, 1:ii) => this%arr(ip:ip+kk*jj*ii-1)
     END SUBROUTINE get_grid3
-
-
-    SUBROUTINE get_rattr(this, val, key)
-        ! Subroutine arguments
-        CLASS(field_t), INTENT(inout) :: this
-        REAL(realk), INTENT(inout) :: val
-        CHARACTER(len=*), INTENT(in) :: key
-
-        ! Local variables
-        INTEGER(intk) :: i
-        LOGICAL :: thisfound
-
-        IF (LEN_TRIM(key) > nchar_name) CALL errr(__FILE__, __LINE__)
-
-        thisfound = .FALSE.
-        DO i = 1, this%n_rattr
-            IF (TRIM(this%rattr_key(i)) == TRIM(key)) THEN
-                val = this%rattr_val(i)
-                thisfound = .TRUE.
-                EXIT
-            END IF
-        END DO
-
-        IF (.NOT. thisfound) THEN
-            WRITE(*, '("Attribute ", A, " does not exist!")') key
-            CALL errr(__FILE__, __LINE__)
-        END IF
-    END SUBROUTINE get_rattr
-
-
-    SUBROUTINE get_iattr(this, val, key)
-        ! Subroutine arguments
-        CLASS(field_t), INTENT(inout) :: this
-        INTEGER(intk), INTENT(inout) :: val
-        CHARACTER(len=*), INTENT(in) :: key
-
-        ! Local variables
-        INTEGER(intk) :: i
-        LOGICAL :: thisfound
-
-        IF (LEN_TRIM(key) > nchar_name) CALL errr(__FILE__, __LINE__)
-
-        thisfound = .FALSE.
-        DO i = 1, this%n_iattr
-            IF (TRIM(this%iattr_key(i)) == TRIM(key)) THEN
-                val = this%iattr_val(i)
-                thisfound = .TRUE.
-                EXIT
-            END IF
-        END DO
-
-        IF (.NOT. thisfound) THEN
-            WRITE(*, '("Attribute ", A, " does not exist!")') key
-            CALL errr(__FILE__, __LINE__)
-        END IF
-    END SUBROUTINE get_iattr
-
-
-    SUBROUTINE set_rattr(this, val, key)
-        ! Subroutine arguments
-        CLASS(field_t), INTENT(inout) :: this
-        REAL(realk), INTENT(in) :: val
-        CHARACTER(len=*), INTENT(in) :: key
-
-        ! Local variables
-        INTEGER(intk) :: i
-
-        IF (LEN_TRIM(key) > nchar_name) CALL errr(__FILE__, __LINE__)
-
-        ! First check if it exists already
-        DO i = 1, this%n_rattr
-            IF (TRIM(this%rattr_key(i)) == TRIM(key)) THEN
-                this%rattr_val(i) = val
-                RETURN
-            END IF
-        END DO
-
-        ! Not existing, is there space for another attribute?
-        IF (this%n_rattr + 1 > nattr_max) THEN
-            WRITE(*, '("Field ", A, " no space for attributes")') this%name
-            CALL errr(__FILE__, __LINE__)
-        END IF
-
-        ! Insert attribute
-        this%n_rattr = this%n_rattr + 1
-        this%rattr_key(this%n_rattr) = TRIM(key)
-        this%rattr_val(this%n_rattr) = val
-    END SUBROUTINE set_rattr
-
-
-    SUBROUTINE set_iattr(this, val, key)
-        ! Subroutine arguments
-        CLASS(field_t), INTENT(inout) :: this
-        INTEGER(intk), INTENT(in) :: val
-        CHARACTER(len=*), INTENT(in) :: key
-
-        ! Local variables
-        INTEGER(intk) :: i
-
-        IF (LEN_TRIM(key) > nchar_name) CALL errr(__FILE__, __LINE__)
-
-        ! First check if it exists already
-        DO i = 1, this%n_iattr
-            IF (TRIM(this%iattr_key(i)) == TRIM(key)) THEN
-                this%iattr_val(i) = val
-                RETURN
-            END IF
-        END DO
-
-        ! Not existing, is there space for another attribute?
-        IF (this%n_rattr + 1 > nattr_max) THEN
-            WRITE(*, '("Field ", A, " no space for attributes")') this%name
-            CALL errr(__FILE__, __LINE__)
-        END IF
-
-        ! Insert attribute
-        this%n_iattr = this%n_iattr + 1
-        this%iattr_key(this%n_iattr) = TRIM(key)
-        this%iattr_val(this%n_iattr) = val
-    END SUBROUTINE set_iattr
 
 
     ! Make a deep copy of another field
@@ -756,4 +460,4 @@ CONTAINS
         this%to(:) = that%to(:)
     END SUBROUTINE copy_buffer
 
-END MODULE field_mod
+END MODULE realfield_mod

--- a/src/core/fields_mod.F90
+++ b/src/core/fields_mod.F90
@@ -1,17 +1,13 @@
 MODULE fields_mod
     USE HDF5
-    USE charfunc_mod, ONLY: lower
     USE comms_mod, ONLY: myid
     USE err_mod, ONLY: errr
     USE fieldio2_mod, ONLY: fieldio_read, fieldio_write
     USE fort7_mod
-    USE grids_mod, ONLY: mygrids, nmygrids, minlevel, maxlevel, get_mgdims, &
-        get_imygrid, level
     USE hdf5common_mod, ONLY: hdf5common_open, hdf5common_close, &
-        hdf5common_group_open, hdf5common_group_close, hdf5common_attr_write
-    USE pointers_mod, ONLY: get_len3, idim2d, get_ibb
+        hdf5common_group_open, hdf5common_group_close
     USE precision_mod
-    USE field_mod, ONLY: field_t, buffer_t, get_len_i, nchar_name
+    USE field_mod, ONLY: field_t, get_len_i, nchar_name
 
     IMPLICIT NONE(type, external)
     PRIVATE

--- a/src/core/grids_mod.F90
+++ b/src/core/grids_mod.F90
@@ -1,6 +1,5 @@
 MODULE grids_mod
-    USE, INTRINSIC :: iso_c_binding, ONLY: C_CHAR
-    USE precision_mod, ONLY: intk, realk, int32, mglet_filename_max
+    USE precision_mod, ONLY: intk, realk, mglet_filename_max
     USE err_mod, ONLY: errr
     USE gridio_mod, ONLY: gridinfo_t, bcond_t, maxboconds
 
@@ -657,8 +656,6 @@ CONTAINS
 
 
     SUBROUTINE get_level(level, igrid)
-        USE simdfunctions_mod, ONLY: l_to_i
-
         INTEGER(intk), INTENT(OUT) :: level
         INTEGER(intk), INTENT(IN) :: igrid
 

--- a/src/core/plugins_mod.F90
+++ b/src/core/plugins_mod.F90
@@ -1,5 +1,4 @@
 MODULE plugins_mod
-    USE err_mod, ONLY: errr
     USE precision_mod, ONLY: intk, realk
 
     IMPLICIT NONE(type, external)

--- a/src/core/precision_mod.F90
+++ b/src/core/precision_mod.F90
@@ -29,13 +29,19 @@ MODULE precision_mod
     INTEGER(int32), PARAMETER :: int_bytes = 4
 #endif
 
+    ! Special kind for integer fields
+    INTEGER(int32), PARAMETER :: ifk = int64
+    INTEGER(int32), PARAMETER :: ifk_bytes = 8
+
     ! MPI data types for REAL and INTEGER
     TYPE(MPI_Datatype), PROTECTED :: mglet_mpi_real
     TYPE(MPI_Datatype), PROTECTED :: mglet_mpi_int
+    TYPE(MPI_Datatype), PROTECTED :: mglet_mpi_ifk
 
     ! HDF5 type for REAL and INTEGER
     INTEGER(HID_T), PROTECTED :: mglet_hdf5_real
     INTEGER(HID_T), PROTECTED :: mglet_hdf5_int
+    INTEGER(HID_T), PROTECTED :: mglet_hdf5_ifk
 
     ! MPI datatype to communicate INTEGER(hsize_t)
     TYPE(MPI_Datatype) :: mglet_mpi_hsize_t
@@ -57,7 +63,8 @@ MODULE precision_mod
     PUBLIC :: init_precision, finish_precision, realk, intk, c_intk, &
         c_realk, mglet_hdf5_real, mglet_hdf5_int, pi, eps, int8, int16, &
         int32, int64, real32, real64, real_bytes, int_bytes, &
-        mglet_filename_max, neps
+        mglet_filename_max, neps, ifk, ifk_bytes, mglet_mpi_ifk, &
+        mglet_hdf5_ifk
 
     PUBLIC :: mglet_mpi_real, mglet_mpi_int, mglet_mpi_hsize_t
 
@@ -72,6 +79,7 @@ CONTAINS
         ! Create HDF5 types
         mglet_hdf5_real = h5kind_to_type(realk, H5_REAL_KIND)
         mglet_hdf5_int = h5kind_to_type(intk, H5_INTEGER_KIND)
+        mglet_hdf5_ifk = h5kind_to_type(ifk, H5_INTEGER_KIND)
 
         ! Set mglet_mpi_hsize_t
         size = STORAGE_SIZE(dummy_hsize_t)/8
@@ -96,6 +104,8 @@ CONTAINS
 #else
         mglet_mpi_int = MPI_INTEGER
 #endif
+
+        mglet_mpi_ifk = MPI_INTEGER8
 
     END SUBROUTINE init_precision
 

--- a/src/core/statistics_mod.F90
+++ b/src/core/statistics_mod.F90
@@ -2,7 +2,6 @@ MODULE statistics_mod
     USE err_mod
     USE field_mod
     USE fields_mod
-    USE grids_mod, ONLY: minlevel, maxlevel
     USE fort7_mod
     USE precision_mod
 

--- a/src/core/stencilio_mod.F90
+++ b/src/core/stencilio_mod.F90
@@ -133,7 +133,7 @@ CONTAINS
                     END IF
                 END IF
             END DO
-            CALL MPI_Allreduce(MPI_IN_PLACE, maxarr, 1, mglet_mpi_int%MPI_val, &
+            CALL MPI_Allreduce(MPI_IN_PLACE, maxarr, 1, mpi_dtype, &
                 MPI_MAX, MPI_COMM_WORLD, ierr)
             IF (maxarr <= HUGE(1_int16)) THEN
                 IF (PRESENT(same_kind)) THEN
@@ -174,7 +174,7 @@ CONTAINS
                         MAXVAL(ABS(stencils(ptr:ptr+len-1))))
                 END IF
             END DO
-            CALL MPI_Allreduce(MPI_IN_PLACE, maxarr, 1, mglet_mpi_int%MPI_val, &
+            CALL MPI_Allreduce(MPI_IN_PLACE, maxarr, 1, mpi_dtype, &
                 MPI_MAX, MPI_COMM_WORLD, ierr)
             IF (maxarr <= HUGE(1_int16)) THEN
                 IF (PRESENT(same_kind)) THEN
@@ -723,7 +723,7 @@ CONTAINS
 
 
     SUBROUTINE stencilio_read(group_id, name, stencils, get_ptr, get_len)
-        USE hdf5common_mod, ONLY: hdf5common_open, hdf5common_dataset_open, &
+        USE hdf5common_mod, ONLY: hdf5common_dataset_open, &
             hdf5common_dataset_close
         USE grids_mod, ONLY: mygrids, nmygrids
         USE commbuf_mod, ONLY: bigbuf, intbuf, increase_bigbuf, increase_intbuf

--- a/src/flow/gc_flowstencils_mod.F90
+++ b/src/flow/gc_flowstencils_mod.F90
@@ -1323,6 +1323,9 @@ CONTAINS
 
 
     SUBROUTINE setpointvalues(pwu, pwv, pww, u, v, w, comp_new)
+        ! This override the module declaration
+        USE core_mod, ONLY: connect => connect_field
+
         ! Subroutine arguments
         TYPE(field_t), INTENT(inout) :: pwu, pwv, pww
         TYPE(field_t), INTENT(in) :: u, v, w
@@ -1356,8 +1359,7 @@ CONTAINS
         END IF
 
         DO ilevel = minlevel, maxlevel
-            CALL connect(ilevel, 1, v1=pwu%arr, v2=pwv%arr, v3=pww%arr, &
-                geom=.TRUE.)
+            CALL connect(ilevel, 1, v1=pwu, v2=pwv, v3=pww, geom=.TRUE.)
             CALL bound_flow%bound(ilevel, pwu, pwv, pww)
         END DO
 
@@ -1394,6 +1396,9 @@ CONTAINS
 
 
     SUBROUTINE setibvalues(u, v, w)
+        ! This override the module declaration
+        USE core_mod, ONLY: connect => connect_field
+
         ! Subroutine arguments
         TYPE(field_t), INTENT(inout) :: u, v, w
 
@@ -1405,19 +1410,17 @@ CONTAINS
         DO ilevel = minlevel, maxlevel
             CALL parent(ilevel, u, v, w)
             CALL bound_flow%bound(ilevel, u, v, w)
-            CALL connect(ilevel, 2, v1=u%arr, v2=v%arr, v3=w%arr)
+            CALL connect(ilevel, 2, v1=u, v2=v, v3=w)
 
             CALL setibvalues_level(ilevel, 'F', u, v, w)
             CALL bound_flow%bound(ilevel, u, v, w)
 
-            CALL connect(ilevel, 1, v1=u%arr, v2=v%arr, v3=w%arr, &
-                corners=.TRUE.)
+            CALL connect(ilevel, 1, v1=u, v2=v, v3=w, corners=.TRUE.)
 
             CALL setibvalues_level(ilevel, 'C', u, v, w)
             CALL bound_flow%bound(ilevel, u, v, w)
 
-            CALL connect(ilevel, 1, v1=u%arr, v2=v%arr, v3=w%arr, &
-                corners=.TRUE.)
+            CALL connect(ilevel, 1, v1=u, v2=v, v3=w, corners=.TRUE.)
         END DO
 
         DO ilevel = maxlevel, minlevel, -1
@@ -1428,11 +1431,11 @@ CONTAINS
 
                 IF (ilevel > minlevel) THEN
                     IF (irepeat == 1) THEN
-                        CALL connect(ilevel-1, 1, v1=u%arr, v2=v%arr, &
-                            v3=w%arr, normal=.TRUE., forward=-1, ityp='Y')
+                        CALL connect(ilevel-1, 1, v1=u, v2=v, &
+                            v3=w, normal=.TRUE., forward=-1, ityp='Y')
                     ELSE IF (irepeat == 2) THEN
-                        CALL connect(ilevel-1, 1, v1=u%arr, v2=v%arr, &
-                            v3=w%arr, corners=.TRUE.)
+                        CALL connect(ilevel-1, 1, v1=u, v2=v, &
+                            v3=w, corners=.TRUE.)
                     ELSE
                         CALL errr(__FILE__, __LINE__)
                     END IF
@@ -1444,13 +1447,11 @@ CONTAINS
             CALL parent(ilevel, u, v, w)
             CALL bound_flow%bound(ilevel, u, v, w)
 
-            CALL connect(ilevel, 1, v1=u%arr, v2=v%arr, v3=w%arr, &
-                corners=.TRUE.)
+            CALL connect(ilevel, 1, v1=u, v2=v, v3=w, corners=.TRUE.)
 
             CALL setibvalues_level(ilevel, 'C', u, v, w)
             CALL bound_flow%bound(ilevel, u, v, w)
-            CALL connect(ilevel, 1, v1=u%arr, v2=v%arr, v3=w%arr, &
-                corners=.TRUE.)
+            CALL connect(ilevel, 1, v1=u, v2=v, v3=w, corners=.TRUE.)
 
             ! The computed fluxes are saved
             CALL setibvalues_level(ilevel, 'S', u, v, w)

--- a/src/flow/lesmodel_mod.F90
+++ b/src/flow/lesmodel_mod.F90
@@ -32,6 +32,9 @@ MODULE lesmodel_mod
 CONTAINS
 
     SUBROUTINE init_lesmodel()
+        ! This override the module declaration
+        USE core_mod, ONLY: connect => connect_field
+
         ! Subroutine arguments
         ! none...
 
@@ -71,7 +74,7 @@ CONTAINS
             CALL zero_ghostlayers(g)
 
             DO ilevel = minlevel, maxlevel
-                CALL connect(ilevel, 2, s1=g%arr, corners=.TRUE.)
+                CALL connect(ilevel, 2, s1=g, corners=.TRUE.)
             END DO
 
             DO ilevel = minlevel+1, maxlevel

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -290,6 +290,8 @@ CONTAINS
 
     SUBROUTINE mgpoisl(u, v, w, p, dt, ittot, irk)
         USE MPI_f08
+        ! This override the module declaration
+        USE core_mod, ONLY: connect => connect_field
 
         ! Subroutine arguments
         TYPE(field_t), INTENT(inout) :: u
@@ -379,7 +381,7 @@ CONTAINS
             ! anything on the finest level, no need to connect finest level
             ! either.
             DO ilevel = minlevel, maxlevel-1
-                CALL connect_field(ilevel, 1, s1=hilf)
+                CALL connect(ilevel, 1, s1=hilf)
             END DO
 
             ! res <- laplace(hilf)
@@ -464,8 +466,7 @@ CONTAINS
         DO ilevel = minlevel, maxlevel
             CALL parent(ilevel, u, v, w, p)
             CALL bound_flow%bound(ilevel, u, v, w, p)
-            CALL connect_field(ilevel, 2, v1=u, v2=v, v3=w, s1=p, &
-                corners=.TRUE.)
+            CALL connect(ilevel, 2, v1=u, v2=v, v3=w, s1=p, corners=.TRUE.)
         END DO
 
         CALL res%finish()
@@ -480,6 +481,9 @@ CONTAINS
 
     ! 'res' is a temporary storage for the SIP algorithm,
     SUBROUTINE mgpoisit(ilevel, dp, rhs, res, bp)
+        ! This override the module declaration
+        USE core_mod, ONLY: connect => connect_field
+
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: ilevel
         TYPE(field_t), INTENT(inout) :: dp
@@ -530,7 +534,7 @@ CONTAINS
                     sipue, sipun, siput, siplpr, bp)
             END IF
 
-            CALL connect(ilevel, 1, s1=dp%arr)
+            CALL connect(ilevel, 1, s1=dp)
         END DO
 
         CALL bound_pressure%bound(ilevel, dp, bp)
@@ -541,6 +545,9 @@ CONTAINS
 
     SUBROUTINE sip(ilevel, iloop, dp, res, rhs, siplw, sipls, siplb, &
             sipue, sipun, siput, siplpr, bp)
+        ! This override the module declaration
+        USE core_mod, ONLY: connect => connect_field
+
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: ilevel
         INTEGER(intk), INTENT(in) :: iloop
@@ -583,9 +590,9 @@ CONTAINS
         END DO
 
         IF (iloop < ninner) THEN
-            CALL connect(ilevel, 1, s1=res%arr)
+            CALL connect(ilevel, 1, s1=res)
         ELSE
-            CALL connect(ilevel, 1, s1=res%arr, forward=-1)
+            CALL connect(ilevel, 1, s1=res, forward=-1)
         END IF
 
         DO i = 1, nmygridslvl(ilevel)

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -379,7 +379,7 @@ CONTAINS
             ! anything on the finest level, no need to connect finest level
             ! either.
             DO ilevel = minlevel, maxlevel-1
-                CALL connect(ilevel, 1, s1=hilf%arr)
+                CALL connect_field(ilevel, 1, s1=hilf)
             END DO
 
             ! res <- laplace(hilf)
@@ -464,7 +464,7 @@ CONTAINS
         DO ilevel = minlevel, maxlevel
             CALL parent(ilevel, u, v, w, p)
             CALL bound_flow%bound(ilevel, u, v, w, p)
-            CALL connect(ilevel, 2, v1=u%arr, v2=v%arr, v3=w%arr, s1=p%arr, &
+            CALL connect_field(ilevel, 2, v1=u, v2=v, v3=w, s1=p, &
                 corners=.TRUE.)
         END DO
 

--- a/src/flow/timeintegration_mod.F90
+++ b/src/flow/timeintegration_mod.F90
@@ -18,6 +18,9 @@ MODULE timeintegration_mod
 
 CONTAINS
     SUBROUTINE timeintegrate_flow(itstep, ittot, timeph, dt, irk, rkscheme)
+        ! This override the module declaration
+        USE core_mod, ONLY: connect => connect_field
+
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: itstep
         INTEGER(intk), INTENT(in) :: ittot
@@ -120,7 +123,7 @@ CONTAINS
 
         ! For divergence computation
         DO ilevel = minlevel, maxlevel
-            CALL connect_field(ilevel, 1, v1=u, v2=v, v3=w, &
+            CALL connect(ilevel, 1, v1=u, v2=v, v3=w, &
                 normal=.true., forward=1)
             CALL parent(ilevel, u, v, w, p)
             CALL bound_flow%bound(ilevel, u, v, w, p)

--- a/src/flow/timeintegration_mod.F90
+++ b/src/flow/timeintegration_mod.F90
@@ -120,7 +120,7 @@ CONTAINS
 
         ! For divergence computation
         DO ilevel = minlevel, maxlevel
-            CALL connect(ilevel, 1, v1=u%arr, v2=v%arr, v3=w%arr, &
+            CALL connect_field(ilevel, 1, v1=u, v2=v, v3=w, &
                 normal=.true., forward=1)
             CALL parent(ilevel, u, v, w, p)
             CALL bound_flow%bound(ilevel, u, v, w, p)

--- a/src/ib/ib_mod.F90
+++ b/src/ib/ib_mod.F90
@@ -41,27 +41,26 @@ CONTAINS
 
 
     SUBROUTINE set_finecell()
-        USE core_mod, ONLY: set_field, get_fieldptr, maxlevel, minlevel, &
-            connect, idim3d
+        USE core_mod
 
         ! Local variables
         INTEGER :: ilevel
         REAL(realk), ALLOCATABLE :: hilf(:)
-        REAL(realk), POINTER, CONTIGUOUS :: finecell(:)
+        TYPE(field_t), POINTER :: finecell
 
         CALL set_field("FINECELL")
-        ALLOCATE(hilf(idim3d))
+        CALL get_field(finecell, "FINECELL")
+        finecell%arr = 1.0
+
+        ALLOCATE(hilf(SIZE(finecell%arr)))
         hilf = 0.0
 
-        CALL get_fieldptr(finecell, "FINECELL")
-        finecell = 1.0
-
         DO ilevel = maxlevel, minlevel, -1
-            CALL ftoc(ilevel, hilf, finecell, 'P')
+            CALL ftoc(ilevel, hilf, finecell%arr, 'P')
         END DO
 
         DO ilevel = maxlevel, minlevel, -1
-            CALL connect(ilevel, 2, s1=finecell, corners=.TRUE.)
+            CALL connect(ilevel, 2, s1=finecell%arr, corners=.TRUE.)
         END DO
 
         DEALLOCATE(hilf)

--- a/src/ib/parent_mod.F90
+++ b/src/ib/parent_mod.F90
@@ -342,7 +342,7 @@ CONTAINS
         ! Pack BU, BV, BW if requested
         IF (exU .AND. pack_buvw) THEN
             CALL get_field(bu, "BU")
-            CALL bu%get_ptr(ip3, igridc)
+            CALL bu%get_ip(ip3, igridc)
             icomp = 0
             SELECT CASE(iface)
                 CASE (1, 2)
@@ -368,7 +368,7 @@ CONTAINS
 
         IF (exV .AND. pack_buvw) THEN
             CALL get_field(bu, "BV")
-            CALL bu%get_ptr(ip3, igridc)
+            CALL bu%get_ip(ip3, igridc)
             icomp = 0
             SELECT CASE(iface)
                 CASE (1, 2)
@@ -394,7 +394,7 @@ CONTAINS
 
         IF (exW .AND. pack_buvw) THEN
             CALL get_field(bu, "BW")
-            CALL bu%get_ptr(ip3, igridc)
+            CALL bu%get_ip(ip3, igridc)
             icomp = 0
             SELECT CASE(iface)
                 CASE (1, 2)
@@ -420,7 +420,7 @@ CONTAINS
 
         ! Fill buffers
         IF (ASSOCIATED(u) .AND. exU) THEN
-            CALL u%get_ptr(ip3, igridc)
+            CALL u%get_ip(ip3, igridc)
             icomp = 0
             SELECT CASE(iface)
                 CASE (1, 2)
@@ -445,7 +445,7 @@ CONTAINS
         END IF
 
         IF (ASSOCIATED(v) .AND. exV) THEN
-            CALL v%get_ptr(ip3, igridc)
+            CALL v%get_ip(ip3, igridc)
             icomp = 0
             SELECT CASE(iface)
                 CASE (1, 2)
@@ -470,7 +470,7 @@ CONTAINS
         END IF
 
         IF (ASSOCIATED(w) .AND. exW) THEN
-            CALL w%get_ptr(ip3, igridc)
+            CALL w%get_ip(ip3, igridc)
             icomp = 0
             SELECT CASE(iface)
                 CASE (1, 2)
@@ -495,7 +495,7 @@ CONTAINS
         END IF
 
         IF (ASSOCIATED(p1)) THEN
-            CALL p1%get_ptr(ip3, igridc)
+            CALL p1%get_ip(ip3, igridc)
             icomp = 0
             SELECT CASE(iface)
                 CASE (1, 2)
@@ -520,7 +520,7 @@ CONTAINS
         END IF
 
         IF (ASSOCIATED(p2)) THEN
-            CALL p2%get_ptr(ip3, igridc)
+            CALL p2%get_ip(ip3, igridc)
             icomp = 0
             SELECT CASE(iface)
                 CASE (1, 2)
@@ -545,7 +545,7 @@ CONTAINS
         END IF
 
         IF (ASSOCIATED(p3)) THEN
-            CALL p3%get_ptr(ip3, igridc)
+            CALL p3%get_ip(ip3, igridc)
             icomp = 0
             SELECT CASE(iface)
                 CASE (1, 2)

--- a/src/scalar/blockbt_mod.F90
+++ b/src/scalar/blockbt_mod.F90
@@ -9,6 +9,9 @@ MODULE blockbt_mod
 
 CONTAINS
     SUBROUTINE blockbt(bt_f)
+        ! This override the module declaration
+        USE core_mod, ONLY: connect => connect_field
+
         ! This routine derives a blocking field BT for the scalar
         ! from the the blocking field BP for the pressure.
         !
@@ -42,7 +45,7 @@ CONTAINS
         END DO
 
         DO ilevel = minlevel, maxlevel
-            CALL connect(ilevel, 2, s1=bt_f%arr, corners=.TRUE.)
+            CALL connect(ilevel, 2, s1=bt_f, corners=.TRUE.)
         END DO
 
         ! Opening the cells near the parent boundary where the coarse grid
@@ -63,7 +66,7 @@ CONTAINS
                     nfro, nbac, nrgt, nlft, nbot, ntop)
             END DO
 
-            CALL connect(ilevel, 2, s1=bt_f%arr, corners=.TRUE.)
+            CALL connect(ilevel, 2, s1=bt_f, corners=.TRUE.)
         END DO
 
         CALL hilf_f%finish()

--- a/src/scalar/scalar_mod.F90
+++ b/src/scalar/scalar_mod.F90
@@ -55,7 +55,8 @@ CONTAINS
 
 
     SUBROUTINE init_tfield()
-        USE core_mod
+        USE core_mod, ONLY: connect => connect_field, get_field, field_t, &
+            minlevel, maxlevel, zero_ghostlayers
         USE ib_mod
         USE setboundarybuffers_scalar_mod, ONLY: setboundarybuffers_scalar
 
@@ -75,7 +76,7 @@ CONTAINS
             CALL zero_ghostlayers(t)
 
             DO ilevel = minlevel, maxlevel
-                CALL connect(ilevel, 2, s1=t%arr, corners=.TRUE.)
+                CALL connect(ilevel, 2, s1=t, corners=.TRUE.)
             END DO
 
             DO ilevel = maxlevel, minlevel+1, -1

--- a/src/scalar/timeintegrate_scalar_mod.F90
+++ b/src/scalar/timeintegrate_scalar_mod.F90
@@ -14,6 +14,9 @@ MODULE timeintegrate_scalar_mod
 
 CONTAINS
     SUBROUTINE timeintegrate_scalar(itstep, ittot, timeph, dt, irk, rkscheme)
+        ! This override the module declaration
+        USE core_mod, ONLY: connect => connect_field
+
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: itstep
         INTEGER(intk), INTENT(in) :: ittot
@@ -87,7 +90,7 @@ CONTAINS
             ! Ghost cell "value" boundary condition applied to t field
             IF (ib%type == "GHOSTCELL") THEN
                 DO ilevel = minlevel, maxlevel
-                    CALL connect(ilevel, 2, s1=t%arr, corners=.TRUE.)
+                    CALL connect(ilevel, 2, s1=t, corners=.TRUE.)
                 END DO
                 CALL set_scastencils("P", scalar(l), t=t)
             END IF
@@ -96,7 +99,7 @@ CONTAINS
                 CALL ftoc(ilevel, t%arr, t%arr, 'T')
             END DO
             DO ilevel = minlevel, maxlevel
-                CALL connect(ilevel, 2, s1=t%arr, corners=.TRUE.)
+                CALL connect(ilevel, 2, s1=t, corners=.TRUE.)
             END DO
 
             ! TODO: Fill ghost layers of T (maybe only at last IRK?)


### PR DESCRIPTION
Support for integer fields of type intfield_t alongside field_t. Basic operations such as IO and connect are supported.

Integer fields are of basic kind ifk (Integer Field Kind). Default to 8 byte integers to trigger errors in building and testing if 'intk' and 'ifk' are mixed up. The rationale for creating a new kind ifk is that intk is used for nearly every integer in MGLET, kk, jj, ii etc. Setting 'intk' to any other value than int32 is failing and I doubt that it will ever work. Therefore it is easier to use a new kind and make this work properly.

In the end 'intk' could possibly be removed all together in favor of "default integers".