### PR TITLE
Intel ifx with Intel MPI warnings fixed

### DIFF
--- a/src/core/fieldio2_mod.F90
+++ b/src/core/fieldio2_mod.F90
@@ -658,11 +658,11 @@ CONTAINS
                 ! the correct MPI type along
                 SELECT TYPE (buffer)
                 TYPE IS (REAL(realk))
-                    CALL MPI_Irecv(buffer(bufptr:bufptr+nelems-1), nelems, &
+                    CALL MPI_Irecv(buffer(bufptr), nelems, &
                         field%mpi_dtype, iproc, igrid, iogrcomm, &
                         recvreq(nrecv))
                 TYPE IS (INTEGER(ifk))
-                    CALL MPI_Irecv(buffer(bufptr:bufptr+nelems-1), nelems, &
+                    CALL MPI_Irecv(buffer(bufptr), nelems, &
                         field%mpi_dtype, iproc, igrid, iogrcomm, &
                         recvreq(nrecv))
                 END SELECT
@@ -725,10 +725,10 @@ CONTAINS
             ! the correct MPI type along
             SELECT TYPE (transposed)
             TYPE IS (REAL(realk))
-                CALL MPI_Isend(transposed(ptr:ptr+nelems-1), nelems, &
+                CALL MPI_Isend(transposed(ptr), nelems, &
                     field%mpi_dtype, 0, igrid, iogrcomm, sendreq(nsend))
             TYPE IS (INTEGER(ifk))
-                CALL MPI_Isend(transposed(ptr:ptr+nelems-1), nelems, &
+                CALL MPI_Isend(transposed(ptr), nelems, &
                     field%mpi_dtype, 0, igrid, iogrcomm, sendreq(nsend))
             END SELECT
         END DO
@@ -1302,10 +1302,10 @@ CONTAINS
             CALL field%get_len(nelems, igrid)
             SELECT TYPE (field)
             TYPE IS (field_t)
-                CALL MPI_Irecv(field%arr(ptr:ptr+nelems-1), nelems, &
+                CALL MPI_Irecv(field%arr(ptr), nelems, &
                     field%mpi_dtype, 0, igrid, iogrcomm, recvreq(nrecv))
             TYPE IS (intfield_t)
-                CALL MPI_Irecv(field%arr(ptr:ptr+nelems-1), nelems, &
+                CALL MPI_Irecv(field%arr(ptr), nelems, &
                     field%mpi_dtype, 0, igrid, iogrcomm, recvreq(nrecv))
             END SELECT
         END DO
@@ -1327,11 +1327,11 @@ CONTAINS
                 nsend = nsend + 1
                 SELECT TYPE (buffer)
                 TYPE IS (REAL(realk))
-                    CALL MPI_Isend(buffer(bufptr:bufptr+nelems-1), nelems, &
+                    CALL MPI_Isend(buffer(bufptr), nelems, &
                         field%mpi_dtype, iproc, igrid, iogrcomm, &
                         sendreq(nsend))
                 TYPE IS (INTEGER(ifk))
-                    CALL MPI_Isend(buffer(bufptr:bufptr+nelems-1), nelems, &
+                    CALL MPI_Isend(buffer(bufptr), nelems, &
                         field%mpi_dtype, iproc, igrid, iogrcomm, &
                         sendreq(nsend))
                 END SELECT

--- a/src/plugins/probes_mod.F90
+++ b/src/plugins/probes_mod.F90
@@ -1332,7 +1332,7 @@ CONTAINS
 
             ALLOCATE(recvreq(0:iogrprocs-1))
             DO i = 0, iogrprocs-1
-                CALL MPI_Irecv(outputbuf, INT(bufloc, int32), &
+                CALL MPI_Irecv(outputbuf(:, :), INT(bufloc, int32), &
                     array%mpitype(i), INT(i, int32), 0, iogrcomm, &
                     recvreq(i))
             END DO


### PR DESCRIPTION
Fixed warnings:

 - warning #8100: The actual argument is an array section or assumed-shape array, corresponding dummy argument that has either the VOLATILE or ASYNCHRONOUS attribute shall be an assumed-shape array.

 - warning #8101: The actual argument is a pointer array, corresponding dummy argument that has either the VOLATILE or ASYNCHRONOUS attribute shall be an assumed-shape array or a pointer array.