### PR TITLE
Uniformization of .github/workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,13 +3,31 @@ name: mglet-build
 on:
   pull_request:
     branches: [ master ]
+  push:
+    branches:
+      - 'tum/**'
+      - 'michael/**'
+      - 'lukas/**'
+      - 'yoshi/**'
+      - 'simon/**'
+      - 'philip/**'
+      - 'julius/**'
+      - 'javier/**'
+      - 'feyza/**'
+      - 'jakob/**'
+      - 'mohammadreza/**'
+      - 'khushnood/**'
+      - 'particle/**'
+      - 'softwarelab/**'
+      - 'catalyst/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build:
+  kmt_build:
+    if: github.repository == 'kmturbulenz/mglet-base'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -43,6 +61,55 @@ jobs:
     - name: Run testcases
       run: |
         source /opt/bashrc || true
+        cd build
+        export OMPI_ALLOW_RUN_AS_ROOT=1
+        export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+        export I_MPI_FABRICS=shm
+        export I_MPI_PLATFORM=ivb
+        export I_MPI_DEBUG=5
+        EXITCODE=0
+        TIC=`date +%s`
+        ctest --timeout ${{ matrix.build == 'Debug' && '600' || '150' }} --output-on-failure --test-dir tests  || EXITCODE=1
+        TOC=`date +%s`
+        DURATION=$((TOC-TIC))
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Total test time: $DURATION sec" >> $GITHUB_STEP_SUMMARY
+        CPUNAME=$(lscpu | grep 'Model name' | cut -f 2 -d ":" | awk '{$1=$1}1')
+        echo "CPU model name: $CPUNAME" >> $GITHUB_STEP_SUMMARY
+        exit $EXITCODE
+
+  tum_build:
+    if: github.repository == 'tum-hydromechanics/tum-mglet-base'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      matrix:
+        image: ["build-base-image:master"]
+        build: ["debug"]
+        prec: ["Single", "Double"]
+      fail-fast: false
+
+    container:
+      image: ghcr.io/tum-hydromechanics/${{ matrix.image }}
+      options: "--cap-add=SYS_PTRACE --shm-size=4gb"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build MGLET
+      run: |
+        source /root/.bashrc || true
+        mkdir build
+        cd build
+        TOOLCHAIN=${{ contains(matrix.image, 'base') && 'gnu' || 'intel' }}
+        cmake -GNinja --preset=${TOOLCHAIN}-${{ matrix.build }} -DMGLET_REAL64="${{ matrix.prec == 'Double' && 'ON' || 'OFF' }}" ..
+        ninja
+        ls -R
+
+    - name: Run testcases
+      run: |
+        source /root/.bashrc || true
         cd build
         export OMPI_ALLOW_RUN_AS_ROOT=1
         export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1


### PR DESCRIPTION
Dear Håkon,

I keep observing that the .github/workflows of KMT and TUM diverge (conflicting changes) once in a while when either side changes their settings. This divergence makes it more inconvenient to (a) update our TUM fork frequently and (b) to create Pull Requests from the TUM fork against the KMT master.

As I stumbled across both within short time, I am suggesting a workflows file, which defines a "kmt_build", that is triggered by actions on your repository, and a  "tum_build", which is triggered by pushes to our repository. Thus, each side should be able to evolve without interference and without conflicting changes.


![DisplayInGithub](https://github.com/user-attachments/assets/988266bc-5039-4aaf-8859-9b924555ee32)

How do you feel about this idea?

Best regards,

Simon
