### PR TITLE
CMake: checking if compiler supports basic Fortran-2018

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -3,4 +3,5 @@ include(CheckFortranSourceRuns)
 
 include(Subdirlist.cmake)
 include(TestQsort.cmake)
+include(TestFortran2018Capability.cmake)
 include(TestSelectRank.cmake)

--- a/cmake/TestFortran2018Capability.cmake
+++ b/cmake/TestFortran2018Capability.cmake
@@ -1,0 +1,18 @@
+message(STATUS "Checking if compiler supports basic Fortran-2018 features")
+check_fortran_source_runs("
+PROGRAM main
+
+    USE, INTRINSIC :: iso_fortran_env, only : int8, int16
+
+    IMPLICIT NONE ( type, external )
+
+    INTEGER(kind=int8) :: m = -1
+    INTEGER(kind=int16) :: n = -1
+
+    n = n + m
+
+END PROGRAM main" F2018_TEST_OK SRC_EXT "F90")
+if(NOT F2018_TEST_OK)
+    message(FATAL_ERROR "Compiler fails at 'implicit none(type,external)'
+    (Fortran-2018 feature)")
+endif()


### PR DESCRIPTION
Dear all,

as a student stumbled across compile time errors that he could not interpret, I am suggesting a CMake configuration test that ensures that the basic Fortran-2018 syntax is supported. Most importantly, 

`IMPLICIT NONE ( type, external )`

must be supported by the compiler.

Best regards,

Simon