### PR TITLE
idea to resolve isse in scalar time integration

### DIFF
--- a/src/scalar/timeintegrate_scalar_mod.F90
+++ b/src/scalar/timeintegrate_scalar_mod.F90
@@ -50,7 +50,7 @@ CONTAINS
             CALL get_field(dt_f, "D"//TRIM(scalar(l)%name))
             CALL get_field(told, TRIM(scalar(l)%name)//"_OLD")
 
-            ! Copy to "T_OLD"  (TO DO: Is this step needed?)
+            ! Copy to "T_OLD" (needed for Boussinesq term)
             told%arr = t%arr
 
             ! TSTSCA4 zeroize qtu, qtv, qtw before use internally


### PR DESCRIPTION
Dear developers,

I think that I came across the following issue in the scalar time integration:

            ! fluxbalance zeroize qtt before use internally
            CALL fluxbalance(qtt, qtu, qtv, qtw)

            ! Ghost cell "flux" boundary condition applied to qtt field
            IF (ib%type == "GHOSTCELL") THEN
                CALL set_scastencils("P", scalar(l), qtt=qtt)
            END IF

            ! In IRK 1, FRHS is zero, therefore we do not need to zeroize
            ! the dt field before each step
            CALL rkscheme%get_coeffs(frhs, fu, dtrk, dtrki, irk)

            ! dT_j = A_j*dT_(j-1) + QTT
            dt_f%arr = frhs*dt_f%arr + qtt%arr

            ! T_j = T_(j-1) + B_j*dT_j
            t%arr = t%arr + dt*fu*dt_f%arr

After "fluxbalance", qtt represents the net flux in/out of the cell and has already been divided by the cell volume, which makes it ready for the time integration. The function "set_scastencils" adds a flux, which, however, has not been divided by the cell volume.

A primitive idea to resolve this problem is suggested in this PR. "qtt" is computed and entered in the "fluxbalance". The solution is not elegant either and may lead to similar misunderstandings... 

Further, I was wondering if "told" is needed at all.

Best regards,

Simon
