### PR TITLE
Deadlock fix

### DIFF
--- a/src/core/fieldio2_mod.F90
+++ b/src/core/fieldio2_mod.F90
@@ -801,7 +801,8 @@ CONTAINS
 
         ! If array "IGRIDLVL" exists already we can skip this function
         ! because it would not write any new data only virtual datasets
-        CALL hdf5common_dataset_exists("IGRIDLVL", parent_id, link_exists)
+        CALL h5lexists_f(parent_id, "IGRIDLVL", link_exists, ierr)
+        IF (ierr < 0) CALL errr(__FILE__, __LINE__)
         IF (link_exists) RETURN
 
         CALL create_iogridinfo_all(iogridinfo_all, iogridinfo)

--- a/src/core/timer_mod.F90
+++ b/src/core/timer_mod.F90
@@ -252,6 +252,9 @@ CONTAINS
             END IF
             inStat%avgN = inStat%n/numprocs
 
+            ! Explicitly initialize stat%n to avoid valgrind errors in the
+            ! IF below (otherwise it is uninitialized for ranks /= 0)
+            stat%n = 0
             CALL MPI_Reduce(inStat, stat, 1, mpitype, mpiop, 0, &
                 MPI_COMM_WORLD)
 


### PR DESCRIPTION
Resolve serious deadlock in writing of fields
    
I have no idea how this at all could be anywhere near working before... Probably by pure goodwill and optimizations from MPI librarie(s).

@swenczowski This fix is rather important. I did not find this until I had a 512-process job hanging in HLRS.