### PR TITLE
Add Field Pool to Avoid Frequent Reallocations of 3D Fields

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(core STATIC
     exprtk_wrapper.cxx
     fieldhelper_mod.F90
     fieldio2_mod.F90
+    fieldpool_mod.F90
     field_t/basefield_mod.F90
     field_t/field_mod.F90
     field_t/fieldmapper_mod.F90

--- a/src/core/core_mod.F90
+++ b/src/core/core_mod.F90
@@ -16,6 +16,7 @@ MODULE core_mod
     USE fieldio2_mod
     USE field_mod
     USE fieldhelper_mod
+    USE fieldpool_mod
     USE fields_mod
     USE fort7_mod
     USE grids_mod
@@ -115,6 +116,7 @@ CONTAINS
         CALL init_pointers()
         CALL init_commbuf()
         CALL init_fields()
+        CALL init_fieldpool()
         CALL init_corefields()
         CALL init_connect2()
 
@@ -135,6 +137,7 @@ CONTAINS
 
         CALL finish_connect2()
         CALL finish_corefields()
+        CALL finish_fieldpool()
         CALL finish_fields()
         CALL finish_commbuf()
         CALL finish_pointers()

--- a/src/core/field_t/fieldmapper_mod.F90
+++ b/src/core/field_t/fieldmapper_mod.F90
@@ -1,10 +1,10 @@
 MODULE fieldmapper_mod
-    USE realfield_mod, ONLY: field_t
+    USE field_mod, ONLY: field_t, intfield_t
 
     IMPLICIT NONE(type, external)
     ! Not PRIVATE'ized
 
-    PRIVATE :: field_t
+    PRIVATE :: field_t, intfield_t
 
     ! Use this module directly. Mapper declarations are not visible through
     ! transitive use statements if any intermediate module is PRIVATE'ized.
@@ -12,6 +12,7 @@ MODULE fieldmapper_mod
     !$omp declare mapper(field_t :: t) map(t%arr, t%buffers, t%ptr, t%length)
     !$omp declare mapper(field_t__map_arr: field_t :: t) map(t%arr)
     !$omp declare mapper(field_t__map_buffers: field_t :: t) map(t%buffers)
-    !$omp declare mapper(field_t__map_deferred: field_t :: t) &
-    !$omp& map(alloc: t%arr, t%buffers) map(to: t%ptr, t%length)
+
+    !$omp declare mapper(intfield_t :: t) map(t%arr, t%ptr, t%length)
+    !$omp declare mapper(intfield_t__map_arr: intfield_t :: t) map(t%arr)
 END MODULE fieldmapper_mod

--- a/src/core/field_t/intfield_mod.F90
+++ b/src/core/field_t/intfield_mod.F90
@@ -23,7 +23,7 @@ MODULE intfield_mod
 
 CONTAINS
     SUBROUTINE init(this, name, description, ndim, istag, jstag, kstag, &
-            units, dread, required, dwrite, active_level, get_len)
+            units, dread, required, dwrite, active_level, get_len, zero)
         ! Subroutine arguments
         CLASS(intfield_t), INTENT(out) :: this
         CHARACTER(len=*), INTENT(in) :: name
@@ -38,9 +38,10 @@ CONTAINS
         LOGICAL, INTENT(in), OPTIONAL :: dwrite
         LOGICAL, INTENT(in), OPTIONAL :: active_level(:)
         PROCEDURE(get_len_i), OPTIONAL :: get_len
+        LOGICAL, INTENT(in), OPTIONAL :: zero
 
         ! Local variables
-        ! none...
+        LOGICAL :: zero2
 
         CALL this%init_corefield(name, description, ndim, istag, jstag, kstag, &
             units, dread, required, dwrite, active_level, get_len)
@@ -48,8 +49,16 @@ CONTAINS
         this%hdf5_dtype = mglet_hdf5_ifk
         this%mpi_dtype = mglet_mpi_ifk
 
+        IF (PRESENT(zero)) THEN
+            zero2 = zero
+        ELSE
+            zero2 = .TRUE.
+        END IF
+
         ALLOCATE(this%arr(this%idim))
-        this%arr = 0.0
+        IF (zero2) THEN
+            this%arr = 0_ifk
+        END IF
     END SUBROUTINE init
 
 

--- a/src/core/field_t/realfield_mod.F90
+++ b/src/core/field_t/realfield_mod.F90
@@ -34,7 +34,7 @@ MODULE realfield_mod
 
 CONTAINS
     SUBROUTINE init(this, name, description, ndim, istag, jstag, kstag, &
-            units, dread, required, dwrite, active_level, get_len)
+            units, dread, required, dwrite, active_level, get_len, zero)
         ! Subroutine arguments
         CLASS(field_t), INTENT(out) :: this
         CHARACTER(len=*), INTENT(in) :: name
@@ -49,9 +49,10 @@ CONTAINS
         LOGICAL, INTENT(in), OPTIONAL :: dwrite
         LOGICAL, INTENT(in), OPTIONAL :: active_level(:)
         PROCEDURE(get_len_i), OPTIONAL :: get_len
+        LOGICAL, INTENT(in), OPTIONAL :: zero
 
         ! Local variables
-        ! none...
+        LOGICAL :: zero2
 
         CALL this%init_corefield(name, description, ndim, istag, jstag, kstag, &
             units, dread, required, dwrite, active_level, get_len)
@@ -59,8 +60,16 @@ CONTAINS
         this%hdf5_dtype = mglet_hdf5_real
         this%mpi_dtype = mglet_mpi_real
 
+        IF (PRESENT(zero)) THEN
+            zero2 = zero
+        ELSE
+            zero2 = .TRUE.
+        END IF
+
         ALLOCATE(this%arr(this%idim))
-        this%arr = 0.0
+        IF (zero2) THEN
+            this%arr = 0.0_realk
+        END IF
     END SUBROUTINE init
 
 

--- a/src/core/fieldpool_mod.F90
+++ b/src/core/fieldpool_mod.F90
@@ -1,0 +1,271 @@
+MODULE fieldpool_mod
+    USE precision_mod
+    USE err_mod, ONLY: errr
+    USE field_mod, ONLY: basefield_t, field_t, intfield_t, nchar_name
+    USE fieldhelper_mod, ONLY: set_field_arr
+
+    IMPLICIT NONE(type, external)
+    PRIVATE
+
+    INTEGER(intk), PARAMETER :: max_realfields = 16
+    INTEGER(intk), PARAMETER :: max_intfields = 16
+
+    TYPE(field_t), TARGET :: realfields(max_realfields)
+    TYPE(intfield_t), TARGET :: intfields(max_intfields)
+
+    ! stackptr always points to the next free slot
+    INTEGER(intk) :: stackptr_real = 1
+    INTEGER(intk) :: stackptr_int = 1
+
+    INTERFACE push_field
+        MODULE PROCEDURE :: push_realfield
+        MODULE PROCEDURE :: push_intfield
+    END INTERFACE push_field
+
+    INTERFACE pop_field
+        MODULE PROCEDURE :: pop_realfield
+        MODULE PROCEDURE :: pop_intfield
+    END INTERFACE pop_field
+
+    PUBLIC :: push_field, pop_field, init_fieldpool, finish_fieldpool
+CONTAINS
+    SUBROUTINE init_fieldpool()
+        CONTINUE
+    END SUBROUTINE init_fieldpool
+
+
+    SUBROUTINE finish_fieldpool()
+        USE fieldmapper_mod
+        ! Subroutine arguments
+        ! none...
+
+        ! Local variables
+        INTEGER(intk) :: i
+
+        IF (stackptr_real > 1) THEN
+            WRITE(*, *) "Stack for realfields is not empty when finishing"
+            WRITE(*, *) "Top of stack: ", TRIM(realfields(stackptr_real-1)%name)
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        IF (stackptr_int > 1) THEN
+            WRITE(*, *) "Stack for intfields is not empty when finishing"
+            WRITE(*, *) "Top of stack: ", TRIM(intfields(stackptr_int-1)%name)
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        DO i = 1, max_realfields
+            IF (realfields(i)%is_init) THEN
+                !$omp target exit data map(mapper(default), &
+                !$omp& delete: realfields(i))
+                CALL realfields(i)%finish()
+            END IF
+        END DO
+        stackptr_real = 1
+
+        DO i = 1, max_intfields
+            IF (intfields(i)%is_init) THEN
+                !$omp target exit data map(mapper(default), &
+                !$omp& delete: intfields(i))
+                CALL intfields(i)%finish()
+            END IF
+        END DO
+        stackptr_int = 1
+    END SUBROUTINE finish_fieldpool
+
+
+    SUBROUTINE push_realfield(field, name, istag, jstag, kstag, units, zero)
+        USE fieldmapper_mod
+        ! Subroutine arguments
+        TYPE(field_t), INTENT(out), POINTER :: field
+        CHARACTER(len=*), INTENT(in) :: name
+        INTEGER(intk), INTENT(in), OPTIONAL :: istag, jstag, kstag
+        INTEGER(intk), INTENT(in), OPTIONAL :: units(7)
+        LOGICAL, INTENT(in), OPTIONAL :: zero
+
+        ! Local variables
+        LOGICAL :: zero2, did_init
+
+        IF (PRESENT(zero)) THEN
+            zero2 = zero
+        ELSE
+            zero2 = .TRUE.
+        END IF
+
+        IF (stackptr_real > max_realfields) THEN
+            WRITE(*, *) "Exceeded maximum number of realfields in fieldpool."
+            WRITE(*, *) "Maximum limit is: ", max_realfields
+            WRITE(*, *) "Stack pointer: ", stackptr_real
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        field => realfields(stackptr_real)
+
+        did_init = .FALSE.
+        IF (.NOT. field%is_init) THEN
+            CALL field%init(name=name, istag=istag, jstag=jstag, kstag=kstag, &
+                units=units, zero=zero2)
+            CALL field%init_buffers()
+            !$omp target enter data map(mapper(default), &
+            !$omp& to: realfields(stackptr_real))
+            did_init = .TRUE.
+        ELSE
+            CALL set_field_properties(field, name, istag, jstag, kstag, units)
+        END IF
+
+        IF (zero2 .AND. .NOT. did_init) THEN
+            ! TODO(offload): Once larger portions of the code are ported,
+            ! remove the device=.FALSE. setter and preprocessor ifdef.
+            ! Currently, we can not generalize whether all fields in the
+            ! fieldpool are only required on the device and are thus required
+            ! to set both host and device buffers to zero.
+#ifdef _MGLET_OFFLOAD_
+            CALL set_field_arr(field, 0.0_realk, device=.TRUE.)
+#endif
+            CALL set_field_arr(field, 0.0_realk, device=.FALSE.)
+        END IF
+
+        stackptr_real = stackptr_real+1
+    END SUBROUTINE push_realfield
+
+
+    SUBROUTINE push_intfield(field, name, istag, jstag, kstag, units, zero)
+        USE fieldmapper_mod
+        ! Subroutine arguments
+        TYPE(intfield_t), INTENT(out), POINTER :: field
+        CHARACTER(len=*), INTENT(in) :: name
+        INTEGER(intk), INTENT(in), OPTIONAL :: istag, jstag, kstag
+        INTEGER(intk), INTENT(in), OPTIONAL :: units(7)
+        LOGICAL, INTENT(in), OPTIONAL :: zero
+
+        ! Local variables
+        LOGICAL :: zero2, did_init
+
+        IF (PRESENT(zero)) THEN
+            zero2 = zero
+        ELSE
+            zero2 = .TRUE.
+        END IF
+
+        IF (stackptr_int > max_intfields) THEN
+            WRITE(*, *) "Exceeded maximum number of intfields in fieldpool."
+            WRITE(*, *) "Maximum limit is: ", max_intfields
+            WRITE(*, *) "Stack pointer: ", stackptr_int
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        field => intfields(stackptr_int)
+
+        did_init = .FALSE.
+        IF (.NOT. field%is_init) THEN
+            CALL field%init(name=name, istag=istag, jstag=jstag, kstag=kstag, &
+                units=units, zero=zero2)
+            !$omp target enter data map(mapper(default), &
+            !$omp& to: intfields(stackptr_int))
+            did_init = .TRUE.
+        ELSE
+            CALL set_field_properties(field, name, istag, jstag, kstag, units)
+        END IF
+
+        IF (zero2 .AND. .NOT. did_init) THEN
+            ! TODO(offload): Once larger portions of the code are ported,
+            ! remove the device=.FALSE. setter and preprocessor ifdef.
+            ! Currently, we can not generalize whether all fields in the
+            ! fieldpool are only required on the device and are thus required
+            ! to set both host and device buffers to zero.
+#ifdef _MGLET_OFFLOAD_
+            CALL set_field_arr(field, 0_ifk, device=.TRUE.)
+#endif
+            CALL set_field_arr(field, 0_ifk, device=.FALSE.)
+        END IF
+
+        stackptr_int = stackptr_int+1
+    END SUBROUTINE push_intfield
+
+
+    SUBROUTINE pop_realfield(field)
+        ! Subroutine arguments
+        TYPE(field_t), INTENT(inout), POINTER :: field
+
+        ! Local variables
+        ! none...
+
+        IF (stackptr_real <= 1) THEN
+            WRITE(*, *) "Attempting to pop from empty realfield stack."
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        IF (.NOT. ASSOCIATED(field, realfields(stackptr_real-1))) THEN
+            WRITE(*, *) "Attempting to pop field that is not on top of stack"
+            WRITE(*, *) "or unassociated."
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        stackptr_real = stackptr_real - 1
+        CALL set_field_properties(field, "UNASSOCIATED")
+        NULLIFY(field)
+    END SUBROUTINE pop_realfield
+
+
+    SUBROUTINE pop_intfield(field)
+        ! Subroutine arguments
+        TYPE(intfield_t), INTENT(inout), POINTER :: field
+
+        ! Local variables
+        ! none...
+
+        IF (stackptr_int <= 1) THEN
+            WRITE(*, *) "Attempting to pop from empty intfield stack."
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        IF (.NOT. ASSOCIATED(field, intfields(stackptr_int-1))) THEN
+            WRITE(*, *) "Attempting to pop field that is not on top of stack"
+            WRITE(*, *) "or unassociated."
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        stackptr_int = stackptr_int - 1
+        CALL set_field_properties(field, "UNASSOCIATED")
+        NULLIFY(field)
+    END SUBROUTINE pop_intfield
+
+
+    SUBROUTINE set_field_properties(field, name, istag, jstag, kstag, units)
+        ! Subroutine arguments
+        CLASS(basefield_t), INTENT(inout) :: field
+        CHARACTER(len=*), INTENT(in) :: name
+        INTEGER(intk), INTENT(in), OPTIONAL :: istag, jstag, kstag
+        INTEGER(intk), INTENT(in), OPTIONAL :: units(7)
+
+        ! Local variables
+        ! none...
+
+        IF (LEN_TRIM(name) > nchar_name) CALL errr(__FILE__, __LINE__)
+        field%name = name
+
+        IF (PRESENT(istag)) THEN
+            field%istag = istag
+        ELSE
+            field%istag = 0
+        END IF
+
+        IF (PRESENT(jstag)) THEN
+            field%jstag = jstag
+        ELSE
+            field%jstag = 0
+        END IF
+
+        IF (PRESENT(kstag)) THEN
+            field%kstag = kstag
+        ELSE
+            field%kstag = 0
+        END IF
+
+        IF (PRESENT(units)) THEN
+            field%units = units
+        ELSE
+            field%units = 0
+        END IF
+    END SUBROUTINE set_field_properties
+END MODULE fieldpool_mod

--- a/src/flow/flowstat_mod.F90
+++ b/src/flow/flowstat_mod.F90
@@ -551,7 +551,7 @@ CONTAINS
         REAL(realk), INTENT(in) :: dt
 
         ! Local variables
-        TYPE(field_t) :: ux_f
+        TYPE(field_t), POINTER :: ux_f
         INTEGER(intk), PARAMETER :: units(*) = [1, -1, -3, 0, 0, 0, 0]
         INTEGER(intk), PARAMETER :: units_ux(*) = [0, 0, -1, 0, 0, 0, 0]
         TYPE(field_t), POINTER :: u_f, p_f
@@ -590,13 +590,13 @@ CONTAINS
 
         CALL field%init(name, istag=istag, jstag=jstag, kstag=kstag, &
             units=units)
-        CALL ux_f%init(name_ux, istag=istag, jstag=jstag, kstag=kstag, &
-            units=units_ux)
+        CALL push_field(ux_f, name_ux, istag=istag, jstag=jstag, &
+            kstag=kstag, units=units_ux)
 
         CALL differentiate(ux_f, u_f, ivar)
 
         CALL field%multiply(ux_f, p_f)
-        CALL ux_f%finish()
+        CALL pop_field(ux_f)
     END SUBROUTINE comp_uxp_avg
 
 
@@ -607,7 +607,7 @@ CONTAINS
         REAL(realk), INTENT(in) :: dt
 
         ! Local variables
-        TYPE(field_t) :: ux_f  ! It can represent any velocity component
+        TYPE(field_t), POINTER :: ux_f  ! Can represent any velocity component
         INTEGER(intk), PARAMETER :: units(*) = [0, 0, -2, 0, 0, 0, 0]
         INTEGER(intk), PARAMETER :: units_ux(*) = [0, 0, -1, 0, 0, 0, 0]
         TYPE(field_t), POINTER :: u_f
@@ -685,12 +685,12 @@ CONTAINS
 
         CALL field%init(name, istag=istag, jstag=jstag, kstag=kstag, &
             units=units)
-        CALL ux_f%init(name_ux, istag=istag, jstag=jstag, kstag=kstag, &
-            units=units_ux)
+        CALL push_field(ux_f, name_ux, istag=istag, jstag=jstag, &
+            kstag=kstag, units=units_ux)
         CALL differentiate(ux_f, u_f, ivar)
 
         field%arr = ux_f%arr**2
-        CALL ux_f%finish()
+        CALL pop_field(ux_f)
     END SUBROUTINE comp_uxux_avg
 
 
@@ -701,7 +701,7 @@ CONTAINS
         REAL(realk), INTENT(in) :: dt
 
         ! Local Variables
-        TYPE(field_t) :: ux_f, vx_f
+        TYPE(field_t), POINTER :: ux_f, vx_f
         INTEGER(intk), PARAMETER :: units(*) = [0, 0, -2, 0, 0, 0, 0]
         INTEGER(intk), PARAMETER :: units_ux(*) = [0, 0, -1, 0, 0, 0, 0]
         ! v_f can be any velocity component different than u_f
@@ -811,10 +811,10 @@ CONTAINS
 
         CALL field%init(name, istag=istag, jstag=jstag, kstag=kstag, &
             units=units)
-        CALL ux_f%init(name_ux, istag=istag, jstag=jstag, kstag=kstag, &
-            units=units_ux)
-        CALL vx_f%init(name_vx, istag=istag, jstag=jstag, kstag=kstag, &
-            units=units_ux)
+        CALL push_field(ux_f, name_ux, istag=istag, jstag=jstag, &
+            kstag=kstag, units=units_ux)
+        CALL push_field(vx_f, name_vx, istag=istag, jstag=jstag, &
+            kstag=kstag, units=units_ux)
 
         CALL differentiate(ux_f, u_f, ivar1)
         CALL differentiate(vx_f, v_f, ivar2)
@@ -824,8 +824,8 @@ CONTAINS
         ! TO DO: if location is not the same multiply method should be used.
 
         field%arr = ux_f%arr * vx_f%arr
-        CALL ux_f%finish()
-        CALL vx_f%finish()
+        CALL pop_field(vx_f)
+        CALL pop_field(ux_f)
     END SUBROUTINE comp_uxvx_avg
 
 
@@ -836,7 +836,7 @@ CONTAINS
         REAL(realk), INTENT(in) :: dt
 
         ! Local Variables
-        TYPE(field_t) :: uy_f, vx_f, temp_f
+        TYPE(field_t), POINTER :: uy_f, vx_f, temp_f
         INTEGER(intk), PARAMETER :: units(*) = [0, 0, -2, 0, 0, 0, 0]
         INTEGER(intk), PARAMETER :: units_ux(*) = [0, 0, -1, 0, 0, 0, 0]
         TYPE(field_t), POINTER :: u_f, v_f, p_f
@@ -881,12 +881,12 @@ CONTAINS
 
         CALL field%init(name, istag=istag, jstag=jstag, kstag=kstag, &
             units=units)
-        CALL uy_f%init(name_uy, istag=istag, jstag=jstag, kstag=kstag, &
-            units=units_ux)
-        CALL vx_f%init(name_vx, istag=istag, jstag=jstag, kstag=kstag, &
-            units=units_ux)
-        CALL temp_f%init('tmp', istag=istag, jstag=jstag, kstag=kstag, &
-            units=units_ux)
+        CALL push_field(uy_f, name_uy, istag=istag, jstag=jstag, &
+            kstag=kstag, units=units_ux)
+        CALL push_field(vx_f, name_vx, istag=istag, jstag=jstag, &
+            kstag=kstag, units=units_ux)
+        CALL push_field(temp_f, 'tmp', istag=istag, jstag=jstag, &
+            kstag=kstag, units=units_ux)
 
         CALL differentiate(uy_f, u_f, ivar1)
         CALL differentiate(vx_f, v_f, ivar2)
@@ -895,9 +895,9 @@ CONTAINS
         CALL get_field(p_f, "P")
         CALL field%multiply(temp_f, p_f)
 
-        CALL uy_f%finish()
-        CALL vx_f%finish()
-        CALL temp_f%finish()
+        CALL pop_field(temp_f)
+        CALL pop_field(vx_f)
+        CALL pop_field(uy_f)
     END SUBROUTINE comp_uyvxp_avg
 
 END MODULE flowstat_mod

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -184,7 +184,7 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: irk
 
         ! Local variables
-        TYPE(field_t) :: dp, hilf, rhs, res
+        TYPE(field_t), POINTER :: dp, hilf, rhs, res
         TYPE(field_t), POINTER :: bp
         INTEGER(intk) :: ilevel, ipcount, ipc, i
         REAL(realk) :: prefak, maxrhs, maxrhsall
@@ -200,13 +200,10 @@ CONTAINS
         END IF
 
         ! All of these fields are initialized to zero automatically
-        CALL dp%init("DP")
-        CALL hilf%init("HILF")
-        CALL rhs%init("RHS")
-        CALL res%init("RES")
-
-        CALL dp%init_buffers()
-        CALL hilf%init_buffers()
+        CALL push_field(dp, "DP")
+        CALL push_field(hilf, "HILF")
+        CALL push_field(rhs, "RHS")
+        CALL push_field(res, "RES")
 
         ! laplace(dp) = prefak * div(u) is the underlying equation
         prefak = rho/dt
@@ -278,7 +275,7 @@ CONTAINS
             CALL maxabscal(maxrhs, maxrhslvl, rhs)
 
             ! dp = dp + hilf
-            dp%arr = dp%arr + hilf%arr
+            CALL accumulate_pcorr(dp, hilf)
             hilf%arr = 0.0
             ipc = ipc + ninner
 
@@ -347,10 +344,10 @@ CONTAINS
             CALL connect(ilevel, 2, v1=u, v2=v, v3=w, s1=p, corners=.TRUE.)
         END DO
 
-        CALL res%finish()
-        CALL rhs%finish()
-        CALL hilf%finish()
-        CALL dp%finish()
+        CALL pop_field(res)
+        CALL pop_field(rhs)
+        CALL pop_field(hilf)
+        CALL pop_field(dp)
 
         DEALLOCATE(maxrhslvl)
         CALL stop_timer(320)
@@ -1089,4 +1086,21 @@ CONTAINS
             END DO
         END IF
     END SUBROUTINE mgpcorr_grid
+
+
+    SUBROUTINE accumulate_pcorr(dp, hilf)
+        ! Subroutine arguments
+        TYPE(field_t), INTENT(inout) :: dp
+        TYPE(field_t), INTENT(in) :: hilf
+
+        ! Local variables
+        INTEGER(intk) :: i, n
+
+        ! Size of dp and hilf must match by nature of the previous operations
+        n = SIZE(dp%arr)
+
+        DO i = 1, n
+            dp%arr(i) = dp%arr(i) + hilf%arr(i)
+        END DO
+    END SUBROUTINE accumulate_pcorr
 END MODULE pressuresolver_mod

--- a/src/flow/timeintegration_mod.F90
+++ b/src/flow/timeintegration_mod.F90
@@ -33,8 +33,7 @@ CONTAINS
         INTEGER(intk) :: ilevel
         REAL(realk) :: frhs, fu, dtrk, dtrki, timerk
         TYPE(field_t), POINTER :: u, v, w, ut, vt, wt, pwu, pwv, pww, p, g
-        TYPE(field_t), POINTER :: du, dv, dw
-        TYPE(field_t) :: uo, vo, wo
+        TYPE(field_t), POINTER :: du, dv, dw, uo, vo, wo
 
         ! Just return if no flow is to be solved
         IF (.NOT. solve_flow) RETURN
@@ -56,9 +55,9 @@ CONTAINS
         CALL get_field(dv, "DV")
         CALL get_field(dw, "DW")
 
-        CALL uo%init("UO")
-        CALL vo%init("VO")
-        CALL wo%init("WO")
+        CALL push_field(uo, "UO")
+        CALL push_field(vo, "VO")
+        CALL push_field(wo, "WO")
 
         ! Transporting velocities for the convective terms
         ! Only CC use a different transporting velocity
@@ -135,6 +134,10 @@ CONTAINS
         END IF
 
         ! TODO: mgplevel
+
+        CALL pop_field(wo)
+        CALL pop_field(vo)
+        CALL pop_field(uo)
 
         CALL stop_timer(300)
     END SUBROUTINE timeintegrate_flow

--- a/src/ib/gc_blockbp_mod.F90
+++ b/src/ib/gc_blockbp_mod.F90
@@ -56,9 +56,9 @@ CONTAINS
         REAL(realk), ALLOCATABLE :: velocity(:, :)
 
         TYPE(field_t), POINTER :: bp, bu, bv, bw
-        TYPE(field_t) :: knoten
-        TYPE(field_t) :: au, av, aw
-        TYPE(field_t) :: kanteu, kantev, kantew
+        TYPE(field_t), POINTER :: knoten
+        TYPE(field_t), POINTER :: au, av, aw
+        TYPE(field_t), POINTER :: kanteu, kantev, kantew
 
         ! Read configuration etc.
         CALL this%init()
@@ -76,16 +76,16 @@ CONTAINS
         ALLOCATE(triaw(ntrimax*idim3d))
         ALLOCATE(bzelltyp(idim3d))
 
-        CALL kanteu%init("KANTEU", jstag=1, kstag=1)
-        CALL kantev%init("KANTEV", istag=1, kstag=1)
-        CALL kantew%init("KANTEW", istag=1, jstag=1)
+        CALL push_field(au, "AU", istag=1)
+        CALL push_field(av, "AV", jstag=1)
+        CALL push_field(aw, "AW", kstag=1)
 
-        CALL au%init("AU", istag=1)
-        CALL av%init("AV", jstag=1)
-        CALL aw%init("AW", kstag=1)
+        CALL push_field(kanteu, "KANTEU", jstag=1, kstag=1)
+        CALL push_field(kantev, "KANTEV", istag=1, kstag=1)
+        CALL push_field(kantew, "KANTEW", istag=1, jstag=1)
 
         ! Important with proper staggering for parent to work
-        CALL knoten%init("KNOTEN", istag=1, jstag=1, kstag=1)
+        CALL push_field(knoten, "KNOTEN", istag=1, jstag=1, kstag=1)
 
         IF (myid == 0) THEN
             WRITE (*, '("BLOCKING: ", A40, ", WTIME:", F16.3)') &
@@ -156,15 +156,15 @@ CONTAINS
         CALL bubvbw(bp, bu, bv, bw)
 
         IF (TRIM(this%blocking_type) == "checkblock") THEN
-            CALL knoten%finish()
+            CALL pop_field(knoten)
 
-            CALL au%finish()
-            CALL av%finish()
-            CALL aw%finish()
+            CALL pop_field(kantew)
+            CALL pop_field(kantev)
+            CALL pop_field(kanteu)
 
-            CALL kanteu%finish()
-            CALL kantev%finish()
-            CALL kantew%finish()
+            CALL pop_field(aw)
+            CALL pop_field(av)
+            CALL pop_field(au)
 
             DEALLOCATE(triau)
             DEALLOCATE(triav)
@@ -211,14 +211,15 @@ CONTAINS
             knoten, kanteu, kantev, kantew, bzelltyp, au, av, aw, icells, &
             icellspointer, ncells, bodyid, ucell, stencils, .TRUE.)
 
+        CALL pop_field(knoten)
+        CALL pop_field(kantew)
+        CALL pop_field(kantev)
+        CALL pop_field(kanteu)
+
         ! Deallocate fields that are no longer needed
-        CALL kanteu%finish()
-        CALL kantev%finish()
-        CALL kantew%finish()
         DEALLOCATE(triau)
         DEALLOCATE(triav)
         DEALLOCATE(triaw)
-        CALL knoten%finish()
 
         CALL stencils%set_stlnames(this%topol%geometries)
         CALL this%topol%finish()
@@ -243,9 +244,9 @@ CONTAINS
         DEALLOCATE(bodyid)
         DEALLOCATE(bzelltyp)
 
-        CALL au%finish()
-        CALL av%finish()
-        CALL aw%finish()
+        CALL pop_field(aw)
+        CALL pop_field(av)
+        CALL pop_field(au)
 
         IF (myid == 0) THEN
             WRITE (*, '("BLOCKING: ", A40, ", WTIME:", F16.3)') &
@@ -312,10 +313,9 @@ CONTAINS
         INTEGER(intk) :: ilevel, igrid, i, kk, jj, ii, ip3, ipp, ncells
         INTEGER(intk) :: nfro, nbac, nrgt, nlft, nbot, ntop
         REAL(realk), POINTER, CONTIGUOUS :: bodyid_3d(:, :, :)
-        TYPE(field_t) :: bodyid_3d_f
+        TYPE(field_t), POINTER :: bodyid_3d_f
 
-        CALL bodyid_3d_f%init("BODYID")
-        CALL bodyid_3d_f%init_buffers()
+        CALL push_field(bodyid_3d_f, "BODYID")
 
         ! Copy from list to 3D field
         DO ilevel = minlevel, maxlevel
@@ -376,7 +376,7 @@ CONTAINS
             END DO
         END DO
 
-        CALL bodyid_3d_f%finish()
+        CALL pop_field(bodyid_3d_f)
     END SUBROUTINE update_bodyid
 
 

--- a/src/ib/ib_mod.F90
+++ b/src/ib/ib_mod.F90
@@ -79,18 +79,18 @@ CONTAINS
 
         ! Local variables
         INTEGER(intk) :: ilevel
-        TYPE(field_t) :: hilf
+        TYPE(field_t), POINTER :: hilf
         TYPE(field_t), POINTER :: finecell
 
         CALL set_field("FINECELL")
         CALL get_field(finecell, "FINECELL")
         finecell%arr = 1.0
 
-        CALL hilf%init("HILF")
+        CALL push_field(hilf, "HILF")
         DO ilevel = maxlevel, minlevel, -1
             CALL ftoc(ilevel, hilf, finecell, 'P')
         END DO
         CALL connect(layers=2, s1=finecell, corners=.TRUE.)
-        CALL hilf%finish()
+        CALL pop_field(hilf)
     END SUBROUTINE set_finecell
 END MODULE ib_mod

--- a/src/scalar/blockbt_mod.F90
+++ b/src/scalar/blockbt_mod.F90
@@ -20,7 +20,7 @@ CONTAINS
         TYPE(field_t), INTENT(inout) :: bt_f
 
         ! Local variables
-        TYPE(field_t) :: hilf_f
+        TYPE(field_t), POINTER :: hilf_f
         TYPE(field_t), POINTER :: bp_f
         REAL(realk), POINTER, CONTIGUOUS :: bt(:, :, :), bp(:, :, :), &
             hilf(:, :, :)
@@ -29,7 +29,7 @@ CONTAINS
         INTEGER(intk) :: nfro, nbac, nrgt, nlft, nbot, ntop
 
         CALL get_field(bp_f, "BP")
-        CALL hilf_f%init("HILF")
+        CALL push_field(hilf_f, "HILF")
 
         ! Checking if any neighboring cell (shared face) has bp=1
         ! [only those cells can have a flux stencil associated with them]
@@ -66,7 +66,7 @@ CONTAINS
             CALL connect(ilevel, 2, s1=bt_f, corners=.TRUE.)
         END DO
 
-        CALL hilf_f%finish()
+        CALL pop_field(hilf_f)
     END SUBROUTINE blockbt
 
 

--- a/src/scalar/scastat_mod.F90
+++ b/src/scalar/scastat_mod.F90
@@ -85,7 +85,8 @@ CONTAINS
         ! Local Variables
         INTEGER(intk), PARAMETER :: units_dx(*) = [0, -1, 0, 0, 0, 0, 0]
         INTEGER(intk) :: units_tx(7), units_txtx(7)
-        TYPE(field_t) :: tx_f  ! derivative of a scalar in any direction
+        ! derivative of a scalar in any direction
+        TYPE(field_t), POINTER :: tx_f
         TYPE(field_t), POINTER :: t_f
         INTEGER(intk) :: istag, jstag, kstag
         CHARACTER(len=3) :: ivar
@@ -122,14 +123,14 @@ CONTAINS
 
         CALL field%init(name, istag=istag, jstag=jstag, kstag=kstag, &
             units=units_txtx)
-        CALL tx_f%init('tmp', istag=istag, jstag=jstag, kstag=kstag, &
+        CALL push_field(tx_f, 'tmp', istag=istag, jstag=jstag, kstag=kstag, &
             units=units_tx)
 
         ! central difference on scalar (= no staggering)
         CALL differentiate(tx_f, t_f, ivar)
 
         field%arr = tx_f%arr**2
-        CALL tx_f%finish()
+        CALL pop_field(tx_f)
     END SUBROUTINE comp_txtx_avg
 
 

--- a/src/scalar/timeintegrate_scalar_mod.F90
+++ b/src/scalar/timeintegrate_scalar_mod.F90
@@ -26,21 +26,18 @@ CONTAINS
         INTEGER(intk) :: ilevel, l
         REAL(realk) :: frhs, fu, dtrk, dtrki
         TYPE(field_t), POINTER :: t, told, dt_f
-        TYPE(field_t) :: qtt, qtu, qtv, qtw
+        TYPE(field_t), POINTER :: qtt, qtu, qtv, qtw
 
         IF (.NOT. solve_scalar) RETURN
         CALL start_timer(400)
         CALL start_timer(401)
 
         ! Local temporary storage ("scrap")
-        CALL qtt%init("QTT")
-        CALL qtu%init("QTU", istag=1)
-        CALL qtv%init("QTV", jstag=1)
-        CALL qtw%init("QTW", kstag=1)
+        CALL push_field(qtt, "QTT")
+        CALL push_field(qtu, "QTU", istag=1)
+        CALL push_field(qtv, "QTV", jstag=1)
+        CALL push_field(qtw, "QTW", kstag=1)
 
-        CALL qtu%init_buffers()
-        CALL qtv%init_buffers()
-        CALL qtw%init_buffers()
         CALL stop_timer(401)
 
         CALL start_timer(402)
@@ -101,10 +98,10 @@ CONTAINS
         END DO
         CALL stop_timer(402)
 
-        CALL qtt%finish()
-        CALL qtu%finish()
-        CALL qtv%finish()
-        CALL qtw%finish()
+        CALL pop_field(qtw)
+        CALL pop_field(qtv)
+        CALL pop_field(qtu)
+        CALL pop_field(qtt)
 
         CALL stop_timer(400)
     END SUBROUTINE timeintegrate_scalar


### PR DESCRIPTION
### Use case
Frequent allocations on the GPU are problematic for performance. This is a preemptive measure to avoid any 3D field reallocations by pooling fields.

### Implementation

1. Addition of `fieldpool_mod`: To the outside, one can use `push_field` and `pop_field`. `push_field` returns a pointer to an internal array of fields (both `realk` and `ifk`). This can replace any use of temporary fields that need to be initialized. The downside is that the maximum number of reserved fields determines the memory that is allocated for temporary fields throughout a full simulation. Internally, the fieldpool is now implemented as a stack. Thus, pushing and popping must be performed in correct stack-order, or the simulation will be stopped explicitly.
Example for flow: In each RK iteration, "UO", "VO", "WO", "DP", "HILF", "RHS" and "RES" were previously reallocated (7*3D realfield). Now, they are only allocated once and the memory is reused in each consecutive iteration.

3. Replace any `field%init` calls. Definitely useful for the pressure solver and statistics. Should be applied carefully in initialization routines. E.g. in `blockbp` of `gc_blockbp_mod`, which is only called once (but this is just blocking and not relevant for running the solvers?).
