### PR TITLE
Closing scalar configuration reader + Comment

### DIFF
--- a/src/scalar/scacore_mod.F90
+++ b/src/scalar/scacore_mod.F90
@@ -212,6 +212,7 @@ CONTAINS
             END IF
         END DO
 
+        CALL scaconf%finish()
         IF (myid == 0) THEN
             WRITE(*, '()')
         END IF

--- a/src/scalar/timeintegrate_scalar_mod.F90
+++ b/src/scalar/timeintegrate_scalar_mod.F90
@@ -50,7 +50,7 @@ CONTAINS
             CALL get_field(dt_f, "D"//TRIM(scalar(l)%name))
             CALL get_field(told, TRIM(scalar(l)%name)//"_OLD")
 
-            ! Copy to "T_OLD"
+            ! Copy to "T_OLD" (not needed here but used for Boussinesq)
             told%arr = t%arr
 
             ! TSTSCA4 zeroize qtu, qtv, qtw before use internally


### PR DESCRIPTION
As suggested, I am launching the same PR against mglet-base -- with the same description:

I just recognized that "finish" was not called for "scaconf".
That is surely not a decisive error, but I just happened to see it.
Please, decide of reasonable to merge or not.

Besides, I added a comment on field "TOLD", as I had forgotten why it was there.

Best regards,

Simon
