### PR TITLE
Misc minor fixes

### DIFF
--- a/src/flow/lesmodel_mod.F90
+++ b/src/flow/lesmodel_mod.F90
@@ -435,7 +435,7 @@ CONTAINS
         ! |Sd| = SQRT(Sd_ij*Sd_ij)
         ! We need to take the off-diagonal terms twice due to symmetry,
         ! i.e. Sd12**2 + Sd21**2 = 2*Sd12**2
-        Sd_abs = SQRT(Sd00**2 + 2*Sd01**2 + 2*Sd02**2 \
+        Sd_abs = SQRT(Sd00**2 + 2*Sd01**2 + 2*Sd02**2 &
             + Sd11**2 + 2*Sd12**2 + Sd22**2)
 
 #if 0

--- a/src/ib/checkblock_mod.F90
+++ b/src/ib/checkblock_mod.F90
@@ -4,6 +4,9 @@ MODULE checkblock_mod
 
     USE core_mod
 
+    IMPLICIT NONE(type, external)
+    PRIVATE
+
     PUBLIC :: checkblock
 
 CONTAINS

--- a/src/ib/gc_totwasser_mod.F90
+++ b/src/ib/gc_totwasser_mod.F90
@@ -318,11 +318,11 @@ CONTAINS
         USE precision_mod, ONLY: i8 => int64
 
         ! Subroutine arguments
-        INTEGER(int64), INTENT(out) :: nall
+        INTEGER(i8), INTENT(out) :: nall
         TYPE(field_t), INTENT(inout) :: bp_f
 
         ! Local variables
-        INTEGER(int64) :: nsingle
+        INTEGER(i8) :: nsingle
         INTEGER(intk) :: igr, igrid, bpi
         INTEGER(intk) :: k, j, i
         INTEGER(intk) :: kk, jj, ii

--- a/src/ib/ibmodel_mod.F90
+++ b/src/ib/ibmodel_mod.F90
@@ -5,6 +5,13 @@ MODULE ibmodel_mod
     IMPLICIT NONE(type, external)
     PRIVATE
 
+    TYPE, ABSTRACT :: restrict_t
+    CONTAINS
+        PROCEDURE :: message_length
+        PROCEDURE(start_and_stop_i), NOPASS, DEFERRED :: start_and_stop
+        PROCEDURE(restrict_i), DEFERRED :: restrict
+    END TYPE restrict_t
+
     TYPE, ABSTRACT :: ibmodel_t
         CHARACTER(len=16) :: type
         CLASS(restrict_t), ALLOCATABLE :: restrict_op
@@ -15,13 +22,6 @@ MODULE ibmodel_mod
         PROCEDURE(giteig_i), NOPASS, DEFERRED :: giteig
         PROCEDURE(divcal_i), DEFERRED :: divcal
     END TYPE ibmodel_t
-
-    TYPE, ABSTRACT :: restrict_t
-    CONTAINS
-        PROCEDURE :: message_length
-        PROCEDURE(start_and_stop_i), NOPASS, DEFERRED :: start_and_stop
-        PROCEDURE(restrict_i), DEFERRED :: restrict
-    END TYPE restrict_t
 
     ABSTRACT INTERFACE
         SUBROUTINE start_and_stop_i(ista, isto, jsta, jsto, &


### PR DESCRIPTION
 - Missing IMPLICIT NONE
 - Type declaration in order of usage (restrict_t was used before it was declared)