### PR TITLE
Fix in scalar value intialization (TUM)

### DIFF
--- a/src/scalar/scacore_mod.F90
+++ b/src/scalar/scacore_mod.F90
@@ -309,10 +309,12 @@ CONTAINS
         REAL(realk), INTENT(in) :: val
 
         ! Local variables
-        INTEGER(intk) :: igrid
+        INTEGER(intk) :: i, igrid
         REAL(realk), POINTER, CONTIGUOUS :: t(:, :, :)
 
-        DO igrid = 1, nmygrids
+        DO i = 1, nmygrids
+            igrid = mygrids(i)
+
             CALL sca_f%get_ptr(t, igrid)
             t = val
         END DO


### PR DESCRIPTION
Dear Hakon,

by chance, we stumbled across a mistake in the iteration over all grids on one process during the scalar value initialization.

This error was not detected by the example case, which uses one grid on one process. A multi-proc use case showed us that issue.

@javierebb: Please, check out and forward to Roman.

Best regards,

Simon