### PR TITLE
SIP for GPU version 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,5 @@ mglet
 
 # Build folder(s)
 build*
+out*
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,10 +56,16 @@ else()
     message(STATUS "Compiling MGLET with 32 bit integers")
 endif()
 
-option(MGLET_OPENMP "Enable OpenMP (experimental)" OFF)
-if(MGLET_OPENMP)
+option(MGLET_OFFLOAD "Enable OpenMP Offload (experimental)" OFF)
+if(MGLET_OFFLOAD)
     message(STATUS "Enabling OpenMP")
     find_package(OpenMP REQUIRED)
+    add_compile_definitions(_MGLET_OFFLOAD_=1)
+
+    option(MGLET_OFFLOAD_BINDTHREAD "Use bind(thread) instead of bind(parallel)" OFF)
+    if (MGLET_OFFLOAD_BINDTHREAD)
+        add_compile_definitions(_MGLET_OFFLOAD_BINDTHREAD_)
+    endif()
 endif()
 
 # CMake build options
@@ -88,6 +94,12 @@ set(MGLET_C_FLAGS_DEBUG "" CACHE STRING "MGLET C flags (debug)")
 set(MGLET_CXX_FLAGS_DEBUG "" CACHE STRING "MGLET CXX flags (debug)")
 set(MGLET_Fortran_FLAGS_DEBUG "" CACHE STRING "MGLET Fortran flags (debug)")
 
+set(MGLET_OFFLOAD_C_FLAGS "" CACHE STRING "MGLET OFFLOAD C flags")
+set(MGLET_OFFLOAD_CXX_FLAGS "" CACHE STRING "MGLET OFFLOAD CXX flags")
+set(MGLET_OFFLOAD_Fortran_FLAGS "" CACHE STRING "MGLET OFFLOAD Fortran flags")
+
+set(MGLET_LINK_FLAGS "" CACHE STRING "MGLET LINK flags")
+
 add_compile_options("$<$<COMPILE_LANGUAGE:C>:${MGLET_C_FLAGS}>"
     "$<$<COMPILE_LANGUAGE:CXX>:${MGLET_CXX_FLAGS}>"
     "$<$<COMPILE_LANGUAGE:Fortran>:${MGLET_Fortran_FLAGS}>"
@@ -111,10 +123,28 @@ add_compile_options("$<$<COMPILE_LANGUAGE:C>:${MGLET_C_FLAGS}>"
     "$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<STREQUAL:${CMAKE_Fortran_COMPILER_ID},IntelLLVM>>:-diag-disable 5268>"
 )
 
-if (MGLET_OPENMP)
-    add_compile_options("$<$<COMPILE_LANGUAGE:C>:${OpenMP_C_FLAGS}>"
+add_link_options(
+    "${MGLET_LINK_FLAGS}"
+)
+
+if (MGLET_OFFLOAD)
+    
+    # (Cray)[<=19] The Fortran OpenMP flag "-h omp" is not properly recognized
+    #              when appended via ${OpenMP_Fortran_FLAGS}. Thus, use the C
+    #              OpenMP flag "-fopenmp" which has the same effect internally.
+    if (CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
+           set(FIX_OpenMP_Fortran_FLAGS "${OpenMP_C_FLAGS}")
+       else()
+           set(FIX_OpenMP_Fortran_FLAGS "${OpenMP_Fortran_FLAGS}")
+    endif()
+
+    add_compile_options("$<$<COMPILE_LANGUAGE:C>:${OpenMP_C_FLAGS};${MGLET_OFFLOAD_C_FLAGS}>"
+        "$<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS};${MGLET_OFFLOAD_CXX_FLAGS}>"
+        "$<$<COMPILE_LANGUAGE:Fortran>:${FIX_OpenMP_Fortran_FLAGS};${MGLET_OFFLOAD_Fortran_FLAGS}>"
+    )
+    add_link_options("$<$<COMPILE_LANGUAGE:C>:${OpenMP_C_FLAGS}>"
         "$<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>"
-        "$<$<COMPILE_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}>"
+        "$<$<COMPILE_LANGUAGE:Fortran>:${FIX_OpenMP_Fortran_FLAGS}>"
     )
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -245,8 +245,8 @@
             "cacheVariables": {
                 "MGLET_OFFLOAD": "ON",
                 "MGLET_OFFLOAD_BINDTHREAD": "OFF",
-                "MGLET_OFFLOAD_Fortran_FLAGS": "-fopenmp-targets=nvptx64-nvidia-cuda;-fopenmp-version=52",
-                "MGLET_LINK_FLAGS": "-fopenmp-targets=nvptx64-nvidia-cuda"
+                "MGLET_OFFLOAD_Fortran_FLAGS": "-fopenmp-targets=nvptx64-nvidia-cuda;-O3;-fopenmp-version=52;-fopenmp-force-usm",
+                "MGLET_LINK_FLAGS": "-fopenmp-targets=nvptx64-nvidia-cuda;-O3;-fopenmp-force-usm"
             }
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -23,7 +23,7 @@
 
                 "MGLET_C_FLAGS": "-qno-openmp-simd",
                 "MGLET_CXX_FLAGS": "-qno-openmp-simd",
-                "MGLET_Fortran_FLAGS": "-std18;-auto;-warn;all,noexternals,nounused,errors,stderrors;-qno-openmp-simd;-fpscomp;logicals",
+                "MGLET_Fortran_FLAGS": "-std18;-auto;-warn;all,noexternals,nounused,noerrors,stderrors;-qno-openmp-simd;-fpscomp;logicals",
 
                 "MGLET_C_FLAGS_RELEASE": "-g",
                 "MGLET_CXX_FLAGS_RELEASE": "-g",
@@ -41,6 +41,18 @@
             "inherits": "intel",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "intel-offload-release",
+            "displayName": "Intel oneAPI compilers (offload-release)",
+            "description": "Offload Release configuration using the Intel compilers",
+            "inherits": "intel-release",
+            "cacheVariables": {
+                "MGLET_OFFLOAD": "ON",
+                "MGLET_OFFLOAD_BINDTHREAD": "OFF",
+                "MGLET_OFFLOAD_Fortran_FLAGS": "-fopenmp-targets=spir64;-qno-openmp-simd",
+                "MGLET_LINK_FLAGS": "-fopenmp-targets=spir64"
             }
         },
         {
@@ -64,11 +76,11 @@
 
                 "MGLET_C_FLAGS": "-Wall;-Wextra;-Wpedantic;-Werror;-Wno-maybe-uninitialized",
                 "MGLET_CXX_FLAGS": "-Wall;-Wextra;-Wpedantic;-Werror;-Wno-maybe-uninitialized",
-                "MGLET_Fortran_FLAGS": "-Wall;-Wextra;-Wpedantic;-Werror;-Wno-maybe-uninitialized;-std=f2018;-fimplicit-none;-ffpe-trap=invalid,zero,overflow;-Wno-unused-dummy-argument;-Wno-uninitialized",
+                "MGLET_Fortran_FLAGS": "-Wall;-Wextra;-Wpedantic;-Wno-maybe-uninitialized;-std=f2018;-fimplicit-none;-ffpe-trap=invalid,zero,overflow;-Wno-unused-dummy-argument;-Wno-uninitialized",
 
-                "MGLET_C_FLAGS_RELEASE": "-g;-fopenmp-simd",
-                "MGLET_CXX_FLAGS_RELEASE": "-g;-fopenmp-simd",
-                "MGLET_Fortran_FLAGS_RELEASE": "-g;-fopenmp-simd",
+                "MGLET_C_FLAGS_RELEASE": "-g",
+                "MGLET_CXX_FLAGS_RELEASE": "-g",
+                "MGLET_Fortran_FLAGS_RELEASE": "-g",
 
                 "MGLET_C_FLAGS_DEBUG": "-Og;-g",
                 "MGLET_CXX_FLAGS_DEBUG": "-Og;-g",
@@ -172,6 +184,17 @@
             }
         },
         {
+            "name": "cray-offload-release",
+            "displayName": "Cray Compiler Environment (CCE) (offload-release)",
+            "description": "Offload Release configuration using the Cray Compiler Environment (CCE)",
+            "inherits": "cray-release",
+            "cacheVariables": {
+                "MGLET_OFFLOAD": "ON",
+                "MGLET_OFFLOAD_BINDTHREAD": "ON",
+                "MGLET_OFFLOAD_Fortran_FLAGS": "-fopenmp-force-usm"
+            }
+        },
+        {
             "name": "cray-debug",
             "displayName": "Cray Compiler Environment (CCE) (debug)",
             "description": "Debug configuration using the Cray Compiler Environment (CCE)",
@@ -195,9 +218,9 @@
                 "MGLET_CXX_FLAGS": "",
                 "MGLET_Fortran_FLAGS": "-fimplicit-none",
 
-                "MGLET_C_FLAGS_RELEASE": "-g",
-                "MGLET_CXX_FLAGS_RELEASE": "-g",
-                "MGLET_Fortran_FLAGS_RELEASE": "-g",
+                "MGLET_C_FLAGS_RELEASE": "",
+                "MGLET_CXX_FLAGS_RELEASE": "",
+                "MGLET_Fortran_FLAGS_RELEASE": "",
 
                 "MGLET_C_FLAGS_DEBUG": "-O0;-g",
                 "MGLET_CXX_FLAGS_DEBUG": "-O0;-g",
@@ -212,6 +235,18 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
 
+            }
+        },
+        {
+            "name": "llvm-offload-release",
+            "displayName": "LLVM compilers (clang, clang++, flang) (release)",
+            "description": "Offload Release configuration using the LLVM compilers (clang, clang++, flang)",
+            "inherits": "llvm-release",
+            "cacheVariables": {
+                "MGLET_OFFLOAD": "ON",
+                "MGLET_OFFLOAD_BINDTHREAD": "OFF",
+                "MGLET_OFFLOAD_Fortran_FLAGS": "-fopenmp-targets=nvptx64-nvidia-cuda;-fopenmp-version=52",
+                "MGLET_LINK_FLAGS": "-fopenmp-targets=nvptx64-nvidia-cuda"
             }
         },
         {

--- a/src/core/grids_mod.F90
+++ b/src/core/grids_mod.F90
@@ -53,7 +53,7 @@ MODULE grids_mod
     ! Public data arrays
     PUBLIC :: ngrid, minlevel, maxlevel, maxgrdsoflvl, noflevel, igrdoflevel, &
         nmygrids, mygrids, nmygridslvl, mygridslvl, nboconds, itypboconds, &
-        idprocofgrd
+        idprocofgrd, gridinfo
 
 CONTAINS
 
@@ -426,6 +426,8 @@ CONTAINS
 
 
     SUBROUTINE get_mgdims(kk, jj, ii, igrid)
+    !$omp declare target
+
         INTEGER(intk), INTENT(OUT) :: kk, jj, ii
         INTEGER(intk), INTENT(IN) :: igrid
 
@@ -444,12 +446,14 @@ CONTAINS
 
 
     SUBROUTINE get_imygrid(imygrid, igrid)
+    !$omp declare target
+        implicit none
         INTEGER(intk), INTENT(in) :: igrid
         INTEGER(intk), INTENT(out) :: imygrid
 
         imygrid = globalgrids(igrid)
 
-        IF (imygrid == -1_intk) CALL errr(__FILE__, __LINE__)
+        ! IF (imygrid == -1_intk) CALL errr(__FILE__, __LINE__)
     END SUBROUTINE get_imygrid
 
 

--- a/src/core/pointers_mod.F90
+++ b/src/core/pointers_mod.F90
@@ -13,7 +13,7 @@ MODULE pointers_mod
     INTEGER(intk), ALLOCATABLE, PROTECTED :: ipbb(:, :)
 
     PUBLIC :: init_pointers, finish_pointers, get_ip3, get_ip3n, get_ibb, &
-        idim3d, idimbb, get_len3
+        idim3d, idimbb, get_len3, ip3d
 
 CONTAINS
     SUBROUTINE init_pointers()
@@ -136,6 +136,8 @@ CONTAINS
 
 
     SUBROUTINE get_len3(len, igrid)
+    !$omp declare target
+
         INTEGER(intk), INTENT(in) :: igrid
         INTEGER(intk), INTENT(out) :: len
 

--- a/src/core/simdfunctions_mod.F90
+++ b/src/core/simdfunctions_mod.F90
@@ -25,7 +25,6 @@ MODULE simdfunctions_mod
 CONTAINS
 
     PURE ELEMENTAL REAL(real32) FUNCTION divide00_sp(a, b, bp) RESULT(res)
-    !$omp declare simd(divide00_sp)
         REAL(real32), INTENT(in) :: a, b, bp
 
         IF (bp == 0.0_real32) THEN
@@ -36,7 +35,6 @@ CONTAINS
     END FUNCTION divide00_sp
 
     PURE ELEMENTAL REAL(real64) FUNCTION divide00_dp(a, b, bp) RESULT(res)
-    !$omp declare simd(divide00_dp)
         REAL(real64), INTENT(in) :: a, b, bp
 
         IF (bp == 0.0_real64) THEN
@@ -48,7 +46,6 @@ CONTAINS
 
 
     PURE ELEMENTAL REAL(real32) FUNCTION divide0_sp(a, b) RESULT(res)
-    !$omp declare simd(divide0_sp)
         REAL(real32), INTENT(in) :: a, b
 
         IF (b == 0.0_real32) THEN
@@ -59,7 +56,6 @@ CONTAINS
     END FUNCTION divide0_sp
 
     PURE ELEMENTAL REAL(real64) FUNCTION divide0_dp(a, b) RESULT(res)
-    !$omp declare simd(divide0_dp)
         REAL(real64), INTENT(in) :: a, b
 
         IF (b == 0.0_real64) THEN
@@ -71,7 +67,6 @@ CONTAINS
 
 
     PURE ELEMENTAL INTEGER(intk) FUNCTION l_to_i(l) RESULT(i)
-    !$omp declare simd(l_to_i)
         LOGICAL, INTENT(in) :: l
 
         IF (l) THEN
@@ -83,7 +78,6 @@ CONTAINS
 
 
     PURE ELEMENTAL LOGICAL FUNCTION i_to_l(i) RESULT(l)
-    !$omp declare simd(i_to_l)
         INTEGER(intk), INTENT(in) :: i
 
         IF (i == 0) THEN
@@ -95,14 +89,12 @@ CONTAINS
 
 
     PURE ELEMENTAL INTEGER(intk) FUNCTION lcm(a, b)
-    !$omp declare simd(lcm)
         INTEGER(intk), INTENT(in) :: a, b
         lcm = a*b/gcd(a, b)
     END FUNCTION lcm
 
 
     PURE ELEMENTAL INTEGER(intk) FUNCTION gcd(a, b)
-    !$omp declare simd(gcd)
         INTEGER(intk), INTENT(in) :: a, b
         INTEGER(intk) :: aa, bb, t
 
@@ -119,7 +111,6 @@ CONTAINS
 
 
     PURE ELEMENTAL REAL(real32) FUNCTION cube_root_sp(a)
-    !$omp declare simd(cube_root_sp)
         REAL(real32), INTENT(in) :: a
 
         INTERFACE
@@ -136,7 +127,6 @@ CONTAINS
 
 
     PURE ELEMENTAL REAL(real64) FUNCTION cube_root_dp(a)
-    !$omp declare simd(cube_root_dp)
         REAL(real64), INTENT(in) :: a
 
         INTERFACE

--- a/src/flow/CMakeLists.txt
+++ b/src/flow/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(flow STATIC
     flowstat_mod.F90
     gc_compbodyforce_mod.F90
     gc_flowstencils_mod.F90
+    hyperplane_mod.F90
     itinfo_mod.F90
     lesmodel_mod.F90
     plog_mod.F90

--- a/src/flow/hyperplane_mod.F90
+++ b/src/flow/hyperplane_mod.F90
@@ -189,13 +189,13 @@ CONTAINS
     SUBROUTINE hyperplane_init_grid(kk, jj, ii, mip, idxsip)
 
         ! Subroutine arguments
-        INTEGER, INTENT(in) :: kk, jj, ii
-        INTEGER, INTENT(inout) :: mip(ii+jj+kk), idxsip(ii*jj*kk)
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        INTEGER(intk), INTENT(inout) :: mip(ii+jj+kk), idxsip(ii*jj*kk)
 
         ! Local variables
-        INTEGER :: n3dmin, n3dmax
-        INTEGER :: lm, nkmin, nkmax, ic1, nimin, nimax
-        INTEGER :: m, k, j, i, idx
+        INTEGER(intk) :: n3dmin, n3dmax
+        INTEGER(intk) :: lm, nkmin, nkmax, ic1, nimin, nimax
+        INTEGER(intk) :: m, k, j, i, idx
 
         ! Only cover [i=3,ii-2], [j=3,jj-2], [k=3,kk-2]
         n3dmin = 3 + 3 + 3
@@ -258,12 +258,12 @@ CONTAINS
     SUBROUTINE hyperplane_sort_grid(kk, jj, ii, mip, idxsip)
 
         ! Subroutine arguments
-        INTEGER, INTENT(in) :: kk, jj, ii
-        INTEGER, INTENT(in) :: mip(ii+jj+kk)
-        INTEGER, INTENT(inout) :: idxsip(ii*jj*kk)
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        INTEGER(intk), INTENT(in) :: mip(ii+jj+kk)
+        INTEGER(intk), INTENT(inout) :: idxsip(ii*jj*kk)
 
         ! Local variables
-        INTEGER :: n3dmin, n3dmax, len, m, s, e
+        INTEGER(intk) :: n3dmin, n3dmax, len, m, s, e
 
         n3dmin = 3 + 3 + 3
         n3dmax = (ii-2) + (jj-2) + (kk-2)

--- a/src/flow/hyperplane_mod.F90
+++ b/src/flow/hyperplane_mod.F90
@@ -5,8 +5,20 @@ MODULE hyperplane_mod
 
     IMPLICIT NONE
 
+    ! Infrastructure for hyperplane traversal
     TYPE(int_stencils_t), ALLOCATABLE, PROTECTED, TARGET :: mip_sip_list(:)
     TYPE(int_stencils_t), ALLOCATABLE, PROTECTED, TARGET :: idx_sip_list(:)
+
+    ! Coefficients in [L] of ILU (including diagonal)
+    TYPE(real_stencils_t), ALLOCATABLE, PROTECTED, TARGET :: lw_sip_list(:)
+    TYPE(real_stencils_t), ALLOCATABLE, PROTECTED, TARGET :: ls_sip_list(:)
+    TYPE(real_stencils_t), ALLOCATABLE, PROTECTED, TARGET :: lb_sip_list(:)
+    TYPE(real_stencils_t), ALLOCATABLE, PROTECTED, TARGET :: lpr_sip_list(:)
+
+    ! Coefficients in [L] of ILU
+    TYPE(real_stencils_t), ALLOCATABLE, PROTECTED, TARGET :: ue_sip_list(:)
+    TYPE(real_stencils_t), ALLOCATABLE, PROTECTED, TARGET :: un_sip_list(:)
+    TYPE(real_stencils_t), ALLOCATABLE, PROTECTED, TARGET :: ut_sip_list(:)
 
     PUBLIC :: hyperplane_init, hyperplane_finish
 
@@ -16,6 +28,8 @@ CONTAINS
 
         ! Local variables
         INTEGER(intk) :: i, igrid, kk, jj, ii
+        REAL(realk), POINTER, CONTIGUOUS :: lw(:), ls(:), lb(:), lpr(:)
+        REAL(realk), POINTER, CONTIGUOUS :: ue(:), un(:), ut(:)
 
         ! Allocation of the lists of stencils for all grids
         ALLOCATE(mip_sip_list(nmygrids))
@@ -44,7 +58,96 @@ CONTAINS
                 idx_sip_list(i)%arr)
         END DO
 
+        ! Allocation of the lists of stencils for all grids
+        ALLOCATE(lw_sip_list(nmygrids))
+        ALLOCATE(ls_sip_list(nmygrids))
+        ALLOCATE(lb_sip_list(nmygrids))
+        ALLOCATE(lpr_sip_list(nmygrids))
+
+        ALLOCATE(ue_sip_list(nmygrids))
+        ALLOCATE(un_sip_list(nmygrids))
+        ALLOCATE(ut_sip_list(nmygrids))
+
+        ! Iteration over all local grids
+        DO i = 1, nmygrids
+
+            igrid = mygrids(i)
+            CALL get_mgdims(kk, jj, ii, igrid)
+
+            ! Getting the already computed SIP coefficients for one grid
+            CALL get_fieldptr(lw, "SIPLW", igrid)
+            CALL get_fieldptr(ls, "SIPLS", igrid)
+            CALL get_fieldptr(lb, "SIPLB", igrid)
+            CALL get_fieldptr(lpr, "SIPLPR", igrid)
+            CALL get_fieldptr(ue, "SIPUE", igrid)
+            CALL get_fieldptr(un, "SIPUN", igrid)
+            CALL get_fieldptr(ut, "SIPUT", igrid)
+
+            ALLOCATE(lw_sip_list(i)%arr(ii*jj*kk))
+            ALLOCATE(ls_sip_list(i)%arr(ii*jj*kk))
+            ALLOCATE(lb_sip_list(i)%arr(ii*jj*kk))
+            ALLOCATE(lpr_sip_list(i)%arr(ii*jj*kk))
+            ALLOCATE(ue_sip_list(i)%arr(ii*jj*kk))
+            ALLOCATE(un_sip_list(i)%arr(ii*jj*kk))
+            ALLOCATE(ut_sip_list(i)%arr(ii*jj*kk))
+
+            ! Store the SIP coefficients for contiguous memory access
+            CALL reorder_for_access(kk, jj, ii, lw_sip_list(i)%arr, lw, &
+                mip_sip_list(i)%arr, idx_sip_list(i)%arr)
+            CALL reorder_for_access(kk, jj, ii, ls_sip_list(i)%arr, ls, &
+                mip_sip_list(i)%arr, idx_sip_list(i)%arr)
+            CALL reorder_for_access(kk, jj, ii, lb_sip_list(i)%arr, lb, &
+                mip_sip_list(i)%arr, idx_sip_list(i)%arr)
+            CALL reorder_for_access(kk, jj, ii, lpr_sip_list(i)%arr, lpr, &
+                mip_sip_list(i)%arr, idx_sip_list(i)%arr)
+            CALL reorder_for_access(kk, jj, ii, ue_sip_list(i)%arr, ue, &
+                mip_sip_list(i)%arr, idx_sip_list(i)%arr)
+            CALL reorder_for_access(kk, jj, ii, un_sip_list(i)%arr, un, &
+                mip_sip_list(i)%arr, idx_sip_list(i)%arr)
+            CALL reorder_for_access(kk, jj, ii, ut_sip_list(i)%arr, ut, &
+                mip_sip_list(i)%arr, idx_sip_list(i)%arr)
+
+        END DO
+
     END SUBROUTINE hyperplane_init
+
+
+    PURE SUBROUTINE reorder_for_access(kk, jj, ii, acc, arr, mip, idxsip)
+
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(inout) :: acc(kk*jj*ii)
+        REAL(realk), INTENT(in) :: arr(kk*jj*ii)
+
+        ! For the hyperplane traversal
+        INTEGER(intk), INTENT(in) :: mip(ii+jj+kk)
+        INTEGER(intk), INTENT(in) :: idxsip(ii*jj*kk)
+
+        ! Local variables
+        INTEGER(intk) :: n3dmin, n3dmax, m, lm, len, ip, idx, iacc
+
+        ! Subroutine body
+        n3dmin = 3 + 3 + 3
+        n3dmax = (ii-2) + (jj-2) + (kk-2)
+        acc(kk*jj*ii) = -HUGE(1.0_realk)
+
+        ! Iterating over the hyperplanes H(k, j, i) = m
+        DO m = n3dmin, n3dmax
+
+            lm = mip(m)
+            len = mip(m+1) - lm
+
+            ! > Parallel operations on the hyperplane (k, j, i) = m
+            DO ip = 1, len
+
+                iacc = lm + ip
+                idx = idxsip(iacc)
+                acc(iacc) = arr(idx)
+
+            END DO
+        END DO
+
+    END SUBROUTINE reorder_for_access
 
 
 
@@ -58,11 +161,25 @@ CONTAINS
             ! Deallocation of the arrays for one grid
             DEALLOCATE(mip_sip_list(i)%arr)
             DEALLOCATE(idx_sip_list(i)%arr)
+            DEALLOCATE(lw_sip_list(i)%arr)
+            DEALLOCATE(ls_sip_list(i)%arr)
+            DEALLOCATE(lb_sip_list(i)%arr)
+            DEALLOCATE(lpr_sip_list(i)%arr)
+            DEALLOCATE(ue_sip_list(i)%arr)
+            DEALLOCATE(un_sip_list(i)%arr)
+            DEALLOCATE(ut_sip_list(i)%arr)
         END DO
 
         ! Deallocation of the lists of stencils for all grids
         DEALLOCATE(mip_sip_list)
         DEALLOCATE(idx_sip_list)
+        DEALLOCATE(lw_sip_list)
+        DEALLOCATE(ls_sip_list)
+        DEALLOCATE(lb_sip_list)
+        DEALLOCATE(lpr_sip_list)
+        DEALLOCATE(ue_sip_list)
+        DEALLOCATE(un_sip_list)
+        DEALLOCATE(ut_sip_list)
 
     END SUBROUTINE hyperplane_finish
 
@@ -72,7 +189,7 @@ CONTAINS
     SUBROUTINE hyperplane_init_grid(kk, jj, ii, mip, idxsip)
 
         ! Subroutine arguments
-        INTEGER, INTENT(in)    :: kk, jj, ii
+        INTEGER, INTENT(in) :: kk, jj, ii
         INTEGER, INTENT(inout) :: mip(ii+jj+kk), idxsip(ii*jj*kk)
 
         ! Local variables
@@ -121,6 +238,7 @@ CONTAINS
 
                     ! Increment counter
                     ic1 = ic1 + 1
+
                     ! Store linear index
                     CALL sub2ind(idx, k, j, i, kk, jj, ii)
                     idxsip(lm + ic1) = idx

--- a/src/flow/hyperplane_mod.F90
+++ b/src/flow/hyperplane_mod.F90
@@ -67,8 +67,8 @@ CONTAINS
     END SUBROUTINE hyperplane_finish
 
 
-    !---------------------------------------------------------------------
-    !> Initialize index vectors for hyperplane traversal
+    ! ---------------------------------------------------------------------
+    ! > Initialize index vectors for hyperplane traversal
     SUBROUTINE hyperplane_init_grid(kk, jj, ii, mip, idxsip)
 
         ! Subroutine arguments
@@ -107,15 +107,15 @@ CONTAINS
 
                     ! Check bounds
                     IF (i < 3 .OR. i > (ii-2)) THEN
-                        WRITE(*,*) 'hyperplane_init_grid: i out of bounds', i
+                        WRITE(*, *) 'hyperplane_init_grid: i out of bounds', i
                         CALL errr(__FILE__, __LINE__)
                     END IF
                     IF (j < 3 .OR. j > (jj-2)) THEN
-                        WRITE(*,*) 'hyperplane_init_grid: j out of bounds', j
+                        WRITE(*, *) 'hyperplane_init_grid: j out of bounds', j
                         CALL errr(__FILE__, __LINE__)
                     END IF
                     IF (k < 3 .OR. k > (kk-2)) THEN
-                        WRITE(*,*) 'hyperplane_init_grid: k out of bounds', k
+                        WRITE(*, *) 'hyperplane_init_grid: k out of bounds', k
                         CALL errr(__FILE__, __LINE__)
                     END IF
 
@@ -135,8 +135,8 @@ CONTAINS
     END SUBROUTINE hyperplane_init_grid
 
 
-    !---------------------------------------------------------------------
-    !> Sort indices within each hyperplane
+    ! ---------------------------------------------------------------------
+    ! > Sort indices within each hyperplane
     SUBROUTINE hyperplane_sort_grid(kk, jj, ii, mip, idxsip)
 
         ! Subroutine arguments
@@ -161,8 +161,8 @@ CONTAINS
     END SUBROUTINE hyperplane_sort_grid
 
 
-    !---------------------------------------------------------------------
-    !> Simple selection sort (for testing -- not performant)
+    ! ---------------------------------------------------------------------
+    ! > Simple selection sort (for testing -- not performant)
     SUBROUTINE sort(n, vec)
 
         ! Subroutine arguments
@@ -183,7 +183,7 @@ CONTAINS
 
         DO ix = 1, n-1
             IF (v_asc(ix+1) <= v_asc(ix)) THEN
-                WRITE(*,*) 'sort: sorting failed'
+                WRITE(*, *) 'sort: sorting failed'
                 CALL errr(__FILE__, __LINE__)
             END IF
         END DO
@@ -193,8 +193,8 @@ CONTAINS
     END SUBROUTINE sort
 
 
-    !---------------------------------------------------------------------
-    !> Check index vector correctness
+    ! ---------------------------------------------------------------------
+    ! > Check index vector correctness
     SUBROUTINE hyperplane_check_grid(kk, jj, ii, mip, idxsip)
 
         ! Subroutine arguments
@@ -220,7 +220,7 @@ CONTAINS
                 CALL ind2sub(idx, k, j, i, kk, jj, ii)
                 test(k, j, i) = test(k, j, i) + 1
                 IF (k+j+i /= m) THEN
-                    WRITE(*,*) 'hyperplane_check_grid: index error'
+                    WRITE(*, *) 'hyperplane_check_grid: index error'
                     CALL errr(__FILE__, __LINE__)
                 END IF
             END DO
@@ -228,15 +228,15 @@ CONTAINS
 
         ! Performing tests and deallocating test grid
         IF (ANY(test > 1)) THEN
-            WRITE(*,*) 'hyperplane_check_grid: some indices are duplicated'
+            WRITE(*, *) 'hyperplane_check_grid: some indices are duplicated'
             CALL errr(__FILE__, __LINE__)
         END IF
         IF (ANY(test(3:kk-2, 3:jj-2, 3:ii-2) < 1)) THEN
-            WRITE(*,*) 'hyperplane_check_grid: some indices are missing'
+            WRITE(*, *) 'hyperplane_check_grid: some indices are missing'
             CALL errr(__FILE__, __LINE__)
         END IF
         IF (SUM(test) /= (kk-4)*(jj-4)*(ii-4)) THEN
-            WRITE(*,*) 'hyperplane_check_grid: summation failed'
+            WRITE(*, *) 'hyperplane_check_grid: summation failed'
             CALL errr(__FILE__, __LINE__)
         END IF
         DEALLOCATE(test)

--- a/src/flow/hyperplane_mod.F90
+++ b/src/flow/hyperplane_mod.F90
@@ -1,0 +1,246 @@
+
+MODULE hyperplane_mod
+
+    USE core_mod
+
+    IMPLICIT NONE
+
+    TYPE(int_stencils_t), ALLOCATABLE, PROTECTED, TARGET :: mip_sip_list(:)
+    TYPE(int_stencils_t), ALLOCATABLE, PROTECTED, TARGET :: idx_sip_list(:)
+
+    PUBLIC :: hyperplane_init, hyperplane_finish
+
+CONTAINS
+
+    SUBROUTINE hyperplane_init()
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid, kk, jj, ii
+
+        ! Allocation of the lists of stencils for all grids
+        ALLOCATE(mip_sip_list(nmygrids))
+        ALLOCATE(idx_sip_list(nmygrids))
+
+        ! Iteration over all local grids
+        DO i = 1, nmygrids
+
+            igrid = mygrids(i)
+            CALL get_mgdims(kk, jj, ii, igrid)
+
+            ! Allocation of the arrays for one grid
+            ALLOCATE(mip_sip_list(i)%arr(ii+jj+kk))
+            ALLOCATE(idx_sip_list(i)%arr(ii*jj*kk))
+
+            ! Populating the arrays for one grid
+            CALL hyperplane_init_grid(kk, jj, ii, mip_sip_list(i)%arr, &
+                idx_sip_list(i)%arr)
+
+            ! Sorting the indices within each hyperplane for one grid
+            CALL hyperplane_sort_grid(kk, jj, ii, mip_sip_list(i)%arr, &
+                idx_sip_list(i)%arr)
+
+            ! Checking the correctness of the arrays for one grid
+            CALL hyperplane_check_grid(kk, jj, ii, mip_sip_list(i)%arr, &
+                idx_sip_list(i)%arr)
+        END DO
+
+    END SUBROUTINE hyperplane_init
+
+
+
+    SUBROUTINE hyperplane_finish()
+
+        ! Local variables
+        INTEGER(intk) :: i
+
+        ! Iteration over all local grids
+        DO i = 1, nmygrids
+            ! Deallocation of the arrays for one grid
+            DEALLOCATE(mip_sip_list(i)%arr)
+            DEALLOCATE(idx_sip_list(i)%arr)
+        END DO
+
+        ! Deallocation of the lists of stencils for all grids
+        DEALLOCATE(mip_sip_list)
+        DEALLOCATE(idx_sip_list)
+
+    END SUBROUTINE hyperplane_finish
+
+
+    !---------------------------------------------------------------------
+    !> Initialize index vectors for hyperplane traversal
+    SUBROUTINE hyperplane_init_grid(kk, jj, ii, mip, idxsip)
+
+        ! Subroutine arguments
+        INTEGER, INTENT(in)    :: kk, jj, ii
+        INTEGER, INTENT(inout) :: mip(ii+jj+kk), idxsip(ii*jj*kk)
+
+        ! Local variables
+        INTEGER :: n3dmin, n3dmax
+        INTEGER :: lm, nkmin, nkmax, ic1, nimin, nimax
+        INTEGER :: m, k, j, i, idx
+
+        ! Only cover [i=3,ii-2], [j=3,jj-2], [k=3,kk-2]
+        n3dmin = 3 + 3 + 3
+        n3dmax = (ii-2) + (jj-2) + (kk-2)
+
+        ! Initialization (to facilitate error detection)
+        mip = 0
+        idxsip = -1
+
+        ! Iterate over hyperplanes H(k,j,i)=m
+        DO m = n3dmin, n3dmax
+
+            ic1 = 0
+            lm  = mip(m)
+            nkmin = MAX(m - (ii-2) - (jj-2), 3)
+            nkmax = MIN((m - 2*3), (kk-2))
+
+            DO k = nkmin, nkmax
+                nimin = MAX(m - (jj-2) - k, 3)
+                nimax = MIN(m - k - 1*3, (ii-2))
+
+                DO i = nimin, nimax
+
+                    ! Calculate remaining index
+                    j = m - k - i
+
+                    ! Check bounds
+                    IF (i < 3 .OR. i > (ii-2)) THEN
+                        WRITE(*,*) 'hyperplane_init_grid: i out of bounds', i
+                        CALL errr(__FILE__, __LINE__)
+                    END IF
+                    IF (j < 3 .OR. j > (jj-2)) THEN
+                        WRITE(*,*) 'hyperplane_init_grid: j out of bounds', j
+                        CALL errr(__FILE__, __LINE__)
+                    END IF
+                    IF (k < 3 .OR. k > (kk-2)) THEN
+                        WRITE(*,*) 'hyperplane_init_grid: k out of bounds', k
+                        CALL errr(__FILE__, __LINE__)
+                    END IF
+
+                    ! Increment counter
+                    ic1 = ic1 + 1
+                    ! Store linear index
+                    CALL sub2ind(idx, k, j, i, kk, jj, ii)
+                    idxsip(lm + ic1) = idx
+
+                END DO
+            END DO
+
+            mip(m+1) = mip(m) + ic1
+
+        END DO
+
+    END SUBROUTINE hyperplane_init_grid
+
+
+    !---------------------------------------------------------------------
+    !> Sort indices within each hyperplane
+    SUBROUTINE hyperplane_sort_grid(kk, jj, ii, mip, idxsip)
+
+        ! Subroutine arguments
+        INTEGER, INTENT(in) :: kk, jj, ii
+        INTEGER, INTENT(in) :: mip(ii+jj+kk)
+        INTEGER, INTENT(inout) :: idxsip(ii*jj*kk)
+
+        ! Local variables
+        INTEGER :: n3dmin, n3dmax, len, m, s, e
+
+        n3dmin = 3 + 3 + 3
+        n3dmax = (ii-2) + (jj-2) + (kk-2)
+
+        ! Iterate over hyperplanes H(k,j,i)=m and sorting within each plane
+        DO m = n3dmin, n3dmax
+            len = mip(m+1) - mip(m)
+            s   = mip(m) + 1
+            e   = mip(m+1)
+            CALL sort(len, idxsip(s:e))
+        END DO
+
+    END SUBROUTINE hyperplane_sort_grid
+
+
+    !---------------------------------------------------------------------
+    !> Simple selection sort (for testing -- not performant)
+    SUBROUTINE sort(n, vec)
+
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: n
+        INTEGER(intk), INTENT(inout) :: vec(n)
+
+        ! Local variables
+        INTEGER(intk) :: ix, v_rand(n), v_asc(n)
+        LOGICAL :: mask(n)
+
+        v_rand(:) = vec(:)
+        mask = .TRUE.
+
+        DO ix = 1, n
+            v_asc(ix) = MINVAL(v_rand, mask)
+            mask(MINLOC(v_rand, mask)) = .FALSE.
+        END DO
+
+        DO ix = 1, n-1
+            IF (v_asc(ix+1) <= v_asc(ix)) THEN
+                WRITE(*,*) 'sort: sorting failed'
+                CALL errr(__FILE__, __LINE__)
+            END IF
+        END DO
+
+        vec(:) = v_asc(:)
+
+    END SUBROUTINE sort
+
+
+    !---------------------------------------------------------------------
+    !> Check index vector correctness
+    SUBROUTINE hyperplane_check_grid(kk, jj, ii, mip, idxsip)
+
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        INTEGER(intk), INTENT(in) :: mip(ii+jj+kk), idxsip(ii*jj*kk)
+
+        ! Local variables
+        INTEGER(intk) :: k, j, i, len, m, idx, n3dmin, n3dmax, lm, ip
+        INTEGER(intk), ALLOCATABLE :: test(:, :, :)
+
+        ! Creating test grid
+        ALLOCATE(test(kk, jj, ii))
+        test = 0
+
+        n3dmin = 3 + 3 + 3
+        n3dmax = (ii-2) + (jj-2) + (kk-2)
+
+        DO m = n3dmin, n3dmax
+            len = mip(m+1) - mip(m)
+            lm  = mip(m)
+            DO ip = 1, len
+                idx = idxsip(lm + ip)
+                CALL ind2sub(idx, k, j, i, kk, jj, ii)
+                test(k, j, i) = test(k, j, i) + 1
+                IF (k+j+i /= m) THEN
+                    WRITE(*,*) 'hyperplane_check_grid: index error'
+                    CALL errr(__FILE__, __LINE__)
+                END IF
+            END DO
+        END DO
+
+        ! Performing tests and deallocating test grid
+        IF (ANY(test > 1)) THEN
+            WRITE(*,*) 'hyperplane_check_grid: some indices are duplicated'
+            CALL errr(__FILE__, __LINE__)
+        END IF
+        IF (ANY(test(3:kk-2, 3:jj-2, 3:ii-2) < 1)) THEN
+            WRITE(*,*) 'hyperplane_check_grid: some indices are missing'
+            CALL errr(__FILE__, __LINE__)
+        END IF
+        IF (SUM(test) /= (kk-4)*(jj-4)*(ii-4)) THEN
+            WRITE(*,*) 'hyperplane_check_grid: summation failed'
+            CALL errr(__FILE__, __LINE__)
+        END IF
+        DEALLOCATE(test)
+
+    END SUBROUTINE hyperplane_check_grid
+
+END MODULE hyperplane_mod

--- a/src/flow/lesmodel_mod.F90
+++ b/src/flow/lesmodel_mod.F90
@@ -363,7 +363,6 @@ CONTAINS
 
     PURE ELEMENTAL REAL(realk) FUNCTION smagorinsky(dudx, dudy, dudz, dvdx, &
     dvdy, dvdz, dwdx, dwdy, dwdz)
-        !$omp declare simd(smagorinsky)
 
         ! Function arguments
         REAL(realk), INTENT(in) :: dudx, dudy, dudz, dvdx, &
@@ -517,7 +516,6 @@ CONTAINS
 
     PURE ELEMENTAL REAL(realk) FUNCTION sabs(dudx, dudy, dudz, dvdx, &
             dvdy, dvdz, dwdx, dwdy, dwdz)
-        !$omp declare simd(sabs)
 
         ! Function arguments
         REAL(realk), INTENT(in) :: dudx, dudy, dudz, dvdx, &

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -5,7 +5,7 @@ MODULE pressuresolver_mod
     USE ib_mod
     USE itinfo_mod, ONLY: itinfo_sample
     USE plog_mod
-    USE hyperplane_mod, ONLY: hyperplane_init, hyperplane_finish
+    USE hyperplane_mod
 
     IMPLICIT NONE (type, external)
     PRIVATE
@@ -129,8 +129,8 @@ CONTAINS
         END SELECT
 
         ! Always intialize SIP - it's always used at the coarsest level
-        CALL hyperplane_init()
         CALL init_sip()
+        CALL hyperplane_init()
 
         ! Initialize SOR if enabled
         IF (ityp == 1) THEN
@@ -585,7 +585,9 @@ CONTAINS
             CALL siplpr%get_ptr(lpr, igrid)
 
             ! CALL sipiter1(kk, jj, ii, rhs_p, res_p, lw, ls, lb, lpr)
-            CALL sipiter1(kk, jj, ii, rhs_p, res_p, lw, ls, lb, lpr, &
+            CALL sipiter1(kk, jj, ii, rhs_p, res_p, &
+                lw_sip_list(i)%arr, ls_sip_list(i)%arr, &
+                lb_sip_list(i)%arr, lpr_sip_list(i)%arr, &
                 mip_sip_list(i)%arr, idx_sip_list(i)%arr)
         END DO
 
@@ -608,7 +610,8 @@ CONTAINS
             CALL siput%get_ptr(ut, igrid)
 
             ! CALL sipiter2(kk, jj, ii, dp_p, res_p, ue, un, ut)
-            CALL sipiter2(kk, jj, ii, dp_p, res_p, ue, un, ut, &
+            CALL sipiter2(kk, jj, ii, dp_p, res_p, &
+                ue_sip_list(i)%arr, un_sip_list(i)%arr, ut_sip_list(i)%arr, &
                 mip_sip_list(i)%arr, idx_sip_list(i)%arr)
         END DO
     END SUBROUTINE sip
@@ -863,7 +866,7 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: idxsip(ii*jj*kk)
 
         ! Local variables
-        INTEGER(intk) :: n3dmin, n3dmax, m, lm, len, ip, &
+        INTEGER(intk) :: n3dmin, n3dmax, m, lm, len, ip, iacc, &
             idx, idx_km, idx_jm, idx_im
 
         ! Subroutine body
@@ -879,18 +882,21 @@ CONTAINS
             ! > Parallel operations on the hyperplane (k, j, i) = m
             DO ip = 1, len
 
+                ! Computing the contiguous access index
+                iacc = lm + ip
+
                 ! Computing the required indices
-                idx = idxsip(lm + ip)
+                idx = idxsip(iacc)
                 idx_km = idx - 1
                 idx_jm = idx - kk
                 idx_im = idx - (kk*jj)
 
                 ! Accounting for RHS
-                res(idx) = (rhs(idx) + res(idx)) * lpr(idx)
+                res(idx) = (rhs(idx) + res(idx)) * lpr(iacc)
 
                 ! Performing the forward substitution
-                res(idx) = res(idx) - lb(idx)*res(idx_km) - &
-                    ls(idx)*res(idx_jm) - lw(idx)*res(idx_im)
+                res(idx) = res(idx) - lb(iacc)*res(idx_km) - &
+                    ls(iacc)*res(idx_jm) - lw(iacc)*res(idx_im)
 
                 ! Original code:
                 ! res(k, j, i) = res(k, j, i) - lw(k, j, i)*res(k, j, i-1) &
@@ -946,7 +952,7 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: idxsip(ii*jj*kk)
 
         ! Local variables
-        INTEGER(intk) :: n3dmin, n3dmax, m, lm, len, ip, &
+        INTEGER(intk) :: n3dmin, n3dmax, m, lm, len, ip, iacc, &
             idx, idx_kp, idx_jp, idx_ip, i, j, k
 
         ! Subroutine body
@@ -962,15 +968,18 @@ CONTAINS
             ! > Parallel operations on the hyperplane (k, j, i) = m
             DO ip = 1, len
 
+                ! Computing the contiguous access index
+                iacc = lm + ip
+
                 ! Computing the required indices
-                idx = idxsip(lm + ip)
+                idx = idxsip(iacc)
                 idx_kp = idx + 1
                 idx_jp = idx + kk
                 idx_ip = idx + (kk*jj)
 
                 ! Performing the backward substitution
-                res(idx) = res(idx) - ut(idx)*res(idx_kp) - &
-                    un(idx)*res(idx_jp) - ue(idx)*res(idx_ip)
+                res(idx) = res(idx) - ut(iacc)*res(idx_kp) - &
+                    un(iacc)*res(idx_jp) - ue(iacc)*res(idx_ip)
 
                 ! Original code:
                 ! res(k, j, i) = res(k, j, i) - un(k, j, i)*res(k, j+1, i) &

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -5,6 +5,7 @@ MODULE pressuresolver_mod
     USE ib_mod
     USE itinfo_mod, ONLY: itinfo_sample
     USE plog_mod
+    USE hyperplane_mod, ONLY: hyperplane_init, hyperplane_finish
 
     IMPLICIT NONE (type, external)
     PRIVATE
@@ -42,8 +43,12 @@ MODULE pressuresolver_mod
     ! A-versions: simple versions not considering the BP field
     ! B-versions: IB versions using the BP field
     INTERFACE sipiter1
-        MODULE PROCEDURE :: sipiter1_A, sipiter1_B
+        MODULE PROCEDURE :: sipiter1_A, sipiter1_B, sipiter1_HPB
     END INTERFACE sipiter1
+
+    INTERFACE sipiter2
+        MODULE PROCEDURE :: sipiter2_A, sipiter2_HPA
+    END INTERFACE sipiter2
 
     INTERFACE pressureftocone
         MODULE PROCEDURE :: pressureftocone_A, pressureftocone_B
@@ -124,6 +129,7 @@ CONTAINS
         END SELECT
 
         ! Always intialize SIP - it's always used at the coarsest level
+        CALL hyperplane_init()
         CALL init_sip()
 
         ! Initialize SOR if enabled
@@ -141,6 +147,7 @@ CONTAINS
 
     SUBROUTINE finish_pressuresolver()
         CALL finish_plog()
+        CALL hyperplane_finish()
     END SUBROUTINE finish_pressuresolver
 
 
@@ -537,6 +544,9 @@ CONTAINS
 
     SUBROUTINE sip(ilevel, iloop, dp, res, rhs, siplw, sipls, siplb, &
             sipue, sipun, siput, siplpr, bp)
+
+        USE hyperplane_mod, ONLY: mip_sip_list, idx_sip_list
+
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: ilevel
         INTEGER(intk), INTENT(in) :: iloop
@@ -553,18 +563,17 @@ CONTAINS
         TYPE(field_t), INTENT(in), OPTIONAL :: bp
 
         ! Local variables
-        INTEGER(intk) :: i, igrid
+        INTEGER(intk) :: i, il, igrid
         INTEGER(intk) :: kk, jj, ii
-        REAL(realk), POINTER, CONTIGUOUS :: lw(:, :, :), ls(:, :, :), &
-            lb(:, :, :), ue(:, :, :), un(:, :, :), ut(:, :, :), &
-            lpr(:, :, :)
-        REAL(realk), POINTER, CONTIGUOUS :: dp_p(:, :, :), res_p(:, :, :), &
-            rhs_p(:, :, :)
+        REAL(realk), POINTER, CONTIGUOUS :: lw(:), ls(:), &
+            lb(:), ue(:), un(:), ut(:), lpr(:)
+        REAL(realk), POINTER, CONTIGUOUS :: dp_p(:), res_p(:), rhs_p(:)
 
         CALL laplacephi_level(ilevel, res, dp, bp)
 
-        DO i = 1, nmygridslvl(ilevel)
-            igrid = mygridslvl(i, ilevel)
+        DO il = 1, nmygridslvl(ilevel)
+            igrid = mygridslvl(il, ilevel)
+            CALL get_imygrid(i, igrid)
             CALL get_mgdims(kk, jj, ii, igrid)
 
             CALL res%get_ptr(res_p, igrid)
@@ -575,7 +584,9 @@ CONTAINS
             CALL siplb%get_ptr(lb, igrid)
             CALL siplpr%get_ptr(lpr, igrid)
 
-            CALL sipiter1(kk, jj, ii, rhs_p, res_p, lw, ls, lb, lpr)
+            ! CALL sipiter1(kk, jj, ii, rhs_p, res_p, lw, ls, lb, lpr)
+            CALL sipiter1(kk, jj, ii, rhs_p, res_p, lw, ls, lb, lpr, &
+                mip_sip_list(i)%arr, idx_sip_list(i)%arr)
         END DO
 
         IF (iloop < ninner) THEN
@@ -584,8 +595,9 @@ CONTAINS
             CALL connect(ilevel, 1, s1=res, forward=-1)
         END IF
 
-        DO i = 1, nmygridslvl(ilevel)
-            igrid = mygridslvl(i, ilevel)
+        DO il = 1, nmygridslvl(ilevel)
+            igrid = mygridslvl(il, ilevel)
+            CALL get_imygrid(i, igrid)
             CALL get_mgdims(kk, jj, ii, igrid)
 
             CALL dp%get_ptr(dp_p, igrid)
@@ -595,7 +607,9 @@ CONTAINS
             CALL sipun%get_ptr(un, igrid)
             CALL siput%get_ptr(ut, igrid)
 
-            CALL sipiter2(kk, jj, ii, dp_p, res_p, ue, un, ut)
+            ! CALL sipiter2(kk, jj, ii, dp_p, res_p, ue, un, ut)
+            CALL sipiter2(kk, jj, ii, dp_p, res_p, ue, un, ut, &
+                mip_sip_list(i)%arr, idx_sip_list(i)%arr)
         END DO
     END SUBROUTINE sip
 
@@ -835,7 +849,61 @@ CONTAINS
     END SUBROUTINE sipiter1_B
 
 
-    PURE SUBROUTINE sipiter2(kk, jj, ii, phi, res, ue, un, ut)
+    PURE SUBROUTINE sipiter1_HPB(kk, jj, ii, rhs, res, lw, ls, lb, lpr, mip, &
+        idxsip)
+
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(inout) :: res(kk*jj*ii)
+        REAL(realk), INTENT(in) :: rhs(kk*jj*ii), lw(kk*jj*ii), ls(kk*jj*ii), &
+            lb(kk*jj*ii), lpr(kk*jj*ii)
+
+        ! For the hyperplane traversal
+        INTEGER(intk), INTENT(in) :: mip(ii+jj+kk)
+        INTEGER(intk), INTENT(in) :: idxsip(ii*jj*kk)
+
+        ! Local variables
+        INTEGER(intk) :: n3dmin, n3dmax, m, lm, len, ip, &
+            idx, idx_km, idx_jm, idx_im
+
+        ! Subroutine body
+        n3dmin = 3 + 3 + 3
+        n3dmax = (ii-2) + (jj-2) + (kk-2)
+
+        ! Iterating over the hyperplanes H(k, j, i) = m
+        DO m = n3dmin, n3dmax
+
+            lm = mip(m)
+            len = mip(m+1) - lm
+
+            ! > Parallel operations on the hyperplane (k, j, i) = m
+            DO ip = 1, len
+
+                ! Computing the required indices
+                idx = idxsip(lm + ip)
+                idx_km = idx - 1
+                idx_jm = idx - kk
+                idx_im = idx - (kk*jj)
+
+                ! Accounting for RHS
+                res(idx) = (rhs(idx) + res(idx)) * lpr(idx)
+
+                ! Performing the forward substitution
+                res(idx) = res(idx) - lb(idx)*res(idx_km) - &
+                    ls(idx)*res(idx_jm) - lw(idx)*res(idx_im)
+
+                ! Original code:
+                ! res(k, j, i) = res(k, j, i) - lw(k, j, i)*res(k, j, i-1) &
+                !     - ls(k, j, i)*res(k, j-1, i) - lb(k, j, i)*res(k-1, j, i)
+
+            END DO
+        END DO
+
+    END SUBROUTINE sipiter1_HPB
+
+
+
+    PURE SUBROUTINE sipiter2_A(kk, jj, ii, phi, res, ue, un, ut)
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: kk, jj, ii
         REAL(realk), INTENT(inout) :: phi(kk, jj, ii), res(kk, jj, ii)
@@ -864,7 +932,62 @@ CONTAINS
                 END DO
             END DO
         END DO
-    END SUBROUTINE sipiter2
+    END SUBROUTINE sipiter2_A
+
+
+    PURE SUBROUTINE sipiter2_HPA(kk, jj, ii, phi, res, ue, un, ut, mip, idxsip)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(inout) :: phi(kk*jj*ii), res(kk*jj*ii)
+        REAL(realk), INTENT(in) :: ue(kk*jj*ii), un(kk*jj*ii), ut(kk*jj*ii)
+
+        ! For the hyperplane traversal
+        INTEGER(intk), INTENT(in) :: mip(ii+jj+kk)
+        INTEGER(intk), INTENT(in) :: idxsip(ii*jj*kk)
+
+        ! Local variables
+        INTEGER(intk) :: n3dmin, n3dmax, m, lm, len, ip, &
+            idx, idx_kp, idx_jp, idx_ip, i, j, k
+
+        ! Subroutine body
+        n3dmin = 3 + 3 + 3
+        n3dmax = (ii-2) + (jj-2) + (kk-2)
+
+        ! Iterating (REVERSE) over the hyperplanes H(k, j, i) = m
+        DO m = n3dmax, n3dmin, -1
+
+            lm = mip(m)
+            len = mip(m+1) - lm
+
+            ! > Parallel operations on the hyperplane (k, j, i) = m
+            DO ip = 1, len
+
+                ! Computing the required indices
+                idx = idxsip(lm + ip)
+                idx_kp = idx + 1
+                idx_jp = idx + kk
+                idx_ip = idx + (kk*jj)
+
+                ! Performing the backward substitution
+                res(idx) = res(idx) - ut(idx)*res(idx_kp) - &
+                    un(idx)*res(idx_jp) - ue(idx)*res(idx_ip)
+
+                ! Original code:
+                ! res(k, j, i) = res(k, j, i) - un(k, j, i)*res(k, j+1, i) &
+                !     - ue(k, j, i)*res(k, j, i+1) - ut(k, j, i)*res(k+1, j, i)
+
+            END DO
+        END DO
+
+        DO i = 3, ii-2
+            DO j = 3, jj-2
+                DO k = 3, kk-2
+                    idx = (k-1)*jj*ii + (j-1)*ii + i
+                    phi(idx) = phi(idx) + res(idx)
+                END DO
+            END DO
+        END DO
+    END SUBROUTINE sipiter2_HPA
 
 
     PURE SUBROUTINE relax(kk, jj, ii, dp, rhs, gsaw, gsae, gsas, gsan, &

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -1,4 +1,10 @@
+
 MODULE pressuresolver_mod
+
+!$omp requires unified_address
+!$omp requires unified_shared_memory
+
+    use omp_lib
     USE bound_flow_mod
     USE core_mod
     USE flowcore_mod
@@ -42,13 +48,13 @@ MODULE pressuresolver_mod
 
     ! A-versions: simple versions not considering the BP field
     ! B-versions: IB versions using the BP field
-    INTERFACE sipiter1
-        MODULE PROCEDURE :: sipiter1_A, sipiter1_B, sipiter1_HPB
-    END INTERFACE sipiter1
+    ! INTERFACE sipiter1
+    !     MODULE PROCEDURE :: sipiter1_HPB
+    ! END INTERFACE sipiter1
 
-    INTERFACE sipiter2
-        MODULE PROCEDURE :: sipiter2_A, sipiter2_HPA
-    END INTERFACE sipiter2
+    ! INTERFACE sipiter2
+    !     MODULE PROCEDURE :: sipiter2_HPA
+    ! END INTERFACE sipiter2
 
     INTERFACE pressureftocone
         MODULE PROCEDURE :: pressureftocone_A, pressureftocone_B
@@ -529,7 +535,11 @@ CONTAINS
                     gsrap, bp)
             ELSE
                 ! Use the SIP solver
-                CALL sip(ilevel, iloop, dp, res, rhs, siplw, sipls, siplb, &
+                ! CALL sip(ilevel, iloop, dp, res, rhs, siplw, sipls, siplb, &
+                !     sipue, sipun, siput, siplpr, bp)
+
+                ! Use the SIP solver (on the GPU, wave-fornt idea)
+                CALL sipx(ilevel, iloop, dp, res, rhs, siplw, sipls, siplb, &
                     sipue, sipun, siput, siplpr, bp)
             END IF
 
@@ -542,9 +552,10 @@ CONTAINS
     END SUBROUTINE mgpoisit
 
 
-    SUBROUTINE sip(ilevel, iloop, dp, res, rhs, siplw, sipls, siplb, &
+    SUBROUTINE sipx(ilevel, iloop, dp, res, rhs, siplw, sipls, siplb, &
             sipue, sipun, siput, siplpr, bp)
 
+        USE omp_lib
         USE hyperplane_mod, ONLY: mip_sip_list, idx_sip_list
 
         ! Subroutine arguments
@@ -563,28 +574,33 @@ CONTAINS
         TYPE(field_t), INTENT(in), OPTIONAL :: bp
 
         ! Local variables
-        INTEGER(intk) :: i, il, igrid
+        INTEGER(intk) :: i, il, igrid, ip3
         INTEGER(intk) :: kk, jj, ii
         REAL(realk), POINTER, CONTIGUOUS :: dp_1d_p(:), res_1d_p(:), &
             rhs_1d_p(:)
 
         CALL laplacephi_level(ilevel, res, dp, bp)
 
+        !$omp target teams loop bind(teams) private(igrid, i, kk, jj, ii, ip3)
         DO il = 1, nmygridslvl(ilevel)
+
             igrid = mygridslvl(il, ilevel)
-            CALL get_imygrid(i, igrid)
-            CALL get_mgdims(kk, jj, ii, igrid)
+            i = igrid
+            kk = gridinfo(igrid)%kk
+            jj = gridinfo(igrid)%jj
+            ii = gridinfo(igrid)%ii
+            ip3 = ip3d(igrid)
 
-            ! Getting the arrays is 1D pointers
-            CALL res%get_ptr(res_1d_p, igrid)
-            CALL rhs%get_ptr(rhs_1d_p, igrid)
-
-            ! CALL sipiter1(kk, jj, ii, rhs_p, res_p, lw, ls, lb, lpr)
-            CALL sipiter1(kk, jj, ii, rhs_1d_p, res_1d_p, &
+            !$omp parallel
+            CALL sipiter1x(kk, jj, ii, &
+                rhs%arr(ip3:ip3+kk*jj*ii-1), res%arr(ip3:ip3+kk*jj*ii-1), &
                 lw_sip_list(i)%arr, ls_sip_list(i)%arr, &
                 lb_sip_list(i)%arr, lpr_sip_list(i)%arr, &
                 mip_sip_list(i)%arr, idx_sip_list(i)%arr)
+            !$omp end parallel
+
         END DO
+        !$omp end target teams loop
 
         IF (iloop < ninner) THEN
             CALL connect(ilevel, 1, s1=res)
@@ -592,21 +608,281 @@ CONTAINS
             CALL connect(ilevel, 1, s1=res, forward=-1)
         END IF
 
+        !$omp target teams loop bind(teams) private(igrid, i, kk, jj, ii, ip3)
         DO il = 1, nmygridslvl(ilevel)
+
             igrid = mygridslvl(il, ilevel)
-            CALL get_imygrid(i, igrid)
-            CALL get_mgdims(kk, jj, ii, igrid)
+            i = igrid
+            kk = gridinfo(igrid)%kk
+            jj = gridinfo(igrid)%jj
+            ii = gridinfo(igrid)%ii
+            ip3 = ip3d(igrid)
 
-            ! Getting the arrays is 1D pointers
-            CALL dp%get_ptr(dp_1d_p, igrid)
-            CALL res%get_ptr(res_1d_p, igrid)
-
-            ! CALL sipiter2(kk, jj, ii, dp_p, res_p, ue, un, ut)
-            CALL sipiter2(kk, jj, ii, dp_1d_p, res_1d_p, &
+            !$omp parallel
+            CALL sipiter2x(kk, jj, ii, &
+                dp%arr(ip3:ip3+kk*jj*ii-1), res%arr(ip3:ip3+kk*jj*ii-1), &
                 ue_sip_list(i)%arr, un_sip_list(i)%arr, ut_sip_list(i)%arr, &
                 mip_sip_list(i)%arr, idx_sip_list(i)%arr)
+            !$omp end parallel
+
         END DO
-    END SUBROUTINE sip
+        !$omp end target teams loop
+
+
+        DO il = 1, nmygridslvl(ilevel)
+
+            igrid = mygridslvl(il, ilevel)
+            kk = gridinfo(igrid)%kk
+            jj = gridinfo(igrid)%jj
+            ii = gridinfo(igrid)%ii
+            ip3 = kk*jj*ii*(i-1) + 1
+
+            CALL sipiter3x(kk, jj, ii, &
+                dp%arr(ip3:ip3+kk*jj*ii-1), res%arr(ip3:ip3+kk*jj*ii-1))
+
+        END DO
+
+    END SUBROUTINE sipx
+
+
+
+    SUBROUTINE sipiter1x(kk, jj, ii, rhs, res, lw, ls, lb, lpr, mip, &
+        idxsip)
+        !$omp declare target
+
+        USE omp_lib
+
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(inout) :: res(kk*jj*ii)
+        REAL(realk), INTENT(in) :: rhs(kk*jj*ii), lw(kk*jj*ii), ls(kk*jj*ii), &
+            lb(kk*jj*ii), lpr(kk*jj*ii)
+
+        ! For the hyperplane traversal
+        INTEGER(intk), INTENT(in) :: mip(ii+jj+kk)
+        INTEGER(intk), INTENT(in) :: idxsip(ii*jj*kk)
+
+        ! Local variables
+        INTEGER(intk) :: n3dmin, n3dmax, m, lm, lp, ip, iacc, &
+            idx, idx_km, idx_jm, idx_im
+
+        ! Subroutine body
+        n3dmin = 3 + 3 + 3
+        n3dmax = (ii-2) + (jj-2) + (kk-2)
+
+        DO m = n3dmin, n3dmax
+
+            ! Computing the number of points in the current hyperplane
+            lm = mip(m)
+            lp = mip(m+1) - lm
+            ! IF (omp_get_num_threads() < lp) THEN
+            !     WRITE(*, *) "Case not yet considered"
+            ! END IF
+
+            ! Each thread will be responsible for one point in the hyperplane
+            ip = omp_get_thread_num() + 1
+            IF (ip <= lp) THEN
+
+                ! Computing the contiguous access index
+                iacc = lm + ip
+
+                ! Computing the required indices
+                idx = idxsip(iacc)
+                idx_km = idx - 1
+                idx_jm = idx - kk
+                idx_im = idx - (kk*jj)
+
+                ! Accounting for RHS
+                res(idx) = (rhs(idx) + res(idx)) * lpr(iacc)
+
+                ! Performing the forward substitution
+                res(idx) = res(idx) - lb(iacc) * res(idx_km) - &
+                    ls(iacc) * res(idx_jm) - lw(iacc) * res(idx_im)
+
+            END IF
+            !$omp barrier
+
+        END DO
+
+    END SUBROUTINE sipiter1x
+
+
+    SUBROUTINE sipiter2x(kk, jj, ii, phi, res, ue, un, ut, mip, idxsip)
+        !$omp declare target
+
+        USE omp_lib, ONLY: omp_get_thread_num, omp_get_num_threads
+
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(inout) :: phi(kk*jj*ii), res(kk*jj*ii)
+        REAL(realk), INTENT(in) :: ue(kk*jj*ii), un(kk*jj*ii), ut(kk*jj*ii)
+
+        ! For the hyperplane traversal
+        INTEGER(intk), INTENT(in) :: mip(ii+jj+kk)
+        INTEGER(intk), INTENT(in) :: idxsip(ii*jj*kk)
+
+        ! Local variables
+        INTEGER(intk) :: n3dmin, n3dmax, m, lm, lp, ip, iacc, &
+            idx, idx_kp, idx_jp, idx_ip, i, j, k
+
+        ! Subroutine body
+        n3dmin = 3 + 3 + 3
+        n3dmax = (ii-2) + (jj-2) + (kk-2)
+
+        ! Iterating (REVERSE) over the hyperplanes H(k, j, i) = m
+        DO m = n3dmax, n3dmin, -1
+
+            ! Computing the number of points in the current hyperplane
+            lm = mip(m)
+            lp = mip(m+1) - lm
+            ! IF (omp_get_num_threads() < lp) THEN
+            !     WRITE(*, *) "Case not yet considered"
+            ! END IF
+
+            ! Each thread will be responsible for one point in the hyperplane
+            ip = omp_get_thread_num() + 1
+            IF (ip <= lp) THEN
+
+                ! Computing the contiguous access index
+                iacc = lm + ip
+
+                ! Computing the required indices
+                idx = idxsip(iacc)
+                idx_kp = idx + 1
+                idx_jp = idx + kk
+                idx_ip = idx + (kk*jj)
+
+                ! Performing the backward substitution
+                res(idx) = res(idx) - ut(iacc)*res(idx_kp) - &
+                    un(iacc)*res(idx_jp) - ue(iacc)*res(idx_ip)
+
+            END IF
+            !$omp barrier
+
+        END DO
+
+    END SUBROUTINE sipiter2x
+
+
+
+    SUBROUTINE sipiter3x(kk, jj, ii, phi, res)
+
+        USE omp_lib, ONLY: omp_get_thread_num, omp_get_num_threads
+
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(inout) :: phi(kk*jj*ii), res(kk*jj*ii)
+
+        INTEGER(intk) :: i, j, k, idx
+
+        DO i = 3, ii-2
+            DO j = 3, jj-2
+                DO k = 3, kk-2
+                    idx = k + (j-1)*kk + (i-1)*kk*jj
+                    phi(idx) = phi(idx) + res(idx)
+                END DO
+            END DO
+        END DO
+
+    END SUBROUTINE sipiter3x
+
+
+
+    ! SUBROUTINE sip_dummy1(kk, jj, ii, dp_1d_p, res_1d_p)
+    ! !$omp declare target
+    !     INTEGER(intk), INTENT(in) :: kk, jj, ii
+    !     REAL(realk), INTENT(inout) :: dp_1d_p(kk*jj*ii)
+    !     REAL(realk), INTENT(in) :: res_1d_p(kk*jj*ii)
+
+    !     INTEGER(intk) :: i
+
+    !     !$omp loop bind(parallel)
+    !     DO i = 1, kk*jj*ii
+    !         dp_1d_p(i) = res_1d_p(i)*2.0_realk
+    !     END DO
+    !     !$omp end loop
+
+    ! END SUBROUTINE sip_dummy1
+
+    ! SUBROUTINE sip_dummy2(kk, jj, ii, dp_1d_p, res_1d_p)
+    ! !$omp declare target
+    !     INTEGER(intk), INTENT(in) :: kk, jj, ii
+    !     REAL(realk), INTENT(inout) :: dp_1d_p(kk*jj*ii)
+    !     REAL(realk), INTENT(in) :: res_1d_p(kk*jj*ii)
+
+    !     INTEGER(intk) :: i, j
+
+    !     DO j = 1, 10
+
+    !         !$omp loop bind(parallel)
+    !         DO i = j, kk*jj*ii-j
+    !             dp_1d_p(i) = res_1d_p(i)*j
+    !         END DO
+    !         !$omp end loop
+
+    !     END DO
+
+    ! END SUBROUTINE sip_dummy2
+
+    ! SUBROUTINE sip_dummy3(kk, jj, ii, rhs, res, lw, ls, lb, lpr, mip, &
+    !     idxsip)
+    !     !$omp declare target
+
+    !     ! Subroutine arguments
+    !     INTEGER(intk), INTENT(in) :: kk, jj, ii
+    !     REAL(realk), INTENT(inout) :: res(kk*jj*ii)
+    !     REAL(realk), INTENT(in) :: rhs(kk*jj*ii), lw(kk*jj*ii), ls(kk*jj*ii), &
+    !         lb(kk*jj*ii), lpr(kk*jj*ii)
+
+    !     ! For the hyperplane traversal
+    !     INTEGER(intk), INTENT(in) :: mip(ii+jj+kk)
+    !     INTEGER(intk), INTENT(in) :: idxsip(ii*jj*kk)
+
+    !     ! Local variables
+    !     INTEGER(intk) :: n3dmin, n3dmax, m, lm, len, ip, iacc, &
+    !         idx, idx_km, idx_jm, idx_im
+
+    !     ! Subroutine body
+    !     n3dmin = 3 + 3 + 3
+    !     n3dmax = (ii-2) + (jj-2) + (kk-2)
+
+    !     ! Iterating over the hyperplanes H(k, j, i) = m
+
+
+    !     DO m = n3dmin, n3dmax
+
+    !         lm = mip(m)
+    !         len = mip(m+1) - lm
+
+    !         !$omp loop private(ip, iacc, idx, idx_km, idx_jm, idx_im)
+    !         DO ip = 1, len
+
+    !             ! Computing the contiguous access index
+    !             iacc = lm + ip
+
+    !             ! Computing the required indices
+    !             idx = idxsip(iacc)
+    !             idx_km = idx - 1
+    !             idx_jm = idx - kk
+    !             idx_im = idx - (kk*jj)
+
+    !             ! ! Accounting for RHS
+    !             res(idx) = 2.234345 !  = (rhs(idx) + res(idx)) * lpr(iacc)
+
+    !             ! Performing the forward substitution
+
+    !             ! Original code:
+    !             ! res(k, j, i) = res(k, j, i) - lw(k, j, i)*res(k, j, i-1) &
+    !             !     - ls(k, j, i)*res(k, j-1, i) - lb(k, j, i)*res(k-1, j, i)
+
+    !         END DO
+    !         !$omp end loop
+
+
+    !     END DO
+
+
+    ! END SUBROUTINE sip_dummy3
 
 
     SUBROUTINE sor(ilevel, dp, rhs, gsaw, gsae, gsas, gsan, gsab, gsat, &
@@ -773,222 +1049,110 @@ CONTAINS
     END SUBROUTINE laplacephi_grid
 
 
-    PURE SUBROUTINE sipiter0(kk, jj, ii, rhs, res, lpr)
-        ! Subroutine arguments
-        INTEGER(intk), INTENT(in) :: kk, jj, ii
-        REAL(realk), INTENT(in) :: rhs(kk, jj, ii)
-        REAL(realk), INTENT(inout) :: res(kk, jj, ii)
-        REAL(realk), INTENT(in) :: lpr(kk, jj, ii)
+    ! PURE SUBROUTINE sipiter0(kk, jj, ii, rhs, res, lpr)
+    !     ! Subroutine arguments
+    !     INTEGER(intk), INTENT(in) :: kk, jj, ii
+    !     REAL(realk), INTENT(in) :: rhs(kk, jj, ii)
+    !     REAL(realk), INTENT(inout) :: res(kk, jj, ii)
+    !     REAL(realk), INTENT(in) :: lpr(kk, jj, ii)
 
-        ! Local variables
-        INTEGER(intk) :: k, j, i
+    !     ! Local variables
+    !     INTEGER(intk) :: k, j, i
 
-        DO i = 3, ii-2
-            DO j = 3, jj-2
-                DO k = 3, kk-2
-                    res(k, j, i) = (rhs(k, j, i) + res(k, j, i))*lpr(k, j, i)
-                END DO
-            END DO
-        END DO
-    END SUBROUTINE sipiter0
-
-
-    PURE SUBROUTINE sipiter1_A(kk, jj, ii, rhs, res, lw, ls, lb)
-        ! Subroutine arguments
-        INTEGER(intk), INTENT(in) :: kk, jj, ii
-        REAL(realk), INTENT(inout) :: res(kk, jj, ii)
-        REAL(realk), INTENT(in) :: rhs(kk, jj, ii)
-        REAL(realk), INTENT(in) :: lw(kk, jj, ii), ls(kk, jj, ii), &
-            lb(kk, jj, ii)
-
-        ! Local variables
-        INTEGER(intk) :: k, j, i
-
-        DO i = 3, ii-2
-            DO j = 3, jj-2
-                DO k = 3, kk-2
-                    res(k, j, i) = res(k, j, i) - lw(k, j, i)*res(k, j, i-1) &
-                        - ls(k, j, i)*res(k, j-1, i)
-                END DO
-                DO k = 3, kk-2
-                    res(k, j, i) = res(k, j, i) - lb(k, j, i)*res(k-1, j, i)
-                END DO
-            END DO
-        END DO
-    END SUBROUTINE sipiter1_A
+    !     DO i = 3, ii-2
+    !         DO j = 3, jj-2
+    !             DO k = 3, kk-2
+    !                 res(k, j, i) = (rhs(k, j, i) + res(k, j, i))*lpr(k, j, i)
+    !             END DO
+    !         END DO
+    !     END DO
+    ! END SUBROUTINE sipiter0
 
 
-    PURE SUBROUTINE sipiter1_B(kk, jj, ii, rhs, res, lw, ls, lb, lpr)
-        ! Subroutine arguments
-        INTEGER(intk), INTENT(in) :: kk, jj, ii
-        REAL(realk), INTENT(inout) :: res(kk, jj, ii)
-        REAL(realk), INTENT(in) :: rhs(kk, jj, ii)
-        REAL(realk), INTENT(in) :: lw(kk, jj, ii), ls(kk, jj, ii), &
-            lb(kk, jj, ii), lpr(kk, jj, ii)
+    ! PURE SUBROUTINE sipiter1_A(kk, jj, ii, rhs, res, lw, ls, lb)
+    !     ! Subroutine arguments
+    !     INTEGER(intk), INTENT(in) :: kk, jj, ii
+    !     REAL(realk), INTENT(inout) :: res(kk, jj, ii)
+    !     REAL(realk), INTENT(in) :: rhs(kk, jj, ii)
+    !     REAL(realk), INTENT(in) :: lw(kk, jj, ii), ls(kk, jj, ii), &
+    !         lb(kk, jj, ii)
 
-        ! Local variables
-        INTEGER(intk) :: k, j, i
+    !     ! Local variables
+    !     INTEGER(intk) :: k, j, i
 
-        DO i = 3, ii-2
-            DO j = 3, jj-2
-                DO k = 3, kk-2
-                    res(k, j, i) = (rhs(k, j, i) + res(k, j, i))*lpr(k, j, i)
-                    res(k, j, i) = res(k, j, i) - lw(k, j, i)*res(k, j, i-1) &
-                        - ls(k, j, i)*res(k, j-1, i)
-                END DO
-                DO k = 3, kk-2
-                    res(k, j, i) = res(k, j, i) - lb(k, j, i)*res(k-1, j, i)
-                END DO
-            END DO
-        END DO
-    END SUBROUTINE sipiter1_B
+    !     DO i = 3, ii-2
+    !         DO j = 3, jj-2
+    !             DO k = 3, kk-2
+    !                 res(k, j, i) = res(k, j, i) - lw(k, j, i)*res(k, j, i-1) &
+    !                     - ls(k, j, i)*res(k, j-1, i)
+    !             END DO
+    !             DO k = 3, kk-2
+    !                 res(k, j, i) = res(k, j, i) - lb(k, j, i)*res(k-1, j, i)
+    !             END DO
+    !         END DO
+    !     END DO
+    ! END SUBROUTINE sipiter1_A
 
 
-    PURE SUBROUTINE sipiter1_HPB(kk, jj, ii, rhs, res, lw, ls, lb, lpr, mip, &
-        idxsip)
+    ! PURE SUBROUTINE sipiter1_B(kk, jj, ii, rhs, res, lw, ls, lb, lpr)
+    !     ! Subroutine arguments
+    !     INTEGER(intk), INTENT(in) :: kk, jj, ii
+    !     REAL(realk), INTENT(inout) :: res(kk, jj, ii)
+    !     REAL(realk), INTENT(in) :: rhs(kk, jj, ii)
+    !     REAL(realk), INTENT(in) :: lw(kk, jj, ii), ls(kk, jj, ii), &
+    !         lb(kk, jj, ii), lpr(kk, jj, ii)
 
-        ! Subroutine arguments
-        INTEGER(intk), INTENT(in) :: kk, jj, ii
-        REAL(realk), INTENT(inout) :: res(kk*jj*ii)
-        REAL(realk), INTENT(in) :: rhs(kk*jj*ii), lw(kk*jj*ii), ls(kk*jj*ii), &
-            lb(kk*jj*ii), lpr(kk*jj*ii)
+    !     ! Local variables
+    !     INTEGER(intk) :: k, j, i
 
-        ! For the hyperplane traversal
-        INTEGER(intk), INTENT(in) :: mip(ii+jj+kk)
-        INTEGER(intk), INTENT(in) :: idxsip(ii*jj*kk)
+    !     DO i = 3, ii-2
+    !         DO j = 3, jj-2
+    !             DO k = 3, kk-2
+    !                 res(k, j, i) = (rhs(k, j, i) + res(k, j, i))*lpr(k, j, i)
+    !                 res(k, j, i) = res(k, j, i) - lw(k, j, i)*res(k, j, i-1) &
+    !                     - ls(k, j, i)*res(k, j-1, i)
+    !             END DO
+    !             DO k = 3, kk-2
+    !                 res(k, j, i) = res(k, j, i) - lb(k, j, i)*res(k-1, j, i)
+    !             END DO
+    !         END DO
+    !     END DO
+    ! END SUBROUTINE sipiter1_B
 
-        ! Local variables
-        INTEGER(intk) :: n3dmin, n3dmax, m, lm, len, ip, iacc, &
-            idx, idx_km, idx_jm, idx_im
 
-        ! Subroutine body
-        n3dmin = 3 + 3 + 3
-        n3dmax = (ii-2) + (jj-2) + (kk-2)
+    ! PURE SUBROUTINE sipiter2_A(kk, jj, ii, phi, res, ue, un, ut)
+    !     ! Subroutine arguments
+    !     INTEGER(intk), INTENT(in) :: kk, jj, ii
+    !     REAL(realk), INTENT(inout) :: phi(kk, jj, ii), res(kk, jj, ii)
+    !     REAL(realk), INTENT(in) :: ue(kk, jj, ii), un(kk, jj, ii), &
+    !         ut(kk, jj, ii)
 
-        ! Iterating over the hyperplanes H(k, j, i) = m
-        DO m = n3dmin, n3dmax
+    !     ! Local variables
+    !     INTEGER(intk) :: k, j, i
 
-            lm = mip(m)
-            len = mip(m+1) - lm
+    !     DO i = ii-2, 3, -1
+    !         DO j = jj-2, 3, -1
+    !             DO k = 3, kk-2
+    !                 res(k, j, i) = res(k, j, i) - un(k, j, i)*res(k, j+1, i) &
+    !                     - ue(k, j, i)*res(k, j, i+1)
+    !             END DO
+    !             DO k = kk-2, 3, -1
+    !                 res(k, j, i) = res(k, j, i) - ut(k, j, i)*res(k+1, j, i)
+    !             END DO
+    !         END DO
+    !     END DO
 
-            ! > Parallel operations on the hyperplane (k, j, i) = m
-            DO ip = 1, len
-
-                ! Computing the contiguous access index
-                iacc = lm + ip
-
-                ! Computing the required indices
-                idx = idxsip(iacc)
-                idx_km = idx - 1
-                idx_jm = idx - kk
-                idx_im = idx - (kk*jj)
-
-                ! Accounting for RHS
-                res(idx) = (rhs(idx) + res(idx)) * lpr(iacc)
-
-                ! Performing the forward substitution
-                res(idx) = res(idx) - lb(iacc)*res(idx_km) - &
-                    ls(iacc)*res(idx_jm) - lw(iacc)*res(idx_im)
-
-                ! Original code:
-                ! res(k, j, i) = res(k, j, i) - lw(k, j, i)*res(k, j, i-1) &
-                !     - ls(k, j, i)*res(k, j-1, i) - lb(k, j, i)*res(k-1, j, i)
-
-            END DO
-        END DO
-
-    END SUBROUTINE sipiter1_HPB
+    !     DO i = 3, ii-2
+    !         DO j = 3, jj-2
+    !             DO k = 3, kk-2
+    !                 phi(k, j, i) = phi(k, j, i) + res(k, j, i)
+    !             END DO
+    !         END DO
+    !     END DO
+    ! END SUBROUTINE sipiter2_A
 
 
 
-    PURE SUBROUTINE sipiter2_A(kk, jj, ii, phi, res, ue, un, ut)
-        ! Subroutine arguments
-        INTEGER(intk), INTENT(in) :: kk, jj, ii
-        REAL(realk), INTENT(inout) :: phi(kk, jj, ii), res(kk, jj, ii)
-        REAL(realk), INTENT(in) :: ue(kk, jj, ii), un(kk, jj, ii), &
-            ut(kk, jj, ii)
-
-        ! Local variables
-        INTEGER(intk) :: k, j, i
-
-        DO i = ii-2, 3, -1
-            DO j = jj-2, 3, -1
-                DO k = 3, kk-2
-                    res(k, j, i) = res(k, j, i) - un(k, j, i)*res(k, j+1, i) &
-                        - ue(k, j, i)*res(k, j, i+1)
-                END DO
-                DO k = kk-2, 3, -1
-                    res(k, j, i) = res(k, j, i) - ut(k, j, i)*res(k+1, j, i)
-                END DO
-            END DO
-        END DO
-
-        DO i = 3, ii-2
-            DO j = 3, jj-2
-                DO k = 3, kk-2
-                    phi(k, j, i) = phi(k, j, i) + res(k, j, i)
-                END DO
-            END DO
-        END DO
-    END SUBROUTINE sipiter2_A
-
-
-    PURE SUBROUTINE sipiter2_HPA(kk, jj, ii, phi, res, ue, un, ut, mip, idxsip)
-        ! Subroutine arguments
-        INTEGER(intk), INTENT(in) :: kk, jj, ii
-        REAL(realk), INTENT(inout) :: phi(kk*jj*ii), res(kk*jj*ii)
-        REAL(realk), INTENT(in) :: ue(kk*jj*ii), un(kk*jj*ii), ut(kk*jj*ii)
-
-        ! For the hyperplane traversal
-        INTEGER(intk), INTENT(in) :: mip(ii+jj+kk)
-        INTEGER(intk), INTENT(in) :: idxsip(ii*jj*kk)
-
-        ! Local variables
-        INTEGER(intk) :: n3dmin, n3dmax, m, lm, len, ip, iacc, &
-            idx, idx_kp, idx_jp, idx_ip, i, j, k
-
-        ! Subroutine body
-        n3dmin = 3 + 3 + 3
-        n3dmax = (ii-2) + (jj-2) + (kk-2)
-
-        ! Iterating (REVERSE) over the hyperplanes H(k, j, i) = m
-        DO m = n3dmax, n3dmin, -1
-
-            lm = mip(m)
-            len = mip(m+1) - lm
-
-            ! > Parallel operations on the hyperplane (k, j, i) = m
-            DO ip = 1, len
-
-                ! Computing the contiguous access index
-                iacc = lm + ip
-
-                ! Computing the required indices
-                idx = idxsip(iacc)
-                idx_kp = idx + 1
-                idx_jp = idx + kk
-                idx_ip = idx + (kk*jj)
-
-                ! Performing the backward substitution
-                res(idx) = res(idx) - ut(iacc)*res(idx_kp) - &
-                    un(iacc)*res(idx_jp) - ue(iacc)*res(idx_ip)
-
-                ! Original code:
-                ! res(k, j, i) = res(k, j, i) - un(k, j, i)*res(k, j+1, i) &
-                !     - ue(k, j, i)*res(k, j, i+1) - ut(k, j, i)*res(k+1, j, i)
-
-            END DO
-        END DO
-
-        DO i = 3, ii-2
-            DO j = 3, jj-2
-                DO k = 3, kk-2
-                    idx = k + (j-1)*kk + (i-1)*kk*jj
-                    phi(idx) = phi(idx) + res(idx)
-                END DO
-            END DO
-        END DO
-    END SUBROUTINE sipiter2_HPA
 
 
     PURE SUBROUTINE relax(kk, jj, ii, dp, rhs, gsaw, gsae, gsas, gsan, &
@@ -1021,7 +1185,6 @@ CONTAINS
                             kstop = kk - 3
                         END IF
 
-                        !$omp simd private(aw, ae, as, an, ab, at, rap, res)
                         DO k = kstart, kstop, 2
                             ! Variations in numerical formulation, please
                             ! keep for future reference. Should be the same
@@ -1074,7 +1237,6 @@ CONTAINS
                             kstop = kk - 3
                         END IF
 
-                        !$omp simd private(res)
                         DO k = kstart, kstop, 2
                             res = (gsaw(i) * dp(k, j, i-1) &
                                   + gsae(i) * dp(k, j, i+1) &
@@ -1682,4 +1844,186 @@ CONTAINS
             END DO
         END IF
     END SUBROUTINE mgpcorr_grid
+
+
+    SUBROUTINE sip(ilevel, iloop, dp, res, rhs, siplw, sipls, siplb, &
+            sipue, sipun, siput, siplpr, bp)
+
+        USE hyperplane_mod, ONLY: mip_sip_list, idx_sip_list
+
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: ilevel
+        INTEGER(intk), INTENT(in) :: iloop
+        TYPE(field_t), INTENT(inout) :: dp
+        TYPE(field_t), INTENT(inout) :: res
+        TYPE(field_t), INTENT(in) :: rhs
+        TYPE(field_t), INTENT(in) :: siplw
+        TYPE(field_t), INTENT(in) :: sipls
+        TYPE(field_t), INTENT(in) :: siplb
+        TYPE(field_t), INTENT(in) :: sipue
+        TYPE(field_t), INTENT(in) :: sipun
+        TYPE(field_t), INTENT(in) :: siput
+        TYPE(field_t), INTENT(in) :: siplpr
+        TYPE(field_t), INTENT(in), OPTIONAL :: bp
+
+        ! Local variables
+        INTEGER(intk) :: i, il, igrid
+        INTEGER(intk) :: kk, jj, ii
+        REAL(realk), POINTER, CONTIGUOUS :: dp_1d_p(:), res_1d_p(:), &
+            rhs_1d_p(:)
+
+        CALL laplacephi_level(ilevel, res, dp, bp)
+
+        DO il = 1, nmygridslvl(ilevel)
+            igrid = mygridslvl(il, ilevel)
+            CALL get_imygrid(i, igrid)
+            CALL get_mgdims(kk, jj, ii, igrid)
+
+            ! Getting the arrays is 1D pointers
+            CALL res%get_ptr(res_1d_p, igrid)
+            CALL rhs%get_ptr(rhs_1d_p, igrid)
+
+            ! CALL sipiter1(kk, jj, ii, rhs_p, res_p, lw, ls, lb, lpr)
+            CALL sipiter1_HPB(kk, jj, ii, rhs_1d_p, res_1d_p, &
+                lw_sip_list(i)%arr, ls_sip_list(i)%arr, &
+                lb_sip_list(i)%arr, lpr_sip_list(i)%arr, &
+                mip_sip_list(i)%arr, idx_sip_list(i)%arr)
+        END DO
+
+        IF (iloop < ninner) THEN
+            CALL connect(ilevel, 1, s1=res)
+        ELSE
+            CALL connect(ilevel, 1, s1=res, forward=-1)
+        END IF
+
+        DO il = 1, nmygridslvl(ilevel)
+            igrid = mygridslvl(il, ilevel)
+            CALL get_imygrid(i, igrid)
+            CALL get_mgdims(kk, jj, ii, igrid)
+
+            ! Getting the arrays is 1D pointers
+            CALL dp%get_ptr(dp_1d_p, igrid)
+            CALL res%get_ptr(res_1d_p, igrid)
+
+            ! CALL sipiter2(kk, jj, ii, dp_p, res_p, ue, un, ut)
+            CALL sipiter2_HPA(kk, jj, ii, dp_1d_p, res_1d_p, &
+                ue_sip_list(i)%arr, un_sip_list(i)%arr, ut_sip_list(i)%arr, &
+                mip_sip_list(i)%arr, idx_sip_list(i)%arr)
+        END DO
+    END SUBROUTINE sip
+
+
+    PURE SUBROUTINE sipiter1_HPB(kk, jj, ii, rhs, res, lw, ls, lb, lpr, mip, &
+        idxsip)
+
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(inout) :: res(kk*jj*ii)
+        REAL(realk), INTENT(in) :: rhs(kk*jj*ii), lw(kk*jj*ii), ls(kk*jj*ii), &
+            lb(kk*jj*ii), lpr(kk*jj*ii)
+
+        ! For the hyperplane traversal
+        INTEGER(intk), INTENT(in) :: mip(ii+jj+kk)
+        INTEGER(intk), INTENT(in) :: idxsip(ii*jj*kk)
+
+        ! Local variables
+        INTEGER(intk) :: n3dmin, n3dmax, m, lm, len, ip, iacc, &
+            idx, idx_km, idx_jm, idx_im
+
+        ! Subroutine body
+        n3dmin = 3 + 3 + 3
+        n3dmax = (ii-2) + (jj-2) + (kk-2)
+
+        ! Iterating over the hyperplanes H(k, j, i) = m
+        DO m = n3dmin, n3dmax
+
+            lm = mip(m)
+            len = mip(m+1) - lm
+
+            ! > Parallel operations on the hyperplane (k, j, i) = m
+            DO ip = 1, len
+
+                ! Computing the contiguous access index
+                iacc = lm + ip
+
+                ! Computing the required indices
+                idx = idxsip(iacc)
+                idx_km = idx - 1
+                idx_jm = idx - kk
+                idx_im = idx - (kk*jj)
+
+                ! Accounting for RHS
+                res(idx) = (rhs(idx) + res(idx)) * lpr(iacc)
+
+                ! Performing the forward substitution
+                res(idx) = res(idx) - lb(iacc)*res(idx_km) - &
+                    ls(iacc)*res(idx_jm) - lw(iacc)*res(idx_im)
+
+                ! Original code:
+                ! res(k, j, i) = res(k, j, i) - lw(k, j, i)*res(k, j, i-1) &
+                !     - ls(k, j, i)*res(k, j-1, i) - lb(k, j, i)*res(k-1, j, i)
+
+            END DO
+        END DO
+
+    END SUBROUTINE sipiter1_HPB
+
+    PURE SUBROUTINE sipiter2_HPA(kk, jj, ii, phi, res, ue, un, ut, mip, idxsip)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(inout) :: phi(kk*jj*ii), res(kk*jj*ii)
+        REAL(realk), INTENT(in) :: ue(kk*jj*ii), un(kk*jj*ii), ut(kk*jj*ii)
+
+        ! For the hyperplane traversal
+        INTEGER(intk), INTENT(in) :: mip(ii+jj+kk)
+        INTEGER(intk), INTENT(in) :: idxsip(ii*jj*kk)
+
+        ! Local variables
+        INTEGER(intk) :: n3dmin, n3dmax, m, lm, len, ip, iacc, &
+            idx, idx_kp, idx_jp, idx_ip, i, j, k
+
+        ! Subroutine body
+        n3dmin = 3 + 3 + 3
+        n3dmax = (ii-2) + (jj-2) + (kk-2)
+
+        ! Iterating (REVERSE) over the hyperplanes H(k, j, i) = m
+        DO m = n3dmax, n3dmin, -1
+
+            lm = mip(m)
+            len = mip(m+1) - lm
+
+            ! > Parallel operations on the hyperplane (k, j, i) = m
+            DO ip = 1, len
+
+                ! Computing the contiguous access index
+                iacc = lm + ip
+
+                ! Computing the required indices
+                idx = idxsip(iacc)
+                idx_kp = idx + 1
+                idx_jp = idx + kk
+                idx_ip = idx + (kk*jj)
+
+                ! Performing the backward substitution
+                res(idx) = res(idx) - ut(iacc)*res(idx_kp) - &
+                    un(iacc)*res(idx_jp) - ue(iacc)*res(idx_ip)
+
+                ! Original code:
+                ! res(k, j, i) = res(k, j, i) - un(k, j, i)*res(k, j+1, i) &
+                !     - ue(k, j, i)*res(k, j, i+1) - ut(k, j, i)*res(k+1, j, i)
+
+            END DO
+        END DO
+
+        DO i = 3, ii-2
+            DO j = 3, jj-2
+                DO k = 3, kk-2
+                    idx = k + (j-1)*kk + (i-1)*kk*jj
+                    phi(idx) = phi(idx) + res(idx)
+                END DO
+            END DO
+        END DO
+    END SUBROUTINE sipiter2_HPA
+
+
 END MODULE pressuresolver_mod

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -565,9 +565,8 @@ CONTAINS
         ! Local variables
         INTEGER(intk) :: i, il, igrid
         INTEGER(intk) :: kk, jj, ii
-        REAL(realk), POINTER, CONTIGUOUS :: lw(:), ls(:), &
-            lb(:), ue(:), un(:), ut(:), lpr(:)
-        REAL(realk), POINTER, CONTIGUOUS :: dp_p(:), res_p(:), rhs_p(:)
+        REAL(realk), POINTER, CONTIGUOUS :: dp_1d_p(:), res_1d_p(:), &
+            rhs_1d_p(:)
 
         CALL laplacephi_level(ilevel, res, dp, bp)
 
@@ -576,16 +575,12 @@ CONTAINS
             CALL get_imygrid(i, igrid)
             CALL get_mgdims(kk, jj, ii, igrid)
 
-            CALL res%get_ptr(res_p, igrid)
-            CALL rhs%get_ptr(rhs_p, igrid)
-
-            CALL siplw%get_ptr(lw, igrid)
-            CALL sipls%get_ptr(ls, igrid)
-            CALL siplb%get_ptr(lb, igrid)
-            CALL siplpr%get_ptr(lpr, igrid)
+            ! Getting the arrays is 1D pointers
+            CALL res%get_ptr(res_1d_p, igrid)
+            CALL rhs%get_ptr(rhs_1d_p, igrid)
 
             ! CALL sipiter1(kk, jj, ii, rhs_p, res_p, lw, ls, lb, lpr)
-            CALL sipiter1(kk, jj, ii, rhs_p, res_p, &
+            CALL sipiter1(kk, jj, ii, rhs_1d_p, res_1d_p, &
                 lw_sip_list(i)%arr, ls_sip_list(i)%arr, &
                 lb_sip_list(i)%arr, lpr_sip_list(i)%arr, &
                 mip_sip_list(i)%arr, idx_sip_list(i)%arr)
@@ -602,15 +597,12 @@ CONTAINS
             CALL get_imygrid(i, igrid)
             CALL get_mgdims(kk, jj, ii, igrid)
 
-            CALL dp%get_ptr(dp_p, igrid)
-            CALL res%get_ptr(res_p, igrid)
-
-            CALL sipue%get_ptr(ue, igrid)
-            CALL sipun%get_ptr(un, igrid)
-            CALL siput%get_ptr(ut, igrid)
+            ! Getting the arrays is 1D pointers
+            CALL dp%get_ptr(dp_1d_p, igrid)
+            CALL res%get_ptr(res_1d_p, igrid)
 
             ! CALL sipiter2(kk, jj, ii, dp_p, res_p, ue, un, ut)
-            CALL sipiter2(kk, jj, ii, dp_p, res_p, &
+            CALL sipiter2(kk, jj, ii, dp_1d_p, res_1d_p, &
                 ue_sip_list(i)%arr, un_sip_list(i)%arr, ut_sip_list(i)%arr, &
                 mip_sip_list(i)%arr, idx_sip_list(i)%arr)
         END DO
@@ -991,7 +983,7 @@ CONTAINS
         DO i = 3, ii-2
             DO j = 3, jj-2
                 DO k = 3, kk-2
-                    idx = (k-1)*jj*ii + (j-1)*ii + i
+                    idx = k + (j-1)*kk + (i-1)*kk*jj
                     phi(idx) = phi(idx) + res(idx)
                 END DO
             END DO

--- a/src/flow/sip_inlined.F90
+++ b/src/flow/sip_inlined.F90
@@ -1,0 +1,165 @@
+    SUBROUTINE sip(ilevel, iloop, dp, res, rhs, siplw, sipls, siplb, &
+            sipue, sipun, siput, siplpr, bp)
+
+        USE hyperplane_mod, ONLY: mip_sip_list, idx_sip_list
+
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: ilevel
+        INTEGER(intk), INTENT(in) :: iloop
+        TYPE(field_t), INTENT(inout) :: dp
+        TYPE(field_t), INTENT(inout) :: res
+        TYPE(field_t), INTENT(in) :: rhs
+        TYPE(field_t), INTENT(in) :: siplw
+        TYPE(field_t), INTENT(in) :: sipls
+        TYPE(field_t), INTENT(in) :: siplb
+        TYPE(field_t), INTENT(in) :: sipue
+        TYPE(field_t), INTENT(in) :: sipun
+        TYPE(field_t), INTENT(in) :: siput
+        TYPE(field_t), INTENT(in) :: siplpr
+        TYPE(field_t), INTENT(in), OPTIONAL :: bp
+
+        ! Local variables
+        INTEGER(intk) :: i, il, igrid, ip3
+        INTEGER(intk) :: kk, jj, ii, n3dmin, n3dmax, m, lm, lp, ip, iacc, &
+            idx, idx_km, idx_jm, idx_im, idx_kp, idx_jp, idx_ip, i2, j2, k2
+        REAL(realk), POINTER, CONTIGUOUS :: dp_1d_p(:), res_1d_p(:), &
+            rhs_1d_p(:)
+
+        CALL laplacephi_level(ilevel, res, dp, bp)
+
+        ! private(igrid, i, kk, jj, ii, ip3, n3dmin, n3dmax)
+        ! private(iacc, idx, idx_km, idx_jm, idx_im)
+
+
+        WRITE(*, *) "A"
+
+        !$omp target teams loop bind(teams) private(igrid, i, kk, jj, ii, ip3, n3dmin, n3dmax) map(to: dp%arr, res%arr) map(to: rhs%arr, mip_sip_list, idx_sip_list)
+        DO il = 1, nmygridslvl(ilevel)
+
+            igrid = mygridslvl(il, ilevel)
+            kk = gridinfo(igrid)%kk
+            jj = gridinfo(igrid)%jj
+            ii = gridinfo(igrid)%ii
+            i = igrid
+            ip3 = kk*jj*ii*(i-1)
+
+            n3dmin = 3 + 3 + 3
+            n3dmax = (ii-2) + (jj-2) + (kk-2)
+
+            WRITE(*, *) igrid, ii, jj, kk, ip3, n3dmin, n3dmax
+
+            !$omp parallel private(lm, lp, ip, iacc, idx, idx_km, idx_jm, idx_im) num_threads(1000)
+
+            DO m = n3dmin, n3dmax
+
+                lm = mip_sip_list(i)%arr(m)
+                lp = mip_sip_list(i)%arr(m+1) - lm
+
+                WRITE(*, *) "A"
+
+                ip = omp_get_thread_num() + 1
+
+                IF (ip <= lp) THEN
+
+                    ! Computing the contiguous access index
+                    iacc = lm + ip
+
+                    ! Computing the required indices
+                    idx = idx_sip_list(i)%arr(iacc) + ip3
+                    idx_km = idx - 1
+                    idx_jm = idx - kk
+                    idx_im = idx - (kk*jj)
+
+                    ! Accounting for RHS
+                    res%arr(idx) = (rhs%arr(idx) + &
+                        res%arr(idx)) * lpr_sip_list(i)%arr(iacc)
+
+                    ! Performing the forward substitution
+                    res%arr(idx) = res%arr(idx) - &
+                        lb_sip_list(i)%arr(iacc) * res%arr(idx_km) - &
+                        ls_sip_list(i)%arr(iacc) * res%arr(idx_jm) - &
+                        lw_sip_list(i)%arr(iacc) * res%arr(idx_im)
+
+                END IF
+
+                !$omp barrier
+
+            END DO
+
+            !$omp end parallel
+
+        END DO
+        !$omp end target teams loop
+
+
+        WRITE(*, '("Finished forward substitution")')
+        IF (iloop < ninner) THEN
+            CALL connect(ilevel, 1, s1=res)
+        ELSE
+            CALL connect(ilevel, 1, s1=res, forward=-1)
+        END IF
+
+
+        !$omp target teams loop bind(teams) private(igrid, i, kk, jj, ii, ip3, n3dmin, n3dmax)
+        DO il = 1, nmygridslvl(ilevel)
+
+            igrid = mygridslvl(il, ilevel)
+            kk = gridinfo(igrid)%kk
+            jj = gridinfo(igrid)%jj
+            ii = gridinfo(igrid)%ii
+            i = igrid
+            ip3 = kk*jj*ii*(i-1)   ! hack
+
+            n3dmin = 3 + 3 + 3
+            n3dmax = (ii-2) + (jj-2) + (kk-2)
+
+            !$omp parallel private(lm, lp, ip, iacc, idx, idx_km, idx_jm, idx_im) num_threads(900)
+
+            DO m = n3dmax, n3dmin, -1
+
+                lm = mip_sip_list(i)%arr(m)
+                lp = mip_sip_list(i)%arr(m+1) - lm
+
+                ip = omp_get_thread_num() + 1
+
+                IF (ip <= lp) THEN
+
+                    ! Computing the contiguous access index
+                    iacc = lm + ip
+
+                    ! Computing the required indices
+                    idx = idx_sip_list(i)%arr(iacc) + ip3
+                    idx_kp = idx + 1
+                    idx_jp = idx + kk
+                    idx_ip = idx + (kk*jj)
+
+                    ! Performing the backward substitution
+                    res%arr(idx) = res%arr(idx) - &
+                        ut_sip_list(i)%arr(iacc) * res%arr(idx_kp) - &
+                        un_sip_list(i)%arr(iacc) * res%arr(idx_jp) - &
+                        ue_sip_list(i)%arr(iacc) * res%arr(idx_ip)
+
+                END IF
+
+                !$omp barrier
+
+            END DO
+
+            !$omp end parallel
+
+            !$omp parallel do private(idx) collapse(3)
+            DO i2 = 3, ii-2
+                DO j2 = 3, jj-2
+                    DO k2 = 3, kk-2
+                        idx = k2 + (j2-1)*kk + (i2-1)*kk*jj + ip3
+                        dp%arr(idx) = dp%arr(idx) + res%arr(idx)
+                    END DO
+                END DO
+            END DO
+            !$omp end parallel do
+
+
+        END DO
+        !$omp end target teams loop
+
+    END SUBROUTINE sip

--- a/src/flow/tstle4_mod.F90
+++ b/src/flow/tstle4_mod.F90
@@ -1868,7 +1868,6 @@ CONTAINS
 
 
     PURE ELEMENTAL REAL(realk) FUNCTION swcle3d_one(ddz, u) RESULT(uo)
-        !$omp declare simd(swcle3d_one)
 
         ! Function arguments
         REAL(realk), INTENT(in) :: ddz  ! wall normal

--- a/src/flow/wernerwengle_mod.F90
+++ b/src/flow/wernerwengle_mod.F90
@@ -35,8 +35,6 @@ CONTAINS
 
 
     PURE ELEMENTAL REAL(realk) FUNCTION gradp2(uquer, dds)
-        !$omp declare simd(gradp2)
-
         ! Computes the gradient dds/2 away from the wall using the WW wall
         ! model
 
@@ -60,7 +58,6 @@ CONTAINS
 
 
     PURE ELEMENTAL REAL(realk) FUNCTION tauwin(uquer, dds)
-        !$omp declare simd(tauwin)
 
         ! Function arguments
         REAL(realk), INTENT(IN) :: uquer, dds
@@ -87,7 +84,6 @@ CONTAINS
     ! usage!
     PURE ELEMENTAL REAL(realk) FUNCTION qwallfix(tbound, tfluid, uquer, dds, &
             prmol)
-        !$omp declare simd(qwallfix)
 
         ! Function arguments
         REAL(realk), INTENT(IN) :: tbound, tfluid, uquer, dds, prmol

--- a/src/scalar/gc_scastencils_mod.F90
+++ b/src/scalar/gc_scastencils_mod.F90
@@ -31,6 +31,19 @@ CONTAINS
         ALLOCATE(scaxpolrvel(nmygrids))
         ALLOCATE(scanblg(nmygrids))
 
+        ! Stencil structure (standard-sized stencil):
+        ! I1 = cell to be treated
+        ! I2 = body id of cell to be treated
+        ! I3 = number of peripheral stencil points (N)
+        ! I4 = 1D-index of peripheral stencil point 1 (or -1 if N<1)
+        ! I5 = 1D-index of peripheral stencil point 2 (or -1 if N<2)
+        ! I6 = 1D-index of peripheral stencil point 3 (or -1 if N<3)
+        ! R1 = surface area divided by cell volume
+        ! R2 = coefficient for peripheral stencil point 1 (or dummy if N<1)
+        ! R3 = coefficient for peripheral stencil point 2 (or dummy if N<2)
+        ! R4 = coefficient for peripheral stencil point 3 (or dummy if N<3)
+        ! R5 = additive constant (e.g. for Dirichlet conditions)
+
         DO ilevel = minlevel, maxlevel
             CALL createstencils_level(ilevel, bp, gc%bzelltyp, gc%icells, &
                 gc%icellspointer, gc%nvecs, gc%arealist, gc%bodyid)
@@ -134,6 +147,7 @@ CONTAINS
         REAL(realk) :: area, areabyvol
         INTEGER(intk), ALLOCATABLE :: xpoli(:)
         REAL(realk), ALLOCATABLE :: xpolr(:), xpolrvel(:)
+        INTEGER(intk) :: initial_pntxpoli, initial_pntxpolr
 
         ! Allocating the arrays with possible overhead
         xpolisize = NINT(icells*1.1 + MAX(kk, jj, ii)**2)*(2+velpts)
@@ -155,7 +169,11 @@ CONTAINS
         DO i = 3, ii-2
             DO j = 3, jj-2
                 DO k = 3, kk-2
+                    ! Storing the initial values of the index counters
+                    initial_pntxpoli = pntxpoli
+                    initial_pntxpolr = pntxpolr
 
+                    ! Starting the stencil generation
                     CALL findinterface2(k, j, i, kk, jj, ii, bp, found, &
                         foundx1, foundx2, foundy1, foundy2, foundz1, &
                         foundz2, foundnr)
@@ -281,6 +299,24 @@ CONTAINS
                         END IF
                     END IF
 
+                    ! Cycle if no new stencil was created at all
+                    IF (pntxpoli - initial_pntxpoli == 0 .AND. &
+                        pntxpolr - initial_pntxpolr == 0) THEN
+                            CYCLE
+                    END IF
+
+                    ! Ensuring that standard-sized stencils were created
+                    IF (pntxpoli - initial_pntxpoli /= 6) THEN
+                        WRITE(*, *) "Error: No standard-sized stencil ", &
+                            pntxpoli, " initial: ", initial_pntxpoli
+                        CALL errr(__FILE__, __LINE__)
+                    END IF
+                    IF (pntxpolr - initial_pntxpolr /= 5) THEN
+                        WRITE(*, *) "Error: No standard-sized stencil ", &
+                            pntxpolr, " initial: ", initial_pntxpolr
+                        CALL errr(__FILE__, __LINE__)
+                    END IF
+
                 END DO
             END DO
         END DO
@@ -294,6 +330,16 @@ CONTAINS
         scaxpolr(imygrid)%arr = xpolr(1:pntxpolr)
         scaxpolrvel(imygrid)%arr = xpolrvel(1:pntxpolr)
         scanblg(imygrid) = counter
+
+        ! Final size check
+        IF (pntxpoli / counter /= 6) THEN
+            WRITE(*, *) "Error: pntxpoli / counter = ", pntxpoli, counter
+            CALL errr(__FILE__, __LINE__)
+        END IF
+        IF (pntxpolr / counter /= 5) THEN
+            WRITE(*, *) "Error: pntxpolr / counter = ", pntxpolr, counter
+            CALL errr(__FILE__, __LINE__)
+        END IF
 
         DEALLOCATE(xpoli)
         DEALLOCATE(xpolr)
@@ -322,7 +368,7 @@ CONTAINS
         ! Local variables
         INTEGER(intk), PARAMETER :: velpts = 1
         INTEGER(intk) :: xpolisize, xpolrsize
-        INTEGER(intk) :: cellind
+        INTEGER(intk) :: cellind, n
 
         xpolisize = SIZE(xpoli)
         xpolrsize = SIZE(xpolr)
@@ -355,18 +401,33 @@ CONTAINS
         xpolr(pntxpolr) = areabyvol
         xpolrvel(pntxpolr) = areabyvol
 
-        ! -- replaces iteration over velpoints --
-        pntxpoli = pntxpoli + 1
-        xpoli(pntxpoli) = cellind
-
-        pntxpolr = pntxpolr + 1
-        xpolr(pntxpolr) = 1.0
-        xpolrvel(pntxpolr) = 1.0
+        ! here with iteration over all N peripheral stencil points
+        ! (velpts here carries the value of "chosenvelpts")
+        DO n = 1, 3
+            ! Keep incrementing the index counter anyway
+            pntxpoli = pntxpoli + 1
+            pntxpolr = pntxpolr + 1
+            IF (n <= velpts) THEN
+                IF (n /= 1) CALL errr(__FILE__, __LINE__)
+                xpoli(pntxpoli) = cellind
+                xpolr(pntxpolr) = 1.0
+                xpolrvel(pntxpolr) = 1.0
+            ELSE
+                ! Setting unused dummy values (yields standard-sized stencils)
+                xpoli(pntxpoli) = -1
+                xpolr(pntxpolr) = -HUGE(0.0_realk)
+                xpolrvel(pntxpolr) = -HUGE(0.0_realk)
+            END IF
+        END DO
 
         ! 3rd real: setting the additive constant
         pntxpolr = pntxpolr + 1
         xpolr(pntxpolr) = 0.0
         xpolrvel(pntxpolr) =  0.0
+
+        ! >>> Integer counter = + 6
+        ! >>> Real counter = + 5
+
     END SUBROUTINE tscastencilcoeffarea
 
 
@@ -738,6 +799,90 @@ CONTAINS
             CALL errr(__FILE__, __LINE__)
         END IF
 
+        ! 1st integer: linearized index of cell to be treated
+        ! TODO: sub2ind
+        pntxpoli = pntxpoli + 1
+        xpoli(pntxpoli) = 1+(k-1)+(j-1)*kk+(i-1)*jj*kk
+
+        ! 2nd integer: body id of this stencils
+        pntxpoli = pntxpoli + 1
+        xpoli(pntxpoli) = body
+
+        ! 3rd integer: number of the peripheral stencil points (N)
+        pntxpoli = pntxpoli + 1
+        xpoli(pntxpoli) = velpts
+
+        ! 1st real: setting area/volume of the interface within the cell
+        ! (additional in comparison to the velocity stencil)
+        pntxpolr = pntxpolr + 1
+        xpolr(pntxpolr) = areabyvol
+        xpolrvel(pntxpolr) = areabyvol
+
+        ! Check that the number of peripheral stencil points <= 3
+        IF (velpts > 3) THEN
+            WRITE(*, *) "Number of peripheral stencil points > 3: ", velpts
+        END IF
+
+        ! here with iteration over all N peripheral stencil points
+        ! (velpts here carries the value of "chosenvelpts")
+        DO n = 1, 3
+            ! Keep incrementing the index counter anyway
+            pntxpoli = pntxpoli + 1
+            pntxpolr = pntxpolr + 1
+            IF (n <= velpts) THEN
+                ! Setting the used values
+                xpoli(pntxpoli) = 1+(kstc(n)-1)+(jstc(n)-1)*kk+(istc(n)-1)*jj*kk
+                xpolr(pntxpolr) = coeffstc(n)
+                xpolrvel(pntxpolr) = coeffstcvel(n)
+            ELSE
+                ! Setting unused dummy values (yields standrd-sized stencils)
+                xpoli(pntxpoli) = -1
+                xpolr(pntxpolr) = -HUGE(0.0_realk)
+                xpolrvel(pntxpolr) = -HUGE(0.0_realk)
+            END IF
+        END DO
+
+        ! last real: setting the additive constant
+        pntxpolr = pntxpolr + 1
+        xpolr(pntxpolr) = acoeffstc
+        xpolrvel(pntxpolr) = acoeffstcvel
+
+        ! >>> Integer counter = + 6
+        ! >>> Real counter = + 5
+
+    END SUBROUTINE tscastencilcoefffull
+
+
+    SUBROUTINE tscastencilcoeffrescue(k, j, i, kk, jj, ii, pntxpoli, xpoli, &
+            pntxpolr, xpolr, xpolrvel, areabyvol, body)
+
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: k, j, i, kk, jj, ii
+        INTEGER(intk), INTENT(inout) :: xpoli(:)
+        REAL(realk), INTENT(inout) :: xpolr(:)
+        REAL(realk), INTENT(inout) :: xpolrvel(:)
+        INTEGER(intk), INTENT(inout) :: pntxpoli, pntxpolr
+        REAL(realk), intent(in) :: areabyvol
+        INTEGER(intk), INTENT(in) :: body
+
+        ! Local variables
+        INTEGER(intk), PARAMETER :: velpts = 0
+        INTEGER(intk) :: xpolisize, xpolrsize, n
+
+        xpolisize = SIZE(xpoli)
+        xpolrsize = SIZE(xpolr)
+
+        IF (pntxpoli+velpts+2 > xpolisize) THEN
+            CALL errr(__FILE__, __LINE__)
+        END IF
+        IF (pntxpolr+velpts+1 > xpolrsize) THEN
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        ! increasing the index counter only by one
+        ! (no iteration over points as in function above)
+
+        ! 1st integer: linearized index of cell to be treated
         ! TODO: sub2ind
         pntxpoli = pntxpoli + 1
         xpoli(pntxpoli) = 1+(k-1)+(j-1)*kk+(i-1)*jj*kk
@@ -758,75 +903,30 @@ CONTAINS
 
         ! here with iteration over all N peripheral stencil points
         ! (velpts here carries the value of "chosenvelpts")
-        DO n = 1, velpts
+        DO n = 1, 3
+            ! Keep incrementing the index counter anyway
             pntxpoli = pntxpoli + 1
-            xpoli(pntxpoli) = 1+(kstc(n)-1)+(jstc(n)-1)*kk+(istc(n)-1)*jj*kk
-
             pntxpolr = pntxpolr + 1
-            xpolr(pntxpolr) = coeffstc(n)
-            xpolrvel(pntxpolr) = coeffstcvel(n)
+            IF (n <= velpts) THEN
+                ! Setting the used values
+                WRITE(*, *) "This case never applies as VELPTS = 0"
+                CALL errr(__FILE__, __LINE__)
+            ELSE
+                ! Setting unused dummy values (yields standard-sized stencils)
+                xpoli(pntxpoli) = -1
+                xpolr(pntxpolr) = -HUGE(0.0_realk)
+                xpolrvel(pntxpolr) = -HUGE(0.0_realk)
+            END IF
         END DO
-
-        ! last real: setting the additive constant
-        pntxpolr = pntxpolr + 1
-        xpolr(pntxpolr) = acoeffstc
-        xpolrvel(pntxpolr) = acoeffstcvel
-    END SUBROUTINE tscastencilcoefffull
-
-
-    SUBROUTINE tscastencilcoeffrescue(k, j, i, kk, jj, ii, pntxpoli, xpoli, &
-            pntxpolr, xpolr, xpolrvel, areabyvol, body)
-
-        ! Subroutine arguments
-        INTEGER(intk), INTENT(in) :: k, j, i, kk, jj, ii
-        INTEGER(intk), INTENT(inout) :: xpoli(:)
-        REAL(realk), INTENT(inout) :: xpolr(:)
-        REAL(realk), INTENT(inout) :: xpolrvel(:)
-        INTEGER(intk), INTENT(inout) :: pntxpoli, pntxpolr
-        REAL(realk), intent(in) :: areabyvol
-        INTEGER(intk), INTENT(in) :: body
-
-        ! Local variables
-        INTEGER(intk), PARAMETER :: velpts = 0
-        INTEGER(intk) :: xpolisize, xpolrsize
-
-        xpolisize = SIZE(xpoli)
-        xpolrsize = SIZE(xpolr)
-
-        IF (pntxpoli+velpts+2 > xpolisize) THEN
-            CALL errr(__FILE__, __LINE__)
-        END IF
-        IF (pntxpolr+velpts+1 > xpolrsize) THEN
-            CALL errr(__FILE__, __LINE__)
-        END IF
-
-        ! increasing the index counter only by one
-        ! (no iteration over points as in function above)
-
-        ! TODO: sub2ind
-        pntxpoli = pntxpoli + 1
-        xpoli(pntxpoli) = 1+(k-1)+(j-1)*kk+(i-1)*jj*kk
-
-        ! 2nd integer: body id of this stencils
-        pntxpoli = pntxpoli + 1
-        xpoli(pntxpoli) = body
-
-        ! 3rd integer: number of the peripheral stencil points (N)
-        pntxpoli = pntxpoli + 1
-        xpoli(pntxpoli) = velpts
-
-        ! 1st real: setting area/volume of the interface within the cell
-        ! (additional in comparison to the velocity stencil)
-        pntxpolr = pntxpolr + 1
-        xpolr(pntxpolr) = areabyvol
-        xpolrvel(pntxpolr) = areabyvol
-
-        ! -- no iteration over velpoints --
 
         ! 3rd real: setting the additive constant (here: equal to the final cell value)
         pntxpolr = pntxpolr + 1
         xpolr(pntxpolr) = 1.0
         xpolrvel(pntxpolr) =  1.0
+
+        ! >>> Integer counter = + 6
+        ! >>> Real counter = + 5
+
     END SUBROUTINE tscastencilcoeffrescue
 
 
@@ -840,7 +940,6 @@ CONTAINS
         INTEGER(intk) :: i, igrid
         INTEGER(intk) :: kk, jj, ii
         REAL(realk), POINTER, CONTIGUOUS :: t_p(:, :, :), qtt_p(:, :, :)
-        REAL(realk), POINTER, CONTIGUOUS :: xpolr(:)
 
         CALL start_timer(412)
 
@@ -849,23 +948,38 @@ CONTAINS
 
         DO i = 1, nmygrids
             igrid = mygrids(i)
-
             CALL get_mgdims(kk, jj, ii, igrid)
 
-            IF (PRESENT(t)) CALL t%get_ptr(t_p, igrid)
-            IF (PRESENT(qtt)) CALL qtt%get_ptr(qtt_p, igrid)
+            ! Repeated lines of code, while more elegant solutions
+            ! are possible. Accepted as easier for the compiler...
+            IF (PRESENT(t)) THEN
+                CALL t%get_ptr(t_p, igrid)
+                SELECT CASE(ctyp)
+                CASE("C")
+                    CALL wmxpolsoltsca(kk, jj, ii, scanblg(i), sca, &
+                        scaxpoli(i)%arr, scaxpolr(i)%arr, t=t_p)
+                CASE("P")
+                    CALL wmxpolsoltsca(kk, jj, ii, scanblg(i), sca, &
+                        scaxpoli(i)%arr, scaxpolrvel(i)%arr, t=t_p)
+                CASE DEFAULT
+                    CALL errr(__FILE__, __LINE__)
+                END SELECT
+            END IF
 
-            SELECT CASE(ctyp)
-            CASE("C")
-                xpolr => scaxpolr(i)%arr
-            CASE("P")
-                xpolr => scaxpolrvel(i)%arr
-            CASE DEFAULT
-                CALL errr(__FILE__, __LINE__)
-            END SELECT
+            IF (PRESENT(qtt)) THEN
+                CALL qtt%get_ptr(qtt_p, igrid)
+                SELECT CASE(ctyp)
+                CASE("C")
+                    CALL wmxpolsoltsca(kk, jj, ii, scanblg(i), sca, &
+                        scaxpoli(i)%arr, scaxpolr(i)%arr, qtt=qtt_p)
+                CASE("P")
+                    CALL wmxpolsoltsca(kk, jj, ii, scanblg(i), sca, &
+                        scaxpoli(i)%arr, scaxpolrvel(i)%arr, qtt=qtt_p)
+                CASE DEFAULT
+                    CALL errr(__FILE__, __LINE__)
+                END SELECT
+            END IF
 
-            CALL wmxpolsoltsca(kk, jj, ii, scanblg(i), sca, scaxpoli(i)%arr, &
-                xpolr, t_p, qtt_p)
         END DO
 
         CALL stop_timer(412)
@@ -881,36 +995,36 @@ CONTAINS
         REAL(realk), INTENT(inout), OPTIONAL :: t(kk*jj*ii), qtt(kk*jj*ii)
 
         ! Local variables
-        INTEGER(intk) :: cellcount, pntxpoli, pntxpolr
+        INTEGER(intk) :: cellcount, start_pntxpoli, start_pntxpolr
 
         IF (PRESENT(t)) THEN
-            pntxpoli = 1
-            pntxpolr = 1
             DO cellcount = 1, ncells
-                CALL wmxpoltsca_t(kk, jj, ii, sca, pntxpoli, pntxpolr, &
-                    xpoli, xpolr, t)
+                start_pntxpoli = (cellcount-1)*6   ! 6 integers per cell
+                start_pntxpolr = (cellcount-1)*5   ! 5 reals per cell
+                CALL wmxpoltsca_t(kk, jj, ii, sca, start_pntxpoli, &
+                    start_pntxpolr, xpoli, xpolr, t)
             END DO
         END IF
 
         IF (PRESENT(qtt)) THEN
-            pntxpoli = 1
-            pntxpolr = 1
             DO cellcount = 1, ncells
-                CALL wmxpoltsca_qtt(kk, jj, ii, sca, pntxpoli, pntxpolr, &
-                    xpoli, xpolr, qtt)
+                start_pntxpoli = (cellcount-1)*6   ! 6 integers per cell
+                start_pntxpolr = (cellcount-1)*5   ! 5 reals per cell
+                CALL wmxpoltsca_qtt(kk, jj, ii, sca, start_pntxpoli, &
+                    start_pntxpolr, xpoli, xpolr, qtt)
             END DO
         END IF
     END SUBROUTINE wmxpolsoltsca
 
 
-    SUBROUTINE wmxpoltsca_t(kk, jj, ii, sca, pntxpoli, pntxpolr, xpoli, &
-        xpolr, var)
+    SUBROUTINE wmxpoltsca_t(kk, jj, ii, sca, start_pntxpoli, start_pntxpolr, &
+        xpoli, xpolr, var)
 
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: kk, jj, ii
         TYPE(scalar_t), INTENT(in) :: sca
-        INTEGER(intk), INTENT(inout) :: pntxpoli
-        INTEGER(intk), INTENT(inout) :: pntxpolr
+        INTEGER(intk), INTENT(in) :: start_pntxpoli
+        INTEGER(intk), INTENT(in) :: start_pntxpolr
         INTEGER(intk), INTENT(in), CONTIGUOUS :: xpoli(:)
         REAL(realk), INTENT(in), CONTIGUOUS :: xpolr(:)
         REAL(realk), INTENT(inout) :: var(kk*jj*ii)
@@ -920,46 +1034,31 @@ CONTAINS
         REAL(realk) :: bcval, coeff, val
 
         ! 1st integer: identifier of the interface cell
-        intcell = xpoli(pntxpoli)
-        pntxpoli = pntxpoli + 1
+        intcell = xpoli(start_pntxpoli + 1)
 
         ! 2nd integer: body ID
-        body = xpoli(pntxpoli)
-        pntxpoli = pntxpoli + 1
+        body = xpoli(start_pntxpoli + 2)
 
         ! Look up boundary condition at bodyid
+        bctype = 1
+        bcval = 0.0
         IF (body > 0) THEN
             bctype = sca%geometries(body)%flag
             bcval = sca%geometries(body)%value
-        ELSE
-            ! default: adiabatic
-            ! TODO: Add body 0 to above list
-            bctype = 1
-            bcval = 0.0
         END IF
 
         ! 3rd integer: cells used for the stencil (may also be 0)
-        stencils = xpoli(pntxpoli)
-        pntxpoli = pntxpoli + 1
-
-        ! 1st real: areabyvol required for the flux
-        ! areabyvol = xpolr(pntxpolr)
-        pntxpolr = pntxpolr + 1
+        stencils = xpoli(start_pntxpoli + 3)
 
         ! Computing the fixed value
         val = 0.0
         DO n = 1, stencils
-            stcell = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
-            coeff = xpolr(pntxpolr)
-            pntxpolr = pntxpolr + 1
-
+            stcell = xpoli(start_pntxpoli + 3 + n)
+            coeff = xpolr(start_pntxpolr + 1 + n)
             val = val + var(stcell)*coeff
         END DO
 
-        coeff = xpolr(pntxpolr)   ! additive constant "acoeffvel"
-        pntxpolr = pntxpolr + 1
+        coeff = xpolr(start_pntxpolr + 5)   ! additive constant "acoeffvel"
 
         ! Set value at cell if BC is fixed value
         IF (bctype == 0) THEN
@@ -969,53 +1068,38 @@ CONTAINS
     END SUBROUTINE wmxpoltsca_t
 
 
-    SUBROUTINE wmxpoltsca_qtt(kk, jj, ii, sca, pntxpoli, pntxpolr, xpoli, &
-            xpolr, var)
+    SUBROUTINE wmxpoltsca_qtt(kk, jj, ii, sca, start_pntxpoli, start_pntxpolr, &
+            xpoli, xpolr, var)
 
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: kk, jj, ii
         TYPE(scalar_t), INTENT(in) :: sca
-        INTEGER(intk), INTENT(inout) :: pntxpoli
-        INTEGER(intk), INTENT(inout) :: pntxpolr
+        INTEGER(intk), INTENT(in) :: start_pntxpoli
+        INTEGER(intk), INTENT(in) :: start_pntxpolr
         INTEGER(intk), INTENT(in), CONTIGUOUS :: xpoli(:)
         REAL(realk), INTENT(in), CONTIGUOUS :: xpolr(:)
         REAL(realk), INTENT(inout) :: var(kk*jj*ii)
 
         ! Local variables
-        INTEGER(intk) :: intcell, body, bctype, stencils
+        INTEGER(intk) :: intcell, body, bctype
         REAL(realk) :: areabyvol, bcval
 
         ! 1st integer: identifier of the interface cell
-        intcell = xpoli(pntxpoli)
-        pntxpoli = pntxpoli + 1
+        intcell = xpoli(start_pntxpoli + 1)
 
         ! 2nd integer: body ID
-        body = xpoli(pntxpoli)
-        pntxpoli = pntxpoli + 1
+        body = xpoli(start_pntxpoli + 2)
 
         ! Look up boundary condition at bodyid
+        bctype = 1
+        bcval = 0.0
         IF (body > 0) THEN
             bctype = sca%geometries(body)%flag
             bcval = sca%geometries(body)%value
-        ELSE
-            ! default: adiabatic
-            ! TODO: Add body 0 to above list
-            bctype = 1
-            bcval = 0.0
         END IF
 
-        ! 3rd integer: number of cells used for the stencil (may also be 0)
-        stencils = xpoli(pntxpoli)
-        pntxpoli = pntxpoli + 1
-
         ! 1st real: areabyvol required for the flux
-        areabyvol = xpolr(pntxpolr)
-        pntxpolr = pntxpolr + 1
-
-        ! Increment counter for unused variables
-        pntxpoli = pntxpoli + stencils     ! 'stcell'
-        pntxpolr = pntxpolr + stencils     ! 'coeff'
-        pntxpolr = pntxpolr + 1            ! Additive constant "acoeffvel"
+        areabyvol = xpolr(start_pntxpolr + 1)
 
         ! Add flux to list of fluxes
         IF (bctype == 1) THEN
@@ -1097,7 +1181,7 @@ CONTAINS
 
         ! Local variables
         INTEGER(intk) :: cellcount, intcell, stencils, nstencils, n, stcell, &
-            pntxpoli, pntxpolr, icell, istag(3)
+            icell, istag(3)
         INTEGER(intk) :: unit
         INTEGER(intk) :: k, j, i
         CHARACTER(len=mglet_filename_max) :: filename
@@ -1115,50 +1199,43 @@ CONTAINS
         WRITE(unit, '("ASCII")')
         WRITE(unit, '("DATASET UNSTRUCTURED_GRID")')
 
+        ! Stencil structure (standard-sized stencil):
+
+        ! I1 = cell to be treated
+        ! I2 = body id of cell to be treated
+        ! I3 = number of peripheral stencil points (N)
+        ! I4 = 1D-index of peripheral stencil point 1 (or -1 if N<1)
+        ! I5 = 1D-index of peripheral stencil point 2 (or -1 if N<2)
+        ! I6 = 1D-index of peripheral stencil point 3 (or -1 if N<3)
+
+        ! R1 = surface area divided by cell volume
+        ! R2 = coefficient for peripheral stencil point 1 (or dummy if N<1)
+        ! R3 = coefficient for peripheral stencil point 2 (or dummy if N<2)
+        ! R4 = coefficient for peripheral stencil point 3 (or dummy if N<3)
+        ! R5 = additive constant (e.g. for Dirichlet conditions)
+
+
         ! Count nstencils
         nstencils = 0
-        pntxpoli = 1
-        DO cellcount = 1, nblgcells
-            ! not needing this one
-            ! intcell = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
-            ! not needing this one either
-            ! body = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
-            stencils = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
+        DO cellcount = 0, nblgcells-1
+            stencils = xpoli(6*cellcount+3)
             nstencils = nstencils + stencils
-            pntxpoli = pntxpoli + stencils
         END DO
 
         WRITE(unit, '("POINTS ", I0, " float")') nblgcells + nstencils
 
         ! Write points
-        pntxpoli = 1
-        DO cellcount = 1, nblgcells
-            ! intcell the same for all components
-            intcell = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
-            ! body = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
+        DO cellcount = 0, nblgcells-1
+            intcell = xpoli(6*cellcount+1)
             CALL ind2sub(intcell, k, j, i, kk, jj, ii)
             WRITE(unit, '(G0, 1X, G0, 1X, G0)') &
                 x(i) + istag(1)*dx(i)/2.0, &
                 y(j) + istag(2)*dy(j)/2.0, &
                 z(k) + istag(3)*dz(k)/2.0
 
-            stencils = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
+            stencils = xpoli(6*cellcount+3)
             DO n = 1, stencils
-                stcell = xpoli(pntxpoli)
-                pntxpoli = pntxpoli + 1
-
+                stcell = xpoli(6*cellcount+3+n)
                 CALL ind2sub(stcell, k, j, i, kk, jj, ii)
                 WRITE(unit, '(G0, 1X, G0, 1X, G0)') &
                     x(i) + istag(1)*dx(i)/2.0, &
@@ -1178,21 +1255,10 @@ CONTAINS
 
         ! Lines
         icell = 0
-        pntxpoli = 1
-        DO cellcount = 1, nblgcells
-            ! not needing this one
-            ! intcell = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
-            ! body = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
-            stencils = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
+        DO cellcount = 0, nblgcells-1
+            stencils = xpoli(6*cellcount+3)
             DO n = 1, stencils
                 WRITE(unit, '(I0, 1X, I0, 1X, I0)') 2, icell, icell+n
-                pntxpoli = pntxpoli + 1
             END DO
             icell = icell + 1 + stencils
         END DO
@@ -1211,40 +1277,18 @@ CONTAINS
         WRITE(unit, '("SCALARS stencils int 1")')
         WRITE(unit, '("LOOKUP_TABLE default")')
 
-        pntxpoli = 1
-        DO cellcount = 1, nblgcells
-            ! not needing this one
-            ! intcell = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
-            ! body = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
-            stencils = xpoli(pntxpoli)
+        DO cellcount = 0, nblgcells-1
+            stencils = xpoli(6*cellcount+3)
             WRITE(unit, '(I0)') stencils
-            pntxpoli = pntxpoli + 1
-
             DO n = 1, stencils
                 WRITE(unit, '("-1")')
-                pntxpoli = pntxpoli + 1
             END DO
         END DO
 
-        pntxpoli = 1
-        DO cellcount = 1, nblgcells
-            ! not needing this one
-            ! intcell = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
-            ! body = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
-            stencils = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
+        DO cellcount = 0, nblgcells-1
+            stencils = xpoli(6*cellcount+3)
             DO n = 1, stencils
                 WRITE(unit, '(I0)') stencils
-                pntxpoli = pntxpoli + 1
             END DO
         END DO
 
@@ -1252,61 +1296,20 @@ CONTAINS
         WRITE(unit, '("SCALARS coefficient float 1")')
         WRITE(unit, '("LOOKUP_TABLE default")')
 
-        pntxpoli = 1
-        pntxpolr = 1
-        DO cellcount = 1, nblgcells
-            ! not needing this one
-            ! intcell = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
 
-            ! body = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
-            stencils = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
-            ! >>> ghost cell
-            WRITE(unit, '(G0)') xpolr(pntxpolr+stencils)
-
+        DO cellcount = 0, nblgcells-1
+            stencils = xpoli(6*cellcount+3)
+            WRITE(unit, '(G0)') xpolr(5*cellcount+5)
             DO n = 1, stencils
-                ! stcell = xpoli(pntxpoli)
-                pntxpoli = pntxpoli + 1
-
-                ! coeff = xpolr(pntxpolr)
-                ! stencil cell
-                WRITE(unit, '(G0)') xpolr(pntxpolr)
-                pntxpolr = pntxpolr + 1
+                WRITE(unit, '(G0)') xpolr(5*cellcount+1+n)
             END DO
-
-            ! coeff = xpolr(pntxpolr)
-            pntxpolr = pntxpolr + 1
         END DO
 
-        pntxpoli = 1
-        pntxpolr = 1
-        DO cellcount = 1, nblgcells
-            ! not needing this one
-            ! intcell = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
-            ! body = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
-            stencils = xpoli(pntxpoli)
-            pntxpoli = pntxpoli + 1
-
+        DO cellcount = 0, nblgcells-1
+            stencils = xpoli(6*cellcount+3)
             DO n = 1, stencils
-                ! stcell = xpoli(pntxpoli)
-                pntxpoli = pntxpoli + 1
-
-                ! coeff = xpolr(pntxpolr)
-                ! >>> stencil cell
-                WRITE(unit, '(G0)') xpolr(pntxpolr)
-                pntxpolr = pntxpolr + 1
+                WRITE(unit, '(G0)') xpolr(5*cellcount+1+n)
             END DO
-
-            ! coeff = xpolr(pntxpolr)
-            pntxpolr = pntxpolr + 1
         END DO
 
         ! Phew...


### PR DESCRIPTION
Dear all (I promise to clean up the branches / PRs after the workshop...),

This draft here is a wavefront-inspired offloading approach for SIP. The parallel region within one team of threads is kept throughout the complete forward or backward substitution. By using the ID of the thread from omp_get_thread_num(), threads are assigned their pieces of work or remain passive if more threads are present than parallely processible locations within one hyperplane. The orchestration of the threads is managed via !$omp barrier, such that hyperplanes are ensure to be treated sequentially. On the test system, the approach performed well.

Best regards,

Simon