### PR TITLE
LLVM flang-new changes and additions

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -180,6 +180,49 @@
                 "CMAKE_BUILD_TYPE": "Debug"
 
             }
+        },
+        {
+            "name": "llvm",
+            "hidden": true,
+            "displayName": "LLVM compilers (clang, clang++, flang-new)",
+            "description": "Default build options using the LLVM compilers",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_Fortran_COMPILER": "flang-new",
+
+                "MGLET_C_FLAGS": "",
+                "MGLET_CXX_FLAGS": "-Wno-missing-template-arg-list-after-template-kw",
+                "MGLET_Fortran_FLAGS": "-fno-implicit-none",
+
+                "MGLET_C_FLAGS_RELEASE": "-O3;-g",
+                "MGLET_CXX_FLAGS_RELEASE": "-O3;-g",
+                "MGLET_Fortran_FLAGS_RELEASE": "-O3;-g",
+
+                "MGLET_C_FLAGS_DEBUG": "-O0;-g",
+                "MGLET_CXX_FLAGS_DEBUG": "-O0;-g",
+                "MGLET_Fortran_FLAGS_DEBUG": "-O0;-g"
+            }
+        },
+        {
+            "name": "llvm-release",
+            "displayName": "LLVM compilers (clang, clang++, flang-new) (release)",
+            "description": "Release configuration using the LLVM compilers (clang, clang++, flang-new)",
+            "inherits": "llvm",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+
+            }
+        },
+        {
+            "name": "llvm-debug",
+            "displayName": "LLVM compilers (clang, clang++, flang-new) (debug)",
+            "description": "Debug configuration using the LLVM compilers (clang, clang++, flang-new)",
+            "inherits": "llvm",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+
+            }
         }
     ]
 }

--- a/src/core/core_mod.F90
+++ b/src/core/core_mod.F90
@@ -222,10 +222,13 @@ CONTAINS
 
         ! Set the flags according to the environment variable
         SELECT CASE(TRIM(mglet_underflow))
+! TODO: monitor when flang-new implements IEEE_SET_UNDERFLOW_MODE
+#ifndef __flang__
         CASE ("gradual")
             CALL IEEE_SET_UNDERFLOW_MODE(.TRUE.)
         CASE ("abrupt")
             CALL IEEE_SET_UNDERFLOW_MODE(.FALSE.)
+#endif
         CASE DEFAULT
             WRITE(*,*) "Invalid value for MGLET_UNDERFLOW: ", &
                 TRIM(mglet_underflow)
@@ -246,12 +249,15 @@ CONTAINS
 
         WRITE(*, '("IEEE aritmetic flags:")')
 
+! TODO: monitor when flang-new implements IEEE_GET_UNDERFLOW_MODE
+#ifndef __flang__
         CALL IEEE_GET_UNDERFLOW_MODE(flag)
         IF (flag) THEN
             WRITE(*, '("    Underflow:     gradual")')
         ELSE
             WRITE(*, '("    Underflow:     abrupt")')
         END IF
+#endif
 
         CALL IEEE_GET_HALTING_MODE(IEEE_DIVIDE_BY_ZERO, flag)
         IF (flag) THEN

--- a/src/core/mglet_precision.h
+++ b/src/core/mglet_precision.h
@@ -19,10 +19,28 @@ typedef float mgletreal;
 
 #ifdef _MGLET_INT64_
 typedef long long mgletint;
+
+// If clang is used as a "companion compiler" to NAG nagfor, this will fail or
+// not work. I am not sure if that is supported, though. Usually we use GCC
+// for this. So leave this as is for now.
+#if __NVCOMPILER || __clang__
+#define CFI_type_mgletint CFI_type_int64_t
+#else
 #define CFI_type_mgletint CFI_type_long_long
+#endif
+
 #else
 typedef int mgletint;
+
+// If clang is used as a "companion compiler" to NAG nagfor, this will fail or
+// not work. I am not sure if that is supported, though. Usually we use GCC
+// for this. So leave this as is for now.
+#if __NVCOMPILER || __clang__
+#define CFI_type_mgletint CFI_type_int32_t
+#else
 #define CFI_type_mgletint CFI_type_int
+#endif
+
 #endif
 
 #endif /* __MGLET_PRECISION_H__ */

--- a/src/core/sort_wrapper.cxx
+++ b/src/core/sort_wrapper.cxx
@@ -54,7 +54,7 @@ void sort_fortran_array(CFI_cdesc_t* idx, CFI_cdesc_t* data)
 extern "C" {
     void sort_int(CFI_cdesc_t* data,  CFI_cdesc_t* idx)
     {
-        assert (data->type == CFI_type_int);
+        assert (data->type == CFI_type_int || data->type == CFI_type_int32_t);
         assert (idx->type == CFI_type_mgletint);
 
         sort_fortran_array<int>(idx, data);
@@ -62,7 +62,7 @@ extern "C" {
 
     void sort_long(CFI_cdesc_t* data,  CFI_cdesc_t* idx)
     {
-        assert (data->type == CFI_type_long_long);
+        assert (data->type == CFI_type_long_long || data->type == CFI_type_int64_t);
         assert (idx->type == CFI_type_mgletint);
 
         sort_fortran_array<long long>(idx, data);

--- a/src/flow/gc_flowstencils_mod.F90
+++ b/src/flow/gc_flowstencils_mod.F90
@@ -1,7 +1,8 @@
 MODULE gc_flowstencils_mod
     USE bound_flow_mod
     USE core_mod
-    USE ib_mod
+    USE ib_mod, ONLY: gc_t, parent, ftoc, wmindexlistn, findinterface2, &
+        maccur, wmcheckneighbor, choosestencil, wmmultimatrix, wmaddcoefflist
 
     IMPLICIT NONE (type, external)
     PRIVATE

--- a/src/scalar/gc_scastencils_mod.F90
+++ b/src/scalar/gc_scastencils_mod.F90
@@ -1,6 +1,7 @@
 MODULE gc_scastencils_mod
     USE core_mod
-    USE ib_mod
+    USE ib_mod, ONLY: gc_t, wmindexlistn, findinterface2, &
+        wmcheckneighbor, choosestencil
     USE scacore_mod
 
     IMPLICIT NONE (type, external)


### PR DESCRIPTION
With these changes MGLET build and runs all basic testcases with LLVM flang-new, clang and clang++ compilers. No advanced testcases tried so far, though.

Be aware that flang is in rapid development, and this was tested with the latest main LLVM branch as of today. Older releases are likely to fail.