### PR TITLE
Add NON_OVERRIDABLE to some derived type procedures

### DIFF
--- a/src/core/field_t/basefield_mod.F90
+++ b/src/core/field_t/basefield_mod.F90
@@ -72,7 +72,7 @@ MODULE basefield_mod
         GENERIC, PUBLIC :: set_attr => set_rattr, set_iattr
         PROCEDURE, PRIVATE :: set_rattr, set_iattr
 
-        PROCEDURE :: get_ip
+        PROCEDURE, NON_OVERRIDABLE :: get_ip
 
         PROCEDURE :: finish_corefield
     END TYPE basefield_t

--- a/src/core/field_t/intfield_mod.F90
+++ b/src/core/field_t/intfield_mod.F90
@@ -13,7 +13,7 @@ MODULE intfield_mod
         PROCEDURE :: init
 
         GENERIC, PUBLIC :: get_ptr => get_grid1, get_grid3
-        PROCEDURE, PRIVATE :: get_grid1, get_grid3
+        PROCEDURE, PRIVATE, NON_OVERRIDABLE :: get_grid1, get_grid3
 
         PROCEDURE :: finish
         FINAL :: destructor

--- a/src/core/field_t/realfield_mod.F90
+++ b/src/core/field_t/realfield_mod.F90
@@ -37,8 +37,8 @@ MODULE realfield_mod
         GENERIC, PUBLIC :: get_ptr => get_grid1, get_grid3
         GENERIC, PUBLIC :: multiply => multiply2, multiply3
 
-        PROCEDURE, PRIVATE :: get_grid1, get_grid3
-        PROCEDURE, PRIVATE :: multiply2, multiply3
+        PROCEDURE, PRIVATE, NON_OVERRIDABLE :: get_grid1, get_grid3
+        PROCEDURE, PRIVATE, NON_OVERRIDABLE :: multiply2, multiply3
 
         PROCEDURE :: copy_from
         PROCEDURE :: shift

--- a/src/core/tensormath_mod.F90
+++ b/src/core/tensormath_mod.F90
@@ -9,16 +9,22 @@ MODULE tensormath_mod
     CONTAINS
         PRIVATE
 
-        PROCEDURE, PUBLIC :: abst
-        PROCEDURE, PUBLIC :: t
-        PROCEDURE, PUBLIC :: sqr
-        PROCEDURE, PUBLIC :: trace
-        PROCEDURE, PUBLIC :: det
-        PROCEDURE, PUBLIC :: eig_a, eig_b
+        PROCEDURE, PUBLIC, NON_OVERRIDABLE :: abst
+        PROCEDURE, PUBLIC, NON_OVERRIDABLE :: t
+        PROCEDURE, PUBLIC, NON_OVERRIDABLE :: sqr
+        PROCEDURE, PUBLIC, NON_OVERRIDABLE :: trace
+        PROCEDURE, PUBLIC, NON_OVERRIDABLE :: det
+        PROCEDURE, PUBLIC, NON_OVERRIDABLE :: eig_a, eig_b
 
+#if defined __GNUC__
         PROCEDURE :: add
         PROCEDURE :: subtract
         PROCEDURE :: multiply
+#else
+        PROCEDURE, NON_OVERRIDABLE :: add
+        PROCEDURE, NON_OVERRIDABLE :: subtract
+        PROCEDURE, NON_OVERRIDABLE :: multiply
+#endif
 
         GENERIC, PUBLIC :: OPERATOR(+) => add
         GENERIC, PUBLIC :: OPERATOR(-) => subtract


### PR DESCRIPTION
Typically those that are frequently called. This helps the compiler in selecting the right procedure to call.