### PR TITLE
Bringing back VOLP for ghost cell (TUM)

### DIFF
--- a/src/ib/gc_stencils_mod.F90
+++ b/src/ib/gc_stencils_mod.F90
@@ -2,7 +2,8 @@ MODULE gc_stencils_mod
     USE HDF5
     USE core_mod, ONLY: realk, intk, eps, errr, nmygrids, sub2ind, field_t, &
         mygrids, nmygrids, get_mgdims, hdf5common_attr_read, hdf5common_open, &
-        hdf5common_close, hdf5common_attr_write, get_ip3, myid, ind2sub
+        hdf5common_close, hdf5common_attr_write, get_ip3, myid, ind2sub, &
+        get_fieldptr, get_field
     USE stencils_mod, ONLY: stencils_t
     IMPLICIT NONE(type, external)
     PRIVATE
@@ -12,6 +13,7 @@ MODULE gc_stencils_mod
         PROCEDURE :: set_bp
         PROCEDURE :: set_auavaw
         PROCEDURE :: get_auavaw
+        PROCEDURE :: calc_volp
         PROCEDURE :: read
         PROCEDURE :: write
         FINAL :: destructor
@@ -198,59 +200,225 @@ CONTAINS
     END SUBROUTINE set_auavaw
 
 
-    SUBROUTINE get_auavaw(this, bu, bv, bw, au_f, av_f, aw_f)
+    SUBROUTINE get_auavaw(this, bu_f, bv_f, bw_f, areau_f, areav_f, areaw_f)
         ! Subroutine arguments
         CLASS(gc_stencils_t), INTENT(inout) :: this
-        TYPE(field_t), INTENT(in) :: bu
-        TYPE(field_t), INTENT(in) :: bv
-        TYPE(field_t), INTENT(in) :: bw
-        TYPE(field_t), INTENT(inout) :: au_f
-        TYPE(field_t), INTENT(inout) :: av_f
-        TYPE(field_t), INTENT(inout) :: aw_f
+        TYPE(field_t), INTENT(in) :: bu_f
+        TYPE(field_t), INTENT(in) :: bv_f
+        TYPE(field_t), INTENT(in) :: bw_f
+        TYPE(field_t), INTENT(inout) :: areau_f
+        TYPE(field_t), INTENT(inout) :: areav_f
+        TYPE(field_t), INTENT(inout) :: areaw_f
 
         ! Local variables
-        INTEGER(intk) :: imygrid, idx, igrid, ind, ip3
+        TYPE(field_t), POINTER :: ddx_f, ddy_f, ddz_f
+        INTEGER(intk) :: imygrid, idx, igrid, ind
         INTEGER(intk) :: aucells
         INTEGER(intk) :: kk, jj, ii, k, j, i
-        REAL(realk), POINTER, CONTIGUOUS :: au(:, :, :)
+        REAL(realk) :: area
+        REAL(realk), POINTER, CONTIGUOUS :: areau(:, :, :)
+        REAL(realk), POINTER, CONTIGUOUS :: bu(:, :, :)
+        REAL(realk), POINTER, CONTIGUOUS :: ddx(:), ddy(:), ddz(:)
 
-        ! First set AU to value of BU
-        au_f%arr = bu%arr
-        av_f%arr = bv%arr
-        aw_f%arr = bw%arr
+        CALL get_field(ddx_f, "DDX")
+        CALL get_field(ddy_f, "DDY")
+        CALL get_field(ddz_f, "DDZ")
 
-        ! Now set AU, AV, AW
+        ! Now set AU, AV, AW ( absolute areas in unit [L^2] )
         all_grids: DO imygrid = 1, nmygrids
+
             igrid = mygrids(imygrid)
             CALL get_mgdims(kk, jj, ii, igrid)
-            CALL get_ip3(ip3, igrid)
 
-            CALL au_f%get_ptr(au, igrid)
+            ! Getting the pressure cell side lengths
+            CALL ddx_f%get_ptr(ddx, igrid)
+            CALL ddy_f%get_ptr(ddy, igrid)
+            CALL ddz_f%get_ptr(ddz, igrid)
+
+            ! Area AU from BU
+            CALL areau_f%get_ptr(areau, igrid)
+            CALL bu_f%get_ptr(bu, igrid)
+            DO i = 1, ii
+                DO j = 1, jj
+                    DO k = 1, kk
+                        area = ddz(k) * ddy(j)
+                        areau(k, j, i) = bu(k, j, i) * area
+                    END DO
+                END DO
+            END DO
+            ! Refine for intersected cells
             aucells = SIZE(this%auind(imygrid)%arr)
             DO idx = 1, aucells
                 ind = this%auind(imygrid)%arr(idx)
                 CALL ind2sub(ind, k, j, i, kk, jj, ii)
-                au(k, j, i) = this%auvalue(imygrid)%arr(idx)
+                area = ddz(k) * ddy(j)
+                areau(k, j, i) = this%auvalue(imygrid)%arr(idx) * area
             END DO
 
-            CALL av_f%get_ptr(au, igrid)
+            ! Area AV from BV
+            CALL areav_f%get_ptr(areau, igrid)
+            CALL bv_f%get_ptr(bu, igrid)
+            DO i = 1, ii
+                DO j = 1, jj
+                    DO k = 1, kk
+                        area = ddx(i) * ddz(k)
+                        areau(k, j, i) = bu(k, j, i) * area
+                    END DO
+                END DO
+            END DO
+            ! Refine for intersected cells
             aucells = SIZE(this%avind(imygrid)%arr)
             DO idx = 1, aucells
                 ind = this%avind(imygrid)%arr(idx)
                 CALL ind2sub(ind, k, j, i, kk, jj, ii)
-                au(k, j, i) = this%avvalue(imygrid)%arr(idx)
+                area = ddx(i) * ddz(k)
+                areau(k, j, i) = this%avvalue(imygrid)%arr(idx) * area
             END DO
 
-            CALL aw_f%get_ptr(au, igrid)
+            ! Area AW from BW
+            CALL areaw_f%get_ptr(areau, igrid)
+            CALL bw_f%get_ptr(bu, igrid)
+            DO i = 1, ii
+                DO j = 1, jj
+                    DO k = 1, kk
+                        area = ddx(i) * ddy(j)
+                        areau(k, j, i) = bu(k, j, i) * area
+                    END DO
+                END DO
+            END DO
+            ! Refine for intersected cells
             aucells = SIZE(this%awind(imygrid)%arr)
             DO idx = 1, aucells
                 ind = this%awind(imygrid)%arr(idx)
                 CALL ind2sub(ind, k, j, i, kk, jj, ii)
-                au(k, j, i) = this%awvalue(imygrid)%arr(idx)
+                area = ddx(i) * ddy(j)
+                areau(k, j, i) = this%awvalue(imygrid)%arr(idx) * area
             END DO
 
         END DO all_grids
     END SUBROUTINE get_auavaw
+
+
+
+    SUBROUTINE calc_volp(this, bzelltyp, areau_f, areav_f, areaw_f, icells, &
+        icellspointer, xpsw, volp_f)
+        ! Subroutine arguments
+        CLASS(gc_stencils_t), INTENT(inout) :: this
+        INTEGER(intk), INTENT(in) :: bzelltyp(*)
+        TYPE(field_t), INTENT(in) :: areau_f
+        TYPE(field_t), INTENT(in) :: areav_f
+        TYPE(field_t), INTENT(in) :: areaw_f
+        INTEGER(intk), INTENT(in) :: icells(:)
+        INTEGER(intk), INTENT(in) :: icellspointer(:)
+        REAL(realk), INTENT(in) :: xpsw(:, :)
+        TYPE(field_t), INTENT(inout) :: volp_f
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid, kk, jj, ii, ip3, ipp, ncells
+        REAL(realk), POINTER, CONTIGUOUS :: xstag(:), ystag(:), zstag(:)
+        REAL(realk), POINTER, CONTIGUOUS :: ddx(:), ddy(:), ddz(:)
+        REAL(realk), POINTER, CONTIGUOUS :: areau(:, :, :)
+        REAL(realk), POINTER, CONTIGUOUS :: areav(:, :, :)
+        REAL(realk), POINTER, CONTIGUOUS :: areaw(:, :, :)
+        REAL(realk), POINTER, CONTIGUOUS :: volp(:, :, :)
+
+        DO i = 1, nmygrids
+            igrid = mygrids(i)
+
+            ! Index pointers and dimensions
+            CALL get_mgdims(kk, jj, ii, igrid)
+            CALL get_ip3(ip3, igrid)
+            ipp = icellspointer(igrid)
+            ncells = icells(igrid)
+
+            ! Cell side lengths of pressure cells
+            CALL get_fieldptr(ddx, "DDX", igrid)
+            CALL get_fieldptr(ddy, "DDY", igrid)
+            CALL get_fieldptr(ddz, "DDZ", igrid)
+            ! Get staggered coordinate positions
+            CALL get_fieldptr(xstag, "XSTAG", igrid)
+            CALL get_fieldptr(ystag, "YSTAG", igrid)
+            CALL get_fieldptr(zstag, "ZSTAG", igrid)
+
+            ! Areas including info on intersected cells
+            CALL areau_f%get_ptr(areau, igrid)
+            CALL areav_f%get_ptr(areav, igrid)
+            CALL areaw_f%get_ptr(areaw, igrid)
+            CALL volp_f%get_ptr(volp, igrid)
+
+            CALL calc_volp_grid(kk, jj, ii, ddx, ddy, ddz, &
+                xstag, ystag, zstag, bzelltyp(ip3), areau, areav, areaw, &
+                xpsw(:, ipp:ipp+ncells-1), volp)
+        END DO
+    END SUBROUTINE calc_volp
+
+
+    SUBROUTINE calc_volp_grid(kk, jj, ii, ddx, ddy, ddz, &
+            xstag, ystag, zstag, bzelltyp, areau, areav, areaw, xpsw, volp)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(in) :: ddx(ii), ddy(jj), ddz(kk)
+        REAL(realk), INTENT(in) :: xstag(ii), ystag(jj), zstag(kk)
+        INTEGER(intk), INTENT(in) :: bzelltyp(kk, jj, ii)
+        REAL(realk), INTENT(in) :: areau(kk, jj, ii)
+        REAL(realk), INTENT(in) :: areav(kk, jj, ii)
+        REAL(realk), INTENT(in) :: areaw(kk, jj, ii)
+        REAL(realk), INTENT(in) :: xpsw(:, :)
+        REAL(realk), INTENT(inout) :: volp(kk, jj, ii)
+
+        ! Local variables
+        INTEGER(intk) :: k, j, i, icell
+        REAL(realk) :: swx, swy, swz, areax, areay, areaz
+        REAL(realk) :: vpx, vpy, vpz
+
+        ! Now set VOLP ( absolute volumes in unit [L^3] )
+        DO i = 2, ii
+            DO j = 2, jj
+                DO k = 2, kk
+
+                    IF (bzelltyp(k, j, i) == 0 .OR. &
+                        bzelltyp(k, j, i) == 1) THEN
+
+                        ! Cell is fully open or fully blocked
+                        volp(k, j, i) = REAL(bzelltyp(k, j, i), realk) * &
+                            ddx(i) * ddy(j) * ddz(k)
+
+                    ELSE IF (bzelltyp(k, j, i) < 0) THEN
+
+                        ! Cell is an interface cell and intersected
+                        icell = -bzelltyp(k, j, i)
+
+                        swx = xpsw(1, icell)
+                        swy = xpsw(2, icell)
+                        swz = xpsw(3, icell)
+
+                        areax = areau(k, j, i) - areau(k, j, i-1)
+                        areay = areav(k, j, i) - areav(k, j-1, i)
+                        areaz = areaw(k, j, i) - areaw(k-1, j, i)
+
+                        vpx = (areau(k, j, i-1) * ddx(i)) &
+                            + areax * (xstag(i) - swx)
+
+                        vpy = (areav(k, j-1, i) * ddy(j)) &
+                            + areay * (ystag(j) - swy)
+
+                        vpz = (areaw(k-1, j, i) * ddz(k)) &
+                            + areaz * (zstag(k) - swz)
+
+                        volp(k, j, i) = 1.0 / 3.0 * (vpx + vpy + vpz)
+
+                    ELSE
+
+                        ! Unexpected type indicator
+                        WRITE(*, *) "bzelltype > 1 not expected"
+                        CALL errr(__FILE__, __LINE__)
+
+                    END IF
+
+                END DO
+            END DO
+        END DO
+    END SUBROUTINE calc_volp_grid
 
 
     SUBROUTINE read(this)


### PR DESCRIPTION
**--- please, consider this PR a draft for discussion, improvements to follow, not tested ---**

Dear all,

as encountered by @javierebb, mglet-base does not provide the field "VOLP", which provides the volume of intersected cells within the ghost cell immersed boundary framework. 

This PR outlines an idea to recover this field, which is primarily used for postprocessing on our side. The following considerations have been made, such that I am slightly optimistic that all relevant locations in the code have been touched. As discussed beforehand, both areas and volume are given absolute in [L^2] or [L^3] and not in terms of fractions.

![image](https://github.com/user-attachments/assets/a12a2681-bf50-4746-a0d8-9e24b22ff662)

I would much appreciate your ideas and feedback on this very rough first draft.

Best regards,

Simon


