### PR TITLE
Temporary errr Workaround on Targets and Declare Target on Helpers in grids_mod and simdfunctions_mod

### DIFF
--- a/src/core/err_mod.F90
+++ b/src/core/err_mod.F90
@@ -15,6 +15,7 @@ MODULE err_mod
 
 CONTAINS
     SUBROUTINE err_print(errorcode, message, fname, line)
+        !$omp declare target
         ! Prints error message to standard error. Does not abort execution.
         USE comms_mod, ONLY: myid
 #if defined __INTEL_COMPILER
@@ -39,6 +40,9 @@ CONTAINS
         END IF
         write(error_unit, '()')
 
+        ! Likely does not run on target - disable backtraces if one
+        ! decides to run on Intel/GNU offload
+#ifndef _MGLET_OFFLOAD_
         ! Produce backtrace to indicate from where the error comming from
 #ifdef __INTEL_COMPILER
         CALL TRACEBACKQQ(user_exit_code=-1)
@@ -46,10 +50,12 @@ CONTAINS
 #ifdef __GFORTRAN__
         CALL BACKTRACE()
 #endif
+#endif
     END SUBROUTINE err_print
 
 
     SUBROUTINE err_abort(errorcode, message, fname, line)
+        !$omp declare target
         ! Generic error handler if something happens on an arbitrary single
         ! rank. Aborts execution of MGLET.
 
@@ -68,11 +74,16 @@ CONTAINS
         IF (mpicode > maxcode) THEN
             mpicode = maxcode
         END IF
+#ifdef _MGLET_OFFLOAD_
+        CALL EXIT(mpicode)
+#else
         CALL MPI_Abort(MPI_COMM_WORLD, mpicode)
+#endif
     END SUBROUTINE err_abort
 
 
     SUBROUTINE errr(fname, line)
+        !$omp declare target
         ! Generic error handler if something happens on an arbitrary single
         ! rank. Aborts execution of MGLET.
 

--- a/src/core/grids_mod.F90
+++ b/src/core/grids_mod.F90
@@ -456,6 +456,7 @@ CONTAINS
 
 
     SUBROUTINE get_mgdims(kk, jj, ii, igrid)
+        !$omp declare target
         INTEGER(intk), INTENT(OUT) :: kk, jj, ii
         INTEGER(intk), INTENT(IN) :: igrid
 
@@ -474,6 +475,7 @@ CONTAINS
 
 
     SUBROUTINE get_imygrid(imygrid, igrid)
+        !$omp declare target
         INTEGER(intk), INTENT(in) :: igrid
         INTEGER(intk), INTENT(out) :: imygrid
 
@@ -484,6 +486,7 @@ CONTAINS
 
 
     SUBROUTINE get_bbox(minx, maxx, miny, maxy, minz, maxz, igrid)
+        !$omp declare target
         REAL(realk), INTENT(OUT) :: minx, maxx, miny, maxy, minz, maxz
         INTEGER(intk), INTENT(IN) :: igrid
 
@@ -505,6 +508,7 @@ CONTAINS
 
 
     SUBROUTINE get_gridvolume(volume, igrid)
+        !$omp declare target
         ! Subroutine arguments
         REAL(realk), INTENT(out) :: volume
         INTEGER(intk), INTENT(in) :: igrid
@@ -518,6 +522,7 @@ CONTAINS
 
 
     SUBROUTINE get_gradpxflag(flag, igrid)
+        !$omp declare target
         USE simdfunctions_mod, ONLY: l_to_i
 
         INTEGER(intk), INTENT(OUT) :: flag
@@ -694,6 +699,7 @@ CONTAINS
 
 
     SUBROUTINE get_level(level, igrid)
+        !$omp declare target
         INTEGER(intk), INTENT(OUT) :: level
         INTEGER(intk), INTENT(IN) :: igrid
 
@@ -710,6 +716,7 @@ CONTAINS
 
 
     INTEGER(intk) FUNCTION iposition(igrid)
+        !$omp declare target
         INTEGER(intk), INTENT(IN) :: igrid
 
 #ifdef _MGLET_DEBUG_
@@ -725,6 +732,7 @@ CONTAINS
 
 
     INTEGER(intk) FUNCTION jposition(igrid)
+        !$omp declare target
         INTEGER(intk), INTENT(IN) :: igrid
 
 #ifdef _MGLET_DEBUG_
@@ -740,6 +748,7 @@ CONTAINS
 
 
     INTEGER(intk) FUNCTION kposition(igrid)
+        !$omp declare target
         INTEGER(intk), INTENT(IN) :: igrid
 
 #ifdef _MGLET_DEBUG_
@@ -755,6 +764,7 @@ CONTAINS
 
 
     INTEGER(intk) FUNCTION iparent(igrid)
+        !$omp declare target
         INTEGER(intk), INTENT(IN) :: igrid
 
 #ifdef _MGLET_DEBUG_
@@ -770,6 +780,7 @@ CONTAINS
 
 
     INTEGER(intk) FUNCTION level(igrid)
+        !$omp declare target
         INTEGER(intk), INTENT(IN) :: igrid
 
 #ifdef _MGLET_DEBUG_
@@ -785,6 +796,7 @@ CONTAINS
 
 
     SUBROUTINE get_neighbours(neighbours, igrid)
+        !$omp declare target
         INTEGER(intk), INTENT(OUT) :: neighbours(26)
         INTEGER(intk), INTENT(IN) :: igrid
 
@@ -801,6 +813,7 @@ CONTAINS
 
 
     SUBROUTINE get_kk(kk, igrid)
+        !$omp declare target
         INTEGER(intk), INTENT(OUT) :: kk
         INTEGER(intk), INTENT(IN) :: igrid
 
@@ -817,6 +830,7 @@ CONTAINS
 
 
     SUBROUTINE get_jj(jj, igrid)
+        !$omp declare target
         INTEGER(intk), INTENT(OUT) :: jj
         INTEGER(intk), INTENT(IN) :: igrid
 
@@ -833,6 +847,7 @@ CONTAINS
 
 
     SUBROUTINE get_ii(ii, igrid)
+        !$omp declare target
         INTEGER(intk), INTENT(OUT) :: ii
         INTEGER(intk), INTENT(IN) :: igrid
 
@@ -849,6 +864,7 @@ CONTAINS
 
 
     SUBROUTINE get_mgbasb1(nfro, nbac, nrgt, nlft, nbot, ntop, igrid)
+        !$omp declare target
         INTEGER(intk), INTENT(out) :: nfro, nbac, nrgt, nlft, nbot, ntop
         INTEGER(intk), INTENT(in) :: igrid
 
@@ -870,6 +886,7 @@ CONTAINS
 
 
     SUBROUTINE get_mgbasb2(bconds, igrid)
+        !$omp declare target
         INTEGER(intk), INTENT(out) :: bconds(6)
         INTEGER(intk), INTENT(in) :: igrid
 

--- a/src/core/simdfunctions_mod.F90
+++ b/src/core/simdfunctions_mod.F90
@@ -25,8 +25,9 @@ MODULE simdfunctions_mod
 CONTAINS
 
     PURE ELEMENTAL REAL(real32) FUNCTION divide00_sp(a, b, bp) RESULT(res)
+        !$omp declare target
 #ifndef _MGLET_OFFLOAD_
-    !$omp declare simd(divide00_sp)
+        !$omp declare simd(divide00_sp)
 #endif
         REAL(real32), INTENT(in) :: a, b, bp
 
@@ -38,8 +39,9 @@ CONTAINS
     END FUNCTION divide00_sp
 
     PURE ELEMENTAL REAL(real64) FUNCTION divide00_dp(a, b, bp) RESULT(res)
+        !$omp declare target
 #ifndef _MGLET_OFFLOAD_
-    !$omp declare simd(divide00_dp)
+        !$omp declare simd(divide00_dp)
 #endif
         REAL(real64), INTENT(in) :: a, b, bp
 
@@ -52,8 +54,9 @@ CONTAINS
 
 
     PURE ELEMENTAL REAL(real32) FUNCTION divide0_sp(a, b) RESULT(res)
+        !$omp declare target
 #ifndef _MGLET_OFFLOAD_
-    !$omp declare simd(divide0_sp)
+        !$omp declare simd(divide0_sp)
 #endif
         REAL(real32), INTENT(in) :: a, b
 
@@ -65,8 +68,9 @@ CONTAINS
     END FUNCTION divide0_sp
 
     PURE ELEMENTAL REAL(real64) FUNCTION divide0_dp(a, b) RESULT(res)
+        !$omp declare target
 #ifndef _MGLET_OFFLOAD_
-    !$omp declare simd(divide0_dp)
+        !$omp declare simd(divide0_dp)
 #endif
         REAL(real64), INTENT(in) :: a, b
 
@@ -79,8 +83,9 @@ CONTAINS
 
 
     PURE ELEMENTAL INTEGER(intk) FUNCTION l_to_i(l) RESULT(i)
+        !$omp declare target
 #ifndef _MGLET_OFFLOAD_
-    !$omp declare simd(l_to_i)
+        !$omp declare simd(l_to_i)
 #endif
         LOGICAL, INTENT(in) :: l
 
@@ -93,8 +98,9 @@ CONTAINS
 
 
     PURE ELEMENTAL LOGICAL FUNCTION i_to_l(i) RESULT(l)
+        !$omp declare target
 #ifndef _MGLET_OFFLOAD_
-    !$omp declare simd(i_to_l)
+        !$omp declare simd(i_to_l)
 #endif
         INTEGER(intk), INTENT(in) :: i
 
@@ -107,8 +113,9 @@ CONTAINS
 
 
     PURE ELEMENTAL INTEGER(intk) FUNCTION lcm(a, b)
+        !$omp declare target
 #ifndef _MGLET_OFFLOAD_
-    !$omp declare simd(lcm)
+        !$omp declare simd(lcm)
 #endif
         INTEGER(intk), INTENT(in) :: a, b
         lcm = a*b/gcd(a, b)
@@ -116,8 +123,9 @@ CONTAINS
 
 
     PURE ELEMENTAL INTEGER(intk) FUNCTION gcd(a, b)
+        !$omp declare target
 #ifndef _MGLET_OFFLOAD_
-    !$omp declare simd(gcd)
+        !$omp declare simd(gcd)
 #endif
         INTEGER(intk), INTENT(in) :: a, b
         INTEGER(intk) :: aa, bb, t
@@ -135,8 +143,9 @@ CONTAINS
 
 
     PURE ELEMENTAL REAL(real32) FUNCTION cube_root_sp(a)
+        !$omp declare target
 #ifndef _MGLET_OFFLOAD_
-    !$omp declare simd(cube_root_sp)
+        !$omp declare simd(cube_root_sp)
 #endif
         REAL(real32), INTENT(in) :: a
 
@@ -154,8 +163,9 @@ CONTAINS
 
 
     PURE ELEMENTAL REAL(real64) FUNCTION cube_root_dp(a)
+        !$omp declare target
 #ifndef _MGLET_OFFLOAD_
-    !$omp declare simd(cube_root_dp)
+        !$omp declare simd(cube_root_dp)
 #endif
         REAL(real64), INTENT(in) :: a
 
@@ -173,6 +183,7 @@ CONTAINS
 
 
     PURE SUBROUTINE cross_sp(c, a, b)
+        !$omp declare target
         REAL(real32), INTENT(out) :: c(3)
         REAL(real32), INTENT(in) :: a(3), b(3)
 
@@ -183,6 +194,7 @@ CONTAINS
 
 
     PURE SUBROUTINE cross_dp(c, a, b)
+        !$omp declare target
         REAL(real64), INTENT(out) :: c(3)
         REAL(real64), INTENT(in) :: a(3), b(3)
 


### PR DESCRIPTION
- Does not `declare target` on `get_bc_ctyp`, `get_nbcprms` and `get_bcprms`
- simdfunctions_mod contains some C interfaces - these work perfectly fine in target regions (tested on LLVM with nvptx64)