### PR TITLE
Adding user defined scalar unit (TUM)

### DIFF
--- a/src/core/config_mod.F90
+++ b/src/core/config_mod.F90
@@ -758,7 +758,8 @@ CONTAINS
         CHARACTER(len=*), INTENT(in) :: key
 
         ! https://github.com/nlohmann/json/blob/develop/include/nlohmann/detail/value_t.hpp
-        is_int = this%is_type(key, 6)
+        is_int = this%is_type(key, 5) ! = signed int
+        ! is_int = this%is_type(key, 6) ! = unsigned int
     END FUNCTION is_int
 
 

--- a/src/core/statistics_mod.F90
+++ b/src/core/statistics_mod.F90
@@ -288,7 +288,7 @@ CONTAINS
 
         ! Local Variables
         INTEGER(intk) :: igr, igrid
-        INTEGER(intk) :: k, j, i
+        INTEGER(intk) :: k, j, i, n
         INTEGER(intk) :: kk, jj, ii
         TYPE(field_t), POINTER :: rdxyz
         ! (usage of different pointers for readability)
@@ -296,6 +296,19 @@ CONTAINS
         REAL(realk), POINTER, CONTIGUOUS :: rdx(:), rdy(:), rdz(:)
         REAL(realk), POINTER, CONTIGUOUS :: rddx(:), rddy(:), rddz(:)
         REAL(realk), POINTER, CONTIGUOUS :: out(:, :, :), phi(:, :, :)
+
+        ! checking for dimensional consistency
+        DO n = 1, 7
+            IF ( n == 2 ) THEN
+                IF ( field%units(n) /= a%units(n) -1 ) THEN
+                    CALL errr(__FILE__, __LINE__)
+                END IF
+            ELSE
+                IF ( field%units(n) /= a%units(n) ) THEN
+                    CALL errr(__FILE__, __LINE__)
+                END IF
+            END IF
+        END DO
 
         SELECT CASE (ivar)
         CASE ("DXS")

--- a/src/scalar/scacore_mod.F90
+++ b/src/scalar/scacore_mod.F90
@@ -19,6 +19,7 @@ MODULE scacore_mod
     TYPE :: scalar_t
         CHARACTER(len=nchar_name) :: name
         REAL(realk) :: prmol
+        INTEGER(intk) :: units(7)
         INTEGER(intk) :: kayscrawford
         TYPE(scalar_bc_t), ALLOCATABLE :: geometries(:)
     CONTAINS
@@ -89,6 +90,13 @@ CONTAINS
 
             CALL sc%get_value("/prmol", scalar(l)%prmol)
 
+            ! Retrieving the scalar units (noisy output for test)
+            IF ( sc%exists("/units") ) THEN
+                CALL sc%get_array("/units", scalar(l)%units)
+            ELSE
+                scalar(l)%units = 0
+            END IF
+
             ! The parameters.json should have a logical, but it is easier
             ! to integrate computations with an integer
             CALL sc%get_value("/kayscrawford", kayscrawford, .FALSE.)
@@ -136,8 +144,8 @@ CONTAINS
 
         ! Declare fields
         DO l = 1, nsca
-            CALL set_field(scalar(l)%name, dread=dread, required=dcont, &
-                dwrite=dwrite, buffers=.TRUE.)
+            CALL set_field(scalar(l)%name, units=scalar(l)%units, dread=dread, &
+                required=dcont, dwrite=dwrite, buffers=.TRUE.)
 
             ! Get field, set PRMOL and scalar index as attribute
             CALL get_field(t, scalar(l)%name)
@@ -151,8 +159,8 @@ CONTAINS
             CALL set_field(TRIM(scalar(l)%name)//"_OLD")
 
             IF (myid == 0) THEN
-                WRITE(*, '(2X, "Scalar:               ", A, " prmol: ", G0)') &
-                    scalar(l)%name, scalar(l)%prmol
+                WRITE(*, '(2X, "Scalar:               ", A, " prmol: ", G0, "   unit: [", 7I3, " ]")') &
+                    scalar(l)%name, scalar(l)%prmol, scalar(l)%units
             END IF
         END DO
 

--- a/src/scalar/scastat_mod.F90
+++ b/src/scalar/scastat_mod.F90
@@ -84,7 +84,7 @@ CONTAINS
 
         ! Local Variables
         INTEGER(intk), PARAMETER :: units_dx(*) = [0, -1, 0, 0, 0, 0, 0]
-        INTEGER(intk) :: units(7), units_tx(7)
+        INTEGER(intk) :: units_tx(7), units_txtx(7)
         TYPE(field_t) :: tx_f  ! derivative of a scalar in any direction
         TYPE(field_t), POINTER :: t_f
         INTEGER(intk) :: istag, jstag, kstag
@@ -114,15 +114,14 @@ CONTAINS
             CALL errr(__FILE__, __LINE__)
         END SELECT
 
-        ! units_dx = [0, -1, 0, 0, 0, 0, 0] = 1/m -> the differentiate operator
-        ! units_tx -> the units of Tx
+        ! unit of spatial derivative of scalar
         units_tx = t_f%units + units_dx
 
-        ! units -> units of TxTx
-        units = 2*units_tx
+        ! units of square of spatial derivative, i.e. TxTx
+        units_txtx = 2*units_tx
 
         CALL field%init(name, istag=istag, jstag=jstag, kstag=kstag, &
-            units=units)
+            units=units_txtx)
         CALL tx_f%init('tmp', istag=istag, jstag=jstag, kstag=kstag, &
             units=units_tx)
 
@@ -144,7 +143,7 @@ CONTAINS
         REAL(realk), INTENT(in) :: dt
 
         ! Local variables
-        INTEGER(intk) :: units(7)
+        INTEGER(intk) :: units_ut(7)
         TYPE(field_t), POINTER :: u_f, t_f
         INTEGER(intk) :: istag, jstag, kstag
         INTEGER(intk) :: sca_name_length
@@ -179,10 +178,10 @@ CONTAINS
 
         ! Units of the result
         ! velocity * scalar
-        units = u_f%units + t_f%units
+        units_ut = u_f%units + t_f%units
 
         CALL field%init(name, istag=istag, jstag=jstag, kstag=kstag, &
-            units=units)
+            units=units_ut)
 
         ! multiplication at staggered positions
         CALL field%multiply(u_f, t_f)
@@ -199,7 +198,7 @@ CONTAINS
         REAL(realk), INTENT(in) :: dt
 
         ! Local variables
-        INTEGER(intk) :: units(7)
+        INTEGER(intk) :: units_utt(7)
         TYPE(field_t), POINTER :: u_f, t_f
         INTEGER(intk) :: istag, jstag, kstag
         INTEGER(intk) :: sca_name_length
@@ -237,10 +236,10 @@ CONTAINS
 
         ! Units of the result
         ! velocity * 2*scalar
-        units = u_f%units + 2*t_f%units
+        units_utt = u_f%units + 2*t_f%units
 
         CALL field%init(name, istag=istag, jstag=jstag, kstag=kstag, &
-            units=units)
+            units=units_utt)
 
         ! multiplication at staggered positions
         CALL field%multiply(u_f, t_f, t_f)

--- a/tests/Statistics/parameters.json
+++ b/tests/Statistics/parameters.json
@@ -43,7 +43,8 @@
         "scalars": [
             {
                 "name": "SCA",
-                "prmol": 1.0
+                "prmol": 1.0,
+                "units": [1,-3,0,1,0,0,0]
             }
         ]
     },


### PR DESCRIPTION
As discussed, here a first draft. 

a) We have changed the identfier for the template number type. According to https://json.nlohmann.me/features/types/number_handling/#template-number-types and consistent with the C++ code,  "5" is signed integer and "6" is only unsigned integer. 

b) The scalar unit is parsed and written to terminal in formatted fashion. Without the specification of a unit (or actually "physical dimension") , the scalar remains dimensionless.

Best regards,

Simon