### PR TITLE
Probes buffer size computation fixed

### DIFF
--- a/src/plugins/probes_mod.F90
+++ b/src/plugins/probes_mod.F90
@@ -841,7 +841,7 @@ CONTAINS
         ! Per-process number of values sampled
         nvalues_max = 0
         DO iarr = 1, narrays
-            nvalues_max = nvalues_max + arr(iarr)%nvars*arr(iarr)%npts
+            nvalues_max = nvalues_max + arr(iarr)%nvars*arr(iarr)%nmypnts
         END DO
 
         ! Sum over IO group


### PR DESCRIPTION
This bug resulted in too small buffer and frequent writing of probe data