### PR TITLE
Change some testcases to use 4 MPI processes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,12 +35,16 @@ jobs:
         TOOLCHAIN=${{ contains(matrix.image, 'gnu') && 'gnu' || 'intel' }}
         cmake -GNinja --preset=${TOOLCHAIN}-${{ matrix.build }} -DMGLET_REAL64="${{ matrix.prec == 'Double' && 'ON' || 'OFF' }}" ..
         ninja
-        ls -R
 
     - name: Install 'gdb' and 'pidof'
       run: |
         source /opt/bashrc || true
         yum ${{ contains(matrix.image, 'intel') && '--disablerepo=oneAPI' || '' }} --disablerepo=ius -y install gdb sysvinit-tools
+
+    - name: System Info
+      run: |
+        lscpu
+        free
 
     - name: Run testcases
       run: |

--- a/tests/BlasiusBL/run.sh
+++ b/tests/BlasiusBL/run.sh
@@ -9,7 +9,7 @@ if [[ "$ACTION" == "test" ]]; then
     MGLET_BIN=$2
 
     python3 add-expression.py
-    mpirun -n 2 $MGLET_BIN 2>&1 | tee mglet.OUT
+    mpirun -n 4 $MGLET_BIN 2>&1 | tee mglet.OUT
 elif [[ "$ACTION" == "clean" ]]; then
     rm -rf LOGS fields.h5 mglet-perf-report.txt *.OUT
 else

--- a/tests/Parker_micro/run.sh
+++ b/tests/Parker_micro/run.sh
@@ -7,8 +7,8 @@ ACTION=$1
 
 if [[ "$ACTION" == "test" ]]; then
     MGLET_BIN=$2
-    mpirun -n 2 $MGLET_BIN parameters-blocking.json 2>&1 | tee mglet-blocking.OUT
-    mpirun -n 2 $MGLET_BIN parameters-run.json 2>&1 | tee mglet-run.OUT
+    mpirun -n 4 $MGLET_BIN parameters-blocking.json 2>&1 | tee mglet-blocking.OUT
+    mpirun -n 4 $MGLET_BIN parameters-run.json 2>&1 | tee mglet-run.OUT
 elif [[ "$ACTION" == "clean" ]]; then
     rm -rf LOGS fields.h5 ib_stencils.h5 mglet-perf-report.txt *.OUT
 else

--- a/tests/Santarelli/run.sh
+++ b/tests/Santarelli/run.sh
@@ -7,8 +7,8 @@ ACTION=$1
 
 if [[ "$ACTION" == "test" ]]; then
     MGLET_BIN=$2
-    mpirun -n 2 $MGLET_BIN parameters-flow.json 2>&1 | tee mglet-flow.OUT
-    mpirun -n 2 $MGLET_BIN parameters-scalar.json 2>&1 | tee mglet-scalar.OUT
+    mpirun -n 4 $MGLET_BIN parameters-flow.json 2>&1 | tee mglet-flow.OUT
+    mpirun -n 4 $MGLET_BIN parameters-scalar.json 2>&1 | tee mglet-scalar.OUT
 elif [[ "$ACTION" == "clean" ]]; then
     rm -rf LOGS fields.h5 ib_stencils.h5 mglet-perf-report.txt *.OUT
 else


### PR DESCRIPTION
Default Github runners for open source projects are now 4 cores by default:

https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/

Update BlasiusBL, Parker_micro and Santarelli to use 4 cores.