### PR TITLE
Do not read in G field

### DIFF
--- a/src/flow/flowcore_mod.F90
+++ b/src/flow/flowcore_mod.F90
@@ -130,8 +130,8 @@ CONTAINS
             required=dread, dwrite=dwrite, buffers=.TRUE.)
         CALL set_field("P", units=units_p, dread=dread, &
             required=dread, dwrite=dwrite, buffers=.TRUE.)
-        CALL set_field("G", units=units_g, dread=dread, &
-            required=dread, dwrite=dwrite, buffers=.TRUE.)
+        CALL set_field("G", units=units_g, dread=.FALSE., &
+            dwrite=dwrite, buffers=.TRUE.)
 
         ! For RK time integration
         CALL set_field("DU", istag=1)


### PR DESCRIPTION
The viscosity field is always properly initialized from the chosen LES model and velocity field in init_lesmodel, so no need to ever read in the G field.

FYI @swenczowski 