### PR TITLE
Restore a single SIP routine for both hyperplane and classic sip solvers

### DIFF
--- a/src/core/core_mod.F90
+++ b/src/core/core_mod.F90
@@ -17,6 +17,7 @@ MODULE core_mod
     USE field_mod
     USE fields_mod
     USE fort7_mod
+    USE get_grid_mod
     USE grids_mod
     ! Should not be neccesary to export gridio_mod - since this is only used
     ! in core functions

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -6,16 +6,17 @@ MODULE pressuresolver_mod
     USE itinfo_mod, ONLY: itinfo_sample
     USE plog_mod
     USE laplacephi_mod
-    USE sip_hyperplane_mod
-    USE sip_classic_mod
+    USE sip_hyperplane_mod, sipiter1_hp => sipiter1, sipiter2_hp => sipiter2
+    USE sip_classic_mod, sipiter1_cl => sipiter1, sipiter2_cl => sipiter2
     USE sor_mod
 
     IMPLICIT NONE (type, external)
     PRIVATE
 
     ! Type of pressure solver
-    !   0 : Standard SIP
+    !   0 : Hyperplane SIP
     !   1 : SIP on coarsest level, then SOR on subsequent levels
+    !   2 : Classic SIP
     INTEGER(intk) :: ityp
 
     ! Number of inner iterations/sweeps in pressure solver
@@ -391,42 +392,112 @@ CONTAINS
         CALL get_field(siplw, "SIPLW")
         CALL get_field(sipls, "SIPLS")
         CALL get_field(siplb, "SIPLB")
-        CALL get_field(siplpr, "SIPLPR")
         CALL get_field(sipue, "SIPUE")
         CALL get_field(sipun, "SIPUN")
         CALL get_field(siput, "SIPUT")
+        CALL get_field(siplpr, "SIPLPR")
 
         DO iloop = 1, ninner
             CALL bound_pressure%bound(ilevel, dp, bp)
 
             IF (ityp == 1 .AND. ilevel > minlevel) THEN
-
                 ! The SOR relaxation is usually not efficient at the
                 ! coarsest level, hence only apply at the finer levels
                 CALL sor(ilevel, dp, rhs, gsaw, gsae, gsas, gsan, gsab, gsat, &
                     gsrap, bp)
-
-            ELSE IF (ityp == 2) THEN
-
-                ! Use the classic SIP solver
-                CALL sip_classic(ilevel, iloop, ninner, dp, res, rhs, &
-                    siplw, sipls, siplb, siplpr, sipue, sipun, siput, bp)
-
             ELSE
-
-                ! Use the hyperplane SIP solver
-                CALL sip_hyperplane(ilevel, iloop, ninner, dp, res, rhs, &
-                    siplw, sipls, siplb, siplpr, sipue, sipun, siput, bp)
-
+                ! Use the SIP solver
+                CALL sip(ilevel, iloop, dp, res, rhs, siplw, sipls, siplb, &
+                    sipue, sipun, siput, siplpr, bp)
             END IF
 
             CALL connect(ilevel, 1, s1=dp)
         END DO
 
         CALL bound_pressure%bound(ilevel, dp, bp)
-        CALL stop_timer(321)
 
+        CALL stop_timer(321)
     END SUBROUTINE mgpoisit
+
+
+    SUBROUTINE sip(ilevel, iloop, dp, res, rhs, siplw, sipls, siplb, &
+            sipue, sipun, siput, siplpr, bp)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: ilevel
+        INTEGER(intk), INTENT(in) :: iloop
+        TYPE(field_t), INTENT(inout) :: dp
+        TYPE(field_t), INTENT(inout) :: res
+        TYPE(field_t), INTENT(in) :: rhs
+        TYPE(field_t), INTENT(in) :: siplw
+        TYPE(field_t), INTENT(in) :: sipls
+        TYPE(field_t), INTENT(in) :: siplb
+        TYPE(field_t), INTENT(in) :: sipue
+        TYPE(field_t), INTENT(in) :: sipun
+        TYPE(field_t), INTENT(in) :: siput
+        TYPE(field_t), INTENT(in) :: siplpr
+        TYPE(field_t), INTENT(in), OPTIONAL :: bp
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid
+        INTEGER(intk) :: kk, jj, ii
+        REAL(realk), POINTER, CONTIGUOUS :: lw(:, :, :), ls(:, :, :), &
+            lb(:, :, :), ue(:, :, :), un(:, :, :), ut(:, :, :), &
+            lpr(:, :, :)
+        REAL(realk), POINTER, CONTIGUOUS :: dp_p(:, :, :), res_p(:, :, :), &
+            rhs_p(:, :, :)
+        INTEGER(ifk), CONTIGUOUS, POINTER :: mip_ptr(:), idx_ptr(:)
+
+        CALL laplacephi_level(ilevel, res, dp, bp)
+
+        DO i = 1, nmygridslvl(ilevel)
+            igrid = mygridslvl(i, ilevel)
+            CALL get_mgdims(kk, jj, ii, igrid)
+
+            CALL res%get_ptr(res_p, igrid)
+            CALL rhs%get_ptr(rhs_p, igrid)
+
+            CALL siplw%get_ptr(lw, igrid)
+            CALL sipls%get_ptr(ls, igrid)
+            CALL siplb%get_ptr(lb, igrid)
+            CALL siplpr%get_ptr(lpr, igrid)
+
+            IF (ityp == 2) THEN
+                CALL sipiter1_cl(kk, jj, ii, rhs_p, res_p, lw, ls, lb, lpr)
+            ELSE
+                CALL get_grid3_ifk_linear(mip_ptr, mip_hp_f, igrid)
+                CALL get_grid3_ifk_linear(idx_ptr, idx_hp_f, igrid)
+                CALL sipiter1_hp(kk, jj, ii, rhs_p, res_p, lw, ls, lb, lpr, &
+                    mip_ptr, idx_ptr)
+            END IF
+        END DO
+
+        IF (iloop < ninner) THEN
+            CALL connect(ilevel, 1, s1=res)
+        ELSE
+            CALL connect(ilevel, 1, s1=res, forward=-1)
+        END IF
+
+        DO i = 1, nmygridslvl(ilevel)
+            igrid = mygridslvl(i, ilevel)
+            CALL get_mgdims(kk, jj, ii, igrid)
+
+            CALL dp%get_ptr(dp_p, igrid)
+            CALL res%get_ptr(res_p, igrid)
+
+            CALL sipue%get_ptr(ue, igrid)
+            CALL sipun%get_ptr(un, igrid)
+            CALL siput%get_ptr(ut, igrid)
+
+            IF (ityp == 2) THEN
+                CALL sipiter2_cl(kk, jj, ii, dp_p, res_p, ue, un, ut)
+            ELSE
+                CALL get_grid3_ifk_linear(mip_ptr, mip_hp_f, igrid)
+                CALL get_grid3_ifk_linear(idx_ptr, idx_hp_f, igrid)
+                CALL sipiter2_hp(kk, jj, ii, dp_p, res_p, ue, un, ut, &
+                    mip_ptr, idx_ptr)
+            END IF
+        END DO
+    END SUBROUTINE sip
 
 
     SUBROUTINE bfront(igrid, iface, ibocd, ctyp, f1, f2, f3, f4, timeph)

--- a/src/flow/sip_classic_mod.F90
+++ b/src/flow/sip_classic_mod.F90
@@ -10,16 +10,7 @@ MODULE sip_classic_mod
 
     LOGICAL :: is_init = .FALSE.
 
-    ! A-versions: simple versions not considering the BP field
-    ! B-versions: IB versions using the BP field
-    INTERFACE sipiter1
-        MODULE PROCEDURE :: sipiter1_A, sipiter1_B
-    END INTERFACE sipiter1
-
-    PUBLIC :: sip_classic_init, sip_classic_finish, sip_classic, &
-        sipiter0, sipiter1, sipiter2
-
-        ! sipiter{0,1,2} decleared public to avoid "unused fucntion" warnings
+    PUBLIC :: sip_classic_init, sip_classic_finish, sipiter1, sipiter2
 
 CONTAINS
 
@@ -149,122 +140,7 @@ CONTAINS
     END SUBROUTINE sip_classic_finish
 
 
-    SUBROUTINE sip_classic(ilevel, iloop, ninner, dp, res, rhs, &
-            siplw, sipls, siplb, siplpr, sipue, sipun, siput, bp)
-
-        ! Subroutine arguments
-        INTEGER(intk), INTENT(in) :: ilevel
-        INTEGER(intk), INTENT(in) :: iloop
-        INTEGER(intk), INTENT(in) :: ninner
-        TYPE(field_t), INTENT(inout) :: dp
-        TYPE(field_t), INTENT(inout) :: res
-        TYPE(field_t), INTENT(in) :: rhs
-        TYPE(field_t), INTENT(in) :: siplw
-        TYPE(field_t), INTENT(in) :: sipls
-        TYPE(field_t), INTENT(in) :: siplb
-        TYPE(field_t), INTENT(in) :: siplpr
-        TYPE(field_t), INTENT(in) :: sipue
-        TYPE(field_t), INTENT(in) :: sipun
-        TYPE(field_t), INTENT(in) :: siput
-        TYPE(field_t), INTENT(in), OPTIONAL :: bp
-
-        ! Local variables
-        INTEGER(intk) :: i, igrid
-        INTEGER(intk) :: kk, jj, ii
-        REAL(realk), POINTER, CONTIGUOUS :: lw(:, :, :), ls(:, :, :), &
-            lb(:, :, :), ue(:, :, :), un(:, :, :), ut(:, :, :), &
-            lpr(:, :, :)
-        REAL(realk), POINTER, CONTIGUOUS :: dp_p(:, :, :), res_p(:, :, :), &
-            rhs_p(:, :, :)
-
-        IF (.NOT. is_init) CALL errr(__FILE__, __LINE__)
-
-        CALL laplacephi_level(ilevel, res, dp, bp)
-
-        DO i = 1, nmygridslvl(ilevel)
-            igrid = mygridslvl(i, ilevel)
-            CALL get_mgdims(kk, jj, ii, igrid)
-
-            CALL res%get_ptr(res_p, igrid)
-            CALL rhs%get_ptr(rhs_p, igrid)
-
-            CALL siplw%get_ptr(lw, igrid)
-            CALL sipls%get_ptr(ls, igrid)
-            CALL siplb%get_ptr(lb, igrid)
-            CALL siplpr%get_ptr(lpr, igrid)
-
-            CALL sipiter1(kk, jj, ii, rhs_p, res_p, lw, ls, lb, lpr)
-            ! >>> corresponds to sipiter1_B
-        END DO
-
-        IF (iloop < ninner) THEN
-            CALL connect(ilevel, 1, s1=res)
-        ELSE
-            CALL connect(ilevel, 1, s1=res, forward=-1)
-        END IF
-
-        DO i = 1, nmygridslvl(ilevel)
-            igrid = mygridslvl(i, ilevel)
-            CALL get_mgdims(kk, jj, ii, igrid)
-
-            CALL dp%get_ptr(dp_p, igrid)
-            CALL res%get_ptr(res_p, igrid)
-
-            CALL sipue%get_ptr(ue, igrid)
-            CALL sipun%get_ptr(un, igrid)
-            CALL siput%get_ptr(ut, igrid)
-
-            CALL sipiter2(kk, jj, ii, dp_p, res_p, ue, un, ut)
-        END DO
-    END SUBROUTINE sip_classic
-
-
-    PURE SUBROUTINE sipiter0(kk, jj, ii, rhs, res, lpr)
-        ! Subroutine arguments
-        INTEGER(intk), INTENT(in) :: kk, jj, ii
-        REAL(realk), INTENT(in) :: rhs(kk, jj, ii)
-        REAL(realk), INTENT(inout) :: res(kk, jj, ii)
-        REAL(realk), INTENT(in) :: lpr(kk, jj, ii)
-
-        ! Local variables
-        INTEGER(intk) :: k, j, i
-
-        DO i = 3, ii-2
-            DO j = 3, jj-2
-                DO k = 3, kk-2
-                    res(k, j, i) = (rhs(k, j, i) + res(k, j, i))*lpr(k, j, i)
-                END DO
-            END DO
-        END DO
-    END SUBROUTINE sipiter0
-
-
-    PURE SUBROUTINE sipiter1_A(kk, jj, ii, rhs, res, lw, ls, lb)
-        ! Subroutine arguments
-        INTEGER(intk), INTENT(in) :: kk, jj, ii
-        REAL(realk), INTENT(inout) :: res(kk, jj, ii)
-        REAL(realk), INTENT(in) :: rhs(kk, jj, ii)
-        REAL(realk), INTENT(in) :: lw(kk, jj, ii), ls(kk, jj, ii), &
-            lb(kk, jj, ii)
-
-        ! Local variables
-        INTEGER(intk) :: k, j, i
-
-        DO i = 3, ii-2
-            DO j = 3, jj-2
-                DO k = 3, kk-2
-                    res(k, j, i) = res(k, j, i) - lw(k, j, i)*res(k, j, i-1) &
-                        - ls(k, j, i)*res(k, j-1, i)
-                END DO
-                DO k = 3, kk-2
-                    res(k, j, i) = res(k, j, i) - lb(k, j, i)*res(k-1, j, i)
-                END DO
-            END DO
-        END DO
-    END SUBROUTINE sipiter1_A
-
-
-    PURE SUBROUTINE sipiter1_B(kk, jj, ii, rhs, res, lw, ls, lb, lpr)
+    PURE SUBROUTINE sipiter1(kk, jj, ii, rhs, res, lw, ls, lb, lpr)
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: kk, jj, ii
         REAL(realk), INTENT(inout) :: res(kk, jj, ii)
@@ -287,7 +163,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-    END SUBROUTINE sipiter1_B
+    END SUBROUTINE sipiter1
 
 
     PURE SUBROUTINE sipiter2(kk, jj, ii, phi, res, ue, un, ut)

--- a/src/flow/sip_hyperplane_mod.F90
+++ b/src/flow/sip_hyperplane_mod.F90
@@ -5,7 +5,6 @@ MODULE sip_hyperplane_mod
     USE, INTRINSIC :: ieee_arithmetic
 
     USE core_mod
-    USE get_grid_mod
     USE laplacephi_mod
 
     IMPLICIT NONE(type, external)
@@ -15,7 +14,8 @@ MODULE sip_hyperplane_mod
     TYPE(intfield_t), PROTECTED, TARGET :: mip_hp_f
     TYPE(intfield_t), PROTECTED, TARGET :: idx_hp_f
 
-    PUBLIC :: sip_hyperplane_init, sip_hyperplane_finish, sip_hyperplane
+    PUBLIC :: sip_hyperplane_init, sip_hyperplane_finish, &
+        sipiter1, sipiter2, mip_hp_f, idx_hp_f
 
 CONTAINS
 
@@ -454,93 +454,6 @@ CONTAINS
         DEALLOCATE(test)
 
     END SUBROUTINE sip_hyperplane_check_grid
-
-
-    SUBROUTINE sip_hyperplane(ilevel, iloop, ninner, dp, res, rhs, &
-            lw_hp_f, ls_hp_f, lb_hp_f, lpr_hp_f, ue_hp_f, un_hp_f, ut_hp_f, bp)
-
-        ! Subroutine arguments
-        INTEGER(intk), INTENT(in) :: ilevel
-        INTEGER(intk), INTENT(in) :: iloop
-        INTEGER(intk), INTENT(in) :: ninner
-        TYPE(field_t), INTENT(inout) :: dp
-        TYPE(field_t), INTENT(inout) :: res
-        TYPE(field_t), INTENT(in) :: rhs
-        TYPE(field_t), INTENT(in) :: lw_hp_f
-        TYPE(field_t), INTENT(in) :: ls_hp_f
-        TYPE(field_t), INTENT(in) :: lb_hp_f
-        TYPE(field_t), INTENT(in) :: lpr_hp_f
-        TYPE(field_t), INTENT(in) :: ue_hp_f
-        TYPE(field_t), INTENT(in) :: un_hp_f
-        TYPE(field_t), INTENT(in) :: ut_hp_f
-        TYPE(field_t), INTENT(in), OPTIONAL :: bp
-
-        ! Local variables
-        INTEGER(intk) :: i, il, igrid
-        INTEGER(intk) :: kk, jj, ii
-        REAL(realk), POINTER, CONTIGUOUS :: dp_1d_p(:), res_1d_p(:), &
-            rhs_1d_p(:)
-
-        INTEGER(ifk), CONTIGUOUS, POINTER :: mip_ptr(:), idx_ptr(:)
-
-        REAL(realk), POINTER, CONTIGUOUS :: lw_hp(:), ls_hp(:), lb_hp(:), &
-            lpr_hp(:), ue_hp(:), un_hp(:), ut_hp(:)
-
-
-        CALL laplacephi_level(ilevel, res, dp, bp)
-
-        DO il = 1, nmygridslvl(ilevel)
-
-            igrid = mygridslvl(il, ilevel)
-            CALL get_imygrid(i, igrid)
-            CALL get_mgdims(kk, jj, ii, igrid)
-
-            ! Getting the arrays is 1D pointers
-            CALL get_grid3_real_linear(res_1d_p, res, igrid)
-            CALL get_grid3_real_linear(rhs_1d_p, rhs, igrid)
-
-            CALL get_grid3_real_linear(lw_hp, lw_hp_f, igrid)
-            CALL get_grid3_real_linear(ls_hp, ls_hp_f, igrid)
-            CALL get_grid3_real_linear(lb_hp, lb_hp_f, igrid)
-            CALL get_grid3_real_linear(lpr_hp, lpr_hp_f, igrid)
-
-            CALL get_grid3_ifk_linear(mip_ptr, mip_hp_f, igrid)
-            CALL get_grid3_ifk_linear(idx_ptr, idx_hp_f, igrid)
-
-            CALL sipiter1(kk, jj, ii, rhs_1d_p, res_1d_p, &
-                lw_hp, ls_hp, lb_hp, lpr_hp, mip_ptr, idx_ptr)
-        END DO
-
-        IF (iloop < ninner) THEN
-            CALL connect(ilevel, 1, s1=res)
-        ELSE
-            CALL connect(ilevel, 1, s1=res, forward=-1)
-        END IF
-
-        DO il = 1, nmygridslvl(ilevel)
-
-            igrid = mygridslvl(il, ilevel)
-            CALL get_imygrid(i, igrid)
-            CALL get_mgdims(kk, jj, ii, igrid)
-
-            ! Getting the arrays is 1D pointers
-            CALL get_grid3_real_linear(dp_1d_p, dp, igrid)
-            CALL get_grid3_real_linear(res_1d_p, res, igrid)
-
-            CALL get_grid3_real_linear(ue_hp, ue_hp_f, igrid)
-            CALL get_grid3_real_linear(un_hp, un_hp_f, igrid)
-            CALL get_grid3_real_linear(ut_hp, ut_hp_f, igrid)
-
-            CALL get_grid3_ifk_linear(mip_ptr, mip_hp_f, igrid)
-            CALL get_grid3_ifk_linear(idx_ptr, idx_hp_f, igrid)
-
-            CALL sipiter2(kk, jj, ii, dp_1d_p, res_1d_p, &
-                ue_hp, un_hp, ut_hp, mip_ptr, idx_ptr)
-
-        END DO
-
-    END SUBROUTINE sip_hyperplane
-
 
 
     SUBROUTINE sipiter1(kk, jj, ii, rhs, res, lw, ls, lb, lpr, mip, idxsip)


### PR DESCRIPTION
The important thing here was to restore the single sip routine in pressuresolver_mod.F90, significantly simplifying the code and reducing the code lines. This becomes particularly important when looking on the ng implementation.

Exactly how this will look like when offloaded is not considered atm. Details can always be adapted later on.