### PR TITLE
Fix Read Feature for Updated Buffer Initialization

### DIFF
--- a/src/flow/flow_mod.F90
+++ b/src/flow/flow_mod.F90
@@ -143,34 +143,32 @@ CONTAINS
             CALL setboundarybuffers%bound(ilevel, u, v, w, timeph=0.0_realk)
         END DO
 
-        ! The rest of this routine is initializing the flow field - we do not
-        ! want to overwrite results read from a restart file
-        IF (dread) RETURN
-
         ! Set initial condition
-        IF (uinf_is_expr) THEN
-            CALL init_uvw_expr(u, v, w)
-        ELSE
-            CALL init_uvw_uinf(u, v, w)
+        IF (.NOT. dread) THEN
+            IF (uinf_is_expr) THEN
+                CALL init_uvw_expr(u, v, w)
+            ELSE
+                CALL init_uvw_uinf(u, v, w)
+            END IF
+            p%arr = 0.0_realk
         END IF
-        p%arr = 0.0_realk
 
         CALL zero_ghostlayers(u)
         CALL zero_ghostlayers(v)
         CALL zero_ghostlayers(w)
 
         DO ilevel = minlevel, maxlevel
-            CALL connect(ilevel, 2, u, v, w, p, corners=.TRUE.)
-        END DO
-
-        DO ilevel = minlevel+1, maxlevel
             CALL parent(ilevel, u, v, w, p)
             CALL bound_flow%bound(ilevel, u, v, w, p)
+            CALL connect(ilevel, 2, v1=u, v2=v, v3=w, s1=p, corners=.TRUE.)
         END DO
 
         DO ilevel = maxlevel, minlevel+1, -1
             CALL ftoc(ilevel, u, v, w, p)
         END DO
+
+        ! connect after ftoc (minlevel:maxlevel-1 would be enough)
+        CALL connect(layers=2, v1=u, v2=v, v3=w, s1=p, corners=.TRUE.)
     END SUBROUTINE init_uvwp
 
 

--- a/tests/sphere/parameters-1.json
+++ b/tests/sphere/parameters-1.json
@@ -1,17 +1,16 @@
 {
     "time": {
-        "mtstep": 200,
+        "mtstep": 100,
         "dt": 0.05,
         "itinfo": 10,
         "tstat": 5.0,
         "read": false,
         "write": true,
-        "continue": true
+        "continue": false
     },
     "io": {
         "grids": "grids.h5",
-        "infile": "fields.h5",
-        "outfile": "fields.h5"
+        "outfile": "fields-checkpoint.h5"
     },
     "ib": {
         "type": "ghostcell",

--- a/tests/sphere/parameters-2.json
+++ b/tests/sphere/parameters-2.json
@@ -1,0 +1,113 @@
+{
+    "time": {
+        "mtstep": 100,
+        "dt": 0.05,
+        "itinfo": 10,
+        "tstat": 5.0,
+        "read": true,
+        "write": true,
+        "continue": true
+    },
+    "io": {
+        "grids": "grids.h5",
+        "infile": "fields-checkpoint.h5",
+        "outfile": "fields.h5"
+    },
+    "ib": {
+        "type": "ghostcell",
+        "stencilfile": "ib_stencils.h5",
+        "blocking": "newblock",
+        "fluidpoints": [
+            [-0.8, 0.0, 0.0],
+            [5.0, 0.0, 0.0]
+        ],
+        "nofluidpoints": [
+            [0.0, 0.0, 0.0],
+            [0.3, 0.0, 0.0],
+            [-0.3, 0.0, 0.0]
+        ],
+        "geometries": [
+            {
+                "file": "sphere.stl",
+                "velocity": [0.0, 0.0, 0.0]
+            }
+        ]
+    },
+    "flow": {
+        "gmol": 0.001,
+        "rho": 1.0,
+        "tu_level": 0.01,
+        "uinf": [1.0, 0.0, 0.0],
+        "gradp": [0.0, 0.0, 0.0],
+        "pressuresolver": {
+            "type": "sip",
+            "epcorr": 0.0002,
+            "nouter_min": 2,
+            "nouter": 9,
+            "ninner": 5,
+            "omega": 1.1,
+            "loglevel": 3
+        },
+        "lesmodel": {
+            "model": "smagorinsky"
+        },
+        "compbodyforce": true
+    },
+    "probes": {
+        "itsamp": 1,
+        "tstart": 2.5,
+        "arrays": [
+            {
+                "name": "line1",
+                "variables": ["U", "P"],
+                "positions": "line1.dat"
+            },
+            {
+                "name": "ring1",
+                "variables": ["U", "V", "W", "P"],
+                "positions": "ring1.dat"
+            },
+            {
+                "name": "ring2",
+                "variables": ["U", "V", "W", "P"],
+                "positions": "ring2.dat"
+            },
+            {
+                "name": "ring3",
+                "variables": ["U", "V", "W", "P"],
+                "positions": "ring3.dat"
+            },
+            {
+                "name": "inlet",
+                "variables": ["P"],
+                "positions": [
+                    [-1.99, 0.0, 0.0],
+                    [-1.99, 0.0, 0.5],
+                    [-1.99, 0.5, 0.5],
+                    [-1.99, 0.5, 0.0],
+                    [-1.99, 0.5, -0.5],
+                    [-1.99, 0.0, -0.5],
+                    [-1.99, -0.5, -0.5],
+                    [-1.99, -0.5, 0.0],
+                    [-1.99, -0.5, 0.5]
+                ]
+            }
+        ]
+    },
+
+    "uvwbulk": true,
+
+    "statistics": [
+        "U_AVG",
+        "UU_AVG",
+        "UV_AVG",
+        "laplaceP_AVG",
+        "laplaceP_SQR_AVG"
+    ],
+
+    "snapshots": {
+        "itsamp": 50,
+        "tstart": 8.0,
+        "fields": ["U", "V", "W", "P"]
+    }
+}

--- a/tests/sphere/run.sh
+++ b/tests/sphere/run.sh
@@ -7,9 +7,10 @@ ACTION=$1
 
 if [[ "$ACTION" == "test" ]]; then
     MGLET_BIN=$2
-    mpirun -n 1 $MGLET_BIN 2>&1 | tee mglet.OUT
+    mpirun -n 1 $MGLET_BIN parameters-1.json 2>&1 | tee mglet.OUT
+    mpirun -n 1 $MGLET_BIN parameters-2.json 2>&1 | tee mglet.OUT
 elif [[ "$ACTION" == "clean" ]]; then
-    rm -rf LOGS fields.h5 ib_stencils.h5 probes.h5 snapshots.h5 mglet-perf-report.txt *.OUT
+    rm -rf LOGS fields-checkpoint.h5 fields.h5 ib_stencils.h5 probes.h5 snapshots.h5 mglet-perf-report.txt *.OUT
 else
     echo "Invalid action: $ACTION"
     exit 1


### PR DESCRIPTION
The `read` feature in `parameters.json` is not working correctly since [commit `970159e6f5fd8aeb84c3ea0d21cb48c80b67a680`.](https://github.com/kmturbulenz/mglet-base/commit/970159e6f5fd8aeb84c3ea0d21cb48c80b67a680). The simulation explodes on the first time step after reading fields from disk.

The fix concerns the logic about what is actually initialized in the `dread` branch of the code. With the commit mentioned above, buffers are no longer default initialized to zero (see the debug code that sets the buffers to `NaN` explicitly). This change must be accounted for in the initialization of fields when read from disk.
