### PR TITLE
Initial OpenMP Offloading Build Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,10 +56,11 @@ else()
     message(STATUS "Compiling MGLET with 32 bit integers")
 endif()
 
-option(MGLET_OPENMP "Enable OpenMP (experimental)" OFF)
-if(MGLET_OPENMP)
-    message(STATUS "Enabling OpenMP")
+option(MGLET_OFFLOAD "Enable OpenMP offloading (experimental)" OFF)
+if(MGLET_OFFLOAD)
+    message(STATUS "Enabling OpenMP offloading")
     find_package(OpenMP REQUIRED)
+    add_compile_definitions(_MGLET_OFFLOAD_=1)
 endif()
 
 # CMake build options
@@ -88,6 +89,11 @@ set(MGLET_C_FLAGS_DEBUG "" CACHE STRING "MGLET C flags (debug)")
 set(MGLET_CXX_FLAGS_DEBUG "" CACHE STRING "MGLET CXX flags (debug)")
 set(MGLET_Fortran_FLAGS_DEBUG "" CACHE STRING "MGLET Fortran flags (debug)")
 
+if(MGLET_OFFLOAD)
+    set(MGLET_OFFLOAD_COMPILE_FLAGS "" CACHE STRING "MGLET Offload compile flags")
+    set(MGLET_OFFLOAD_ARCH_FLAGS "" CACHE STRING "MGLET Offload architecture flags")
+endif()
+
 add_compile_options("$<$<COMPILE_LANGUAGE:C>:${MGLET_C_FLAGS}>"
     "$<$<COMPILE_LANGUAGE:CXX>:${MGLET_CXX_FLAGS}>"
     "$<$<COMPILE_LANGUAGE:Fortran>:${MGLET_Fortran_FLAGS}>"
@@ -111,10 +117,17 @@ add_compile_options("$<$<COMPILE_LANGUAGE:C>:${MGLET_C_FLAGS}>"
     "$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<STREQUAL:${CMAKE_Fortran_COMPILER_ID},IntelLLVM>>:-diag-disable 5268>"
 )
 
-if (MGLET_OPENMP)
-    add_compile_options("$<$<COMPILE_LANGUAGE:C>:${OpenMP_C_FLAGS}>"
-        "$<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>"
-        "$<$<COMPILE_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}>"
+if (MGLET_OFFLOAD)
+    # Only add compile and link flags to Fortran, since we never want to
+    # interface to C/CXX in any MGLET library that is not specifically
+    # designed to be an offloading backend. If backends are added in the
+    # future, simply add compile and link options for C/CXX to the backend
+    # library itself.
+    add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:${MGLET_OFFLOAD_COMPILE_FLAGS}>"
+        "$<$<COMPILE_LANGUAGE:Fortran>:${MGLET_OFFLOAD_ARCH_FLAGS}>"
+    )
+    add_link_options("$<$<LINK_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}>"
+        "$<$<LINK_LANGUAGE:Fortran>:${MGLET_OFFLOAD_ARCH_FLAGS}>"
     )
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -223,6 +223,79 @@
                 "CMAKE_BUILD_TYPE": "Debug"
 
             }
+        },
+        {
+            "name": "amd",
+            "hidden": true,
+            "displayName": "AMD compilers (amdclang, amdclang++, amdflang)",
+            "description": "Default build options using the AMD compilers",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "amdclang",
+                "CMAKE_CXX_COMPILER": "amdclang++",
+                "CMAKE_Fortran_COMPILER": "amdflang",
+
+                "MGLET_C_FLAGS": "",
+                "MGLET_CXX_FLAGS": "",
+                "MGLET_Fortran_FLAGS": "-fimplicit-none",
+
+                "MGLET_C_FLAGS_RELEASE": "-O3;-g",
+                "MGLET_CXX_FLAGS_RELEASE": "-O3;-g",
+                "MGLET_Fortran_FLAGS_RELEASE": "-O3;-g",
+
+                "MGLET_C_FLAGS_DEBUG": "-O0;-g",
+                "MGLET_CXX_FLAGS_DEBUG": "-O0;-g",
+                "MGLET_Fortran_FLAGS_DEBUG": "-O0;-g;-pedantic;-Wno-non-target-passed-to-target"
+            }
+        },
+        {
+            "name": "amd-release",
+            "displayName": "AMD compilers (amdclang, amdclang++, amdflang) (release)",
+            "description": "Release configuration using the AMD compilers (amdclang, amdclang++, amdflang)",
+            "inherits": "amd",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+
+            }
+        },
+        {
+            "name": "amd-debug",
+            "displayName": "AMD compilers (amdclang, amdclang++, amdflang) (debug)",
+            "description": "Debug configuration using the AMD compilers (amdclang, amdclang++, amdflang)",
+            "inherits": "amd",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+
+            }
+        },
+        {
+            "name": "gfx942",
+            "displayName": "Offload architecture gfx942",
+            "description": "Flags to target the gfx942 architecture using the AMD compilers (amdclang, amdclang++, amdflang)",
+            "hidden": true,
+            "cacheVariables": {
+                "MGLET_OFFLOAD_COMPILE_FLAGS": "-fopenmp-version=52",
+                "MGLET_OFFLOAD_ARCH_FLAGS": "--offload-arch=gfx942"
+            }
+        },
+        {
+            "name": "amd-gfx942-release",
+            "displayName": "AMD compilers (amdclang, amdclang++, amdflang) (release)",
+            "description": "Offloaded release configuration using the AMD compilers (amdclang, amdclang++, amdflang)",
+            "inherits": ["amd-release", "gfx942"],
+            "cacheVariables": {
+                "MGLET_OFFLOAD": "ON"
+
+            }
+        },
+        {
+            "name": "amd-gfx942-debug",
+            "displayName": "AMD compilers (amdclang, amdclang++, amdflang) (debug)",
+            "description": "Offloaded debug configuration using the AMD compilers (amdclang, amdclang++, amdflang)",
+            "inherits": ["amd-debug", "gfx942"],
+            "cacheVariables": {
+                "MGLET_OFFLOAD": "ON"
+
+            }
         }
     ]
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(mgletlib
     PUBLIC plugins
     PUBLIC scalar
     PRIVATE ${MPI_Fortran_LIBRARIES}
+    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_Fortran>
 )
 
 # Executable
@@ -37,7 +38,7 @@ target_link_libraries(mglet
     PUBLIC mgletlib
     PRIVATE ${HDF5_Fortran_LIBRARIES}
     PRIVATE ${MPI_Fortran_LIBRARIES}
-    PRIVATE $<IF:$<BOOL:${MGLET_OPENMP}>,OpenMP::OpenMP_Fortran,>
+    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_Fortran>
 )
 
 # When using the NAG Fortran compiler, use the CXX linker (usually GCC),

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries(core
     PRIVATE ${MPI_Fortran_LIBRARIES}
     PRIVATE ${HDF5_Fortran_LIBRARIES}
     PRIVATE ZLIB::ZLIB
+    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_Fortran>
 )
 
 # Set include directories for specific files

--- a/src/core/corefields_mod.F90
+++ b/src/core/corefields_mod.F90
@@ -156,7 +156,9 @@ CONTAINS
         ii = SIZE(rezip)
         IF (SIZE(dx) /= ii) CALL errr(__FILE__, __LINE__)
 
+#ifndef _MGLET_OFFLOAD_
         !$omp simd
+#endif
         DO i = 1, ii
             rezip(i) = divide0(1.0_realk, dx(i))
         END DO

--- a/src/core/simdfunctions_mod.F90
+++ b/src/core/simdfunctions_mod.F90
@@ -25,7 +25,9 @@ MODULE simdfunctions_mod
 CONTAINS
 
     PURE ELEMENTAL REAL(real32) FUNCTION divide00_sp(a, b, bp) RESULT(res)
+#ifndef _MGLET_OFFLOAD_
     !$omp declare simd(divide00_sp)
+#endif
         REAL(real32), INTENT(in) :: a, b, bp
 
         IF (bp == 0.0_real32) THEN
@@ -36,7 +38,9 @@ CONTAINS
     END FUNCTION divide00_sp
 
     PURE ELEMENTAL REAL(real64) FUNCTION divide00_dp(a, b, bp) RESULT(res)
+#ifndef _MGLET_OFFLOAD_
     !$omp declare simd(divide00_dp)
+#endif
         REAL(real64), INTENT(in) :: a, b, bp
 
         IF (bp == 0.0_real64) THEN
@@ -48,7 +52,9 @@ CONTAINS
 
 
     PURE ELEMENTAL REAL(real32) FUNCTION divide0_sp(a, b) RESULT(res)
+#ifndef _MGLET_OFFLOAD_
     !$omp declare simd(divide0_sp)
+#endif
         REAL(real32), INTENT(in) :: a, b
 
         IF (b == 0.0_real32) THEN
@@ -59,7 +65,9 @@ CONTAINS
     END FUNCTION divide0_sp
 
     PURE ELEMENTAL REAL(real64) FUNCTION divide0_dp(a, b) RESULT(res)
+#ifndef _MGLET_OFFLOAD_
     !$omp declare simd(divide0_dp)
+#endif
         REAL(real64), INTENT(in) :: a, b
 
         IF (b == 0.0_real64) THEN
@@ -71,7 +79,9 @@ CONTAINS
 
 
     PURE ELEMENTAL INTEGER(intk) FUNCTION l_to_i(l) RESULT(i)
+#ifndef _MGLET_OFFLOAD_
     !$omp declare simd(l_to_i)
+#endif
         LOGICAL, INTENT(in) :: l
 
         IF (l) THEN
@@ -83,7 +93,9 @@ CONTAINS
 
 
     PURE ELEMENTAL LOGICAL FUNCTION i_to_l(i) RESULT(l)
+#ifndef _MGLET_OFFLOAD_
     !$omp declare simd(i_to_l)
+#endif
         INTEGER(intk), INTENT(in) :: i
 
         IF (i == 0) THEN
@@ -95,14 +107,18 @@ CONTAINS
 
 
     PURE ELEMENTAL INTEGER(intk) FUNCTION lcm(a, b)
+#ifndef _MGLET_OFFLOAD_
     !$omp declare simd(lcm)
+#endif
         INTEGER(intk), INTENT(in) :: a, b
         lcm = a*b/gcd(a, b)
     END FUNCTION lcm
 
 
     PURE ELEMENTAL INTEGER(intk) FUNCTION gcd(a, b)
+#ifndef _MGLET_OFFLOAD_
     !$omp declare simd(gcd)
+#endif
         INTEGER(intk), INTENT(in) :: a, b
         INTEGER(intk) :: aa, bb, t
 
@@ -119,7 +135,9 @@ CONTAINS
 
 
     PURE ELEMENTAL REAL(real32) FUNCTION cube_root_sp(a)
+#ifndef _MGLET_OFFLOAD_
     !$omp declare simd(cube_root_sp)
+#endif
         REAL(real32), INTENT(in) :: a
 
         INTERFACE
@@ -136,7 +154,9 @@ CONTAINS
 
 
     PURE ELEMENTAL REAL(real64) FUNCTION cube_root_dp(a)
+#ifndef _MGLET_OFFLOAD_
     !$omp declare simd(cube_root_dp)
+#endif
         REAL(real64), INTENT(in) :: a
 
         INTERFACE

--- a/src/flow/CMakeLists.txt
+++ b/src/flow/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(flow
     PRIVATE core
     PRIVATE ib
     PRIVATE ${MPI_Fortran_LIBRARIES}
+    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_Fortran>
 )
 
 set_source_files_properties(pressuresolver_mod.F90 PROPERTIES COMPILE_FLAGS

--- a/src/flow/lesmodel_mod.F90
+++ b/src/flow/lesmodel_mod.F90
@@ -255,7 +255,9 @@ CONTAINS
                     dwdz(k-2) = (w(k, j, i) - w(k-1, j, i))*rddz(k)
                 END DO
 
+#ifndef _MGLET_OFFLOAD_
                 !$omp simd
+#endif
                 DO k = 3, kk-2
                     delta(k-2) = cube_root(ddx(i)*ddy(j)*ddz(k))
                     delta(k-2) = delta(k-2)*bp(k, j, i)
@@ -334,7 +336,9 @@ CONTAINS
 
                 SELECT CASE (ilesmodel)
                 CASE (1)
+#ifndef _MGLET_OFFLOAD_
                     !$omp simd private(dm)
+#endif
                     DO k = 3, kk-2
                         dm = smagorinsky(dudx(k-2), dudy(k-2), dudz(k-2), &
                             dvdx(k-2), dvdy(k-2), dvdz(k-2), &
@@ -363,7 +367,9 @@ CONTAINS
 
     PURE ELEMENTAL REAL(realk) FUNCTION smagorinsky(dudx, dudy, dudz, dvdx, &
     dvdy, dvdz, dwdx, dwdy, dwdz)
+#ifndef _MGLET_OFFLOAD_
         !$omp declare simd(smagorinsky)
+#endif
 
         ! Function arguments
         REAL(realk), INTENT(in) :: dudx, dudy, dudz, dvdx, &
@@ -517,7 +523,9 @@ CONTAINS
 
     PURE ELEMENTAL REAL(realk) FUNCTION sabs(dudx, dudy, dudz, dvdx, &
             dvdy, dvdz, dwdx, dwdy, dwdz)
+#ifndef _MGLET_OFFLOAD_
         !$omp declare simd(sabs)
+#endif
 
         ! Function arguments
         REAL(realk), INTENT(in) :: dudx, dudy, dudz, dvdx, &

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -897,7 +897,9 @@ CONTAINS
                             kstop = kk - 3
                         END IF
 
+#ifndef _MGLET_OFFLOAD_
                         !$omp simd private(aw, ae, as, an, ab, at, rap, res)
+#endif
                         DO k = kstart, kstop, 2
                             ! Variations in numerical formulation, please
                             ! keep for future reference. Should be the same
@@ -950,7 +952,9 @@ CONTAINS
                             kstop = kk - 3
                         END IF
 
+#ifndef _MGLET_OFFLOAD_
                         !$omp simd private(res)
+#endif
                         DO k = kstart, kstop, 2
                             res = (gsaw(i) * dp(k, j, i-1) &
                                   + gsae(i) * dp(k, j, i+1) &

--- a/src/flow/tstle4_mod.F90
+++ b/src/flow/tstle4_mod.F90
@@ -1868,7 +1868,9 @@ CONTAINS
 
 
     PURE ELEMENTAL REAL(realk) FUNCTION swcle3d_one(ddz, u) RESULT(uo)
+#ifndef _MGLET_OFFLOAD_
         !$omp declare simd(swcle3d_one)
+#endif
 
         ! Function arguments
         REAL(realk), INTENT(in) :: ddz  ! wall normal

--- a/src/flow/wernerwengle_mod.F90
+++ b/src/flow/wernerwengle_mod.F90
@@ -35,7 +35,9 @@ CONTAINS
 
 
     PURE ELEMENTAL REAL(realk) FUNCTION gradp2(uquer, dds)
+#ifndef _MGLET_OFFLOAD_
         !$omp declare simd(gradp2)
+#endif
 
         ! Computes the gradient dds/2 away from the wall using the WW wall
         ! model
@@ -60,7 +62,9 @@ CONTAINS
 
 
     PURE ELEMENTAL REAL(realk) FUNCTION tauwin(uquer, dds)
+#ifndef _MGLET_OFFLOAD_
         !$omp declare simd(tauwin)
+#endif
 
         ! Function arguments
         REAL(realk), INTENT(IN) :: uquer, dds
@@ -87,7 +91,9 @@ CONTAINS
     ! usage!
     PURE ELEMENTAL REAL(realk) FUNCTION qwallfix(tbound, tfluid, uquer, dds, &
             prmol)
+#ifndef _MGLET_OFFLOAD_
         !$omp declare simd(qwallfix)
+#endif
 
         ! Function arguments
         REAL(realk), INTENT(IN) :: tbound, tfluid, uquer, dds, prmol

--- a/src/ib/CMakeLists.txt
+++ b/src/ib/CMakeLists.txt
@@ -52,6 +52,7 @@ target_include_directories(ib
 target_link_libraries(ib
     PRIVATE core
     PRIVATE ${MPI_Fortran_LIBRARIES}
+    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_Fortran>
 )
 
 set_source_files_properties(checkzelle_mod.F90 PROPERTIES COMPILE_FLAGS

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -16,4 +16,5 @@ target_link_libraries(plugins
     PRIVATE ib
     PRIVATE ${MPI_Fortran_LIBRARIES}
     PRIVATE ${HDF5_Fortran_LIBRARIES}
+    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_Fortran>
 )

--- a/src/scalar/CMakeLists.txt
+++ b/src/scalar/CMakeLists.txt
@@ -20,4 +20,5 @@ target_link_libraries(scalar
     PRIVATE ib
     PRIVATE flow
     PRIVATE ${MPI_Fortran_LIBRARIES}
+    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_Fortran>
 )


### PR DESCRIPTION
### OpenMP simd
- Check all `!$omp simd` and `!$omp declare simd` constructs such that they are excluded if offloading is enabled (amdflang does not support `!$omp declare simd` yet, other compilers have similar issues -> best to just remove all for offloading)