### PR TITLE
GFortran compiler bug workaround

### DIFF
--- a/src/core/timekeeper_mod.F90
+++ b/src/core/timekeeper_mod.F90
@@ -21,12 +21,12 @@ MODULE timekeeper_mod
 
     TYPE :: timekeeper_t
         ! Time value in double precision
-        REAL(real64), PRIVATE :: time
+        REAL(real64), PRIVATE :: time = 0.0_real64
 
         ! Kahan summation coefficients
-        REAL(real64), PRIVATE :: c
-        REAL(real64), PRIVATE :: y
-        REAL(real64), PRIVATE :: t
+        REAL(real64), PRIVATE :: c = 0.0_real64
+        REAL(real64), PRIVATE :: y = 0.0_real64
+        REAL(real64), PRIVATE :: t = 0.0_real64
     CONTAINS
         GENERIC, PUBLIC :: init => init_sp, init_dp
         PROCEDURE, PRIVATE :: init_sp, init_dp


### PR DESCRIPTION
There is a bug in recent GFortran versions when using -fcheck=all (which include -fcheck=recursion):

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115348

When a compiler affected by this bug is used with MGLET, it will not build with cmake --preset=gnu-debug.

This is a workaround for this issue.