### PR TITLE
Add OpenMP Offloading Target Probe to Startup Information

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(core STATIC
     plugins_mod.F90
     pointers_mod.F90
     precision_mod.F90
+    probeoffload_mod.F90
     pvtk.c
     pvtk_mod.F90
     qsort_mod.F90

--- a/src/core/core_mod.F90
+++ b/src/core/core_mod.F90
@@ -25,6 +25,7 @@ MODULE core_mod
     USE plugins_mod
     USE pointers_mod
     USE precision_mod
+    USE probeoffload_mod
     USE pvtk_mod
     USE qsort_mod
     USE readstl_mod
@@ -93,6 +94,9 @@ CONTAINS
 
         CALL init_precision()
         CALL init_buildinfo()
+#ifdef _MGLET_OFFLOAD_
+        CALL init_offload()
+#endif
         CALL init_timer()
 
         CALL set_timer(1, "MGLET")

--- a/src/core/probeoffload_mod.F90
+++ b/src/core/probeoffload_mod.F90
@@ -1,0 +1,78 @@
+MODULE probeoffload_mod
+    USE comms_mod, ONLY: myid, numprocs
+    USE precision_mod, ONLY: intk
+
+    IMPLICIT NONE(type, external)
+    PRIVATE
+
+    PUBLIC :: init_offload
+CONTAINS
+    SUBROUTINE init_offload()
+        USE MPI_f08
+
+        ! Local variables
+        LOGICAL, ALLOCATABLE :: offload_ranks(:)
+        INTEGER(intk), ALLOCATABLE :: failed_ranks(:)
+        INTEGER(intk) :: i, nfail
+        LOGICAL :: available
+
+        available = probe_target()
+
+        IF (myid == 0) THEN
+            ALLOCATE(offload_ranks(numprocs))
+        ELSE
+            ALLOCATE(offload_ranks(0))
+        END IF
+
+        CALL MPI_Gather(available, 1, MPI_LOGICAL, offload_ranks, 1, &
+            MPI_LOGICAL, 0, MPI_COMM_WORLD)
+
+        IF (myid == 0) THEN
+            nfail = 0
+            DO i = 1, numprocs
+                IF (.NOT. offload_ranks(i)) nfail = nfail + 1
+            END DO
+
+            WRITE(*, '("OPENMP OFFLOADING:")')
+            IF (nfail == 0) THEN
+                WRITE(*, '("    Target probe successful on all ranks")')
+            ELSE
+                ALLOCATE(failed_ranks(nfail), source=0_intk)
+                nfail = 0
+                DO i = 1, numprocs
+                    IF (.NOT. offload_ranks(i)) THEN
+                        nfail = nfail + 1
+                        failed_ranks(nfail) = i - 1
+                    END IF
+                END DO
+                WRITE(*, '("    Target probe FAILED on rank(s):", *(1X, I0))') &
+                    failed_ranks
+                DEALLOCATE(failed_ranks)
+            END IF
+            WRITE(*, '()')
+        END IF
+
+        DEALLOCATE(offload_ranks)
+    END SUBROUTINE init_offload
+
+    FUNCTION probe_target() RESULT(available)
+#ifdef _MGLET_OFFLOAD_
+        USE omp_lib
+#endif
+        ! Function arguments
+        LOGICAL :: available
+
+        ! Local variables
+        LOGICAL :: is_initial_device
+
+        is_initial_device = .TRUE.
+
+#ifdef _MGLET_OFFLOAD_
+        !$omp target map(from: is_initial_device)
+        is_initial_device = omp_is_initial_device()
+        !$omp end target
+#endif
+
+        available = .NOT. is_initial_device
+    END FUNCTION probe_target
+END MODULE probeoffload_mod


### PR DESCRIPTION
Quickly obtainable information on startup to see if target regions actually execute on a non-initial device. Also helpful if pinning has gone wrong.

