### PR TITLE
Move get_grid_mod to fieldhelper_mod and Extend it With Field Setter Functionality

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(core STATIC
     err_mod.F90
     expression_mod.F90
     exprtk_wrapper.cxx
+    fieldhelper_mod.F90
     fieldio2_mod.F90
     field_t/basefield_mod.F90
     field_t/field_mod.F90
@@ -22,7 +23,6 @@ add_library(core STATIC
     field_t/realfield_mod.F90
     fields_mod.F90
     fort7_mod.F90
-    get_grid_mod.F90
     getrusage_wrapper.c
     gridio_mod.F90
     grids_mod.F90

--- a/src/core/core_mod.F90
+++ b/src/core/core_mod.F90
@@ -15,9 +15,9 @@ MODULE core_mod
     USE expression_mod
     USE fieldio2_mod
     USE field_mod
+    USE fieldhelper_mod
     USE fields_mod
     USE fort7_mod
-    USE get_grid_mod
     USE grids_mod
     ! Should not be neccesary to export gridio_mod - since this is only used
     ! in core functions

--- a/src/core/fieldhelper_mod.F90
+++ b/src/core/fieldhelper_mod.F90
@@ -1,25 +1,23 @@
 
-MODULE get_grid_mod
-
-    ! Module provides simplier interfaces to get grid pointers
-    ! for intfield_t and realfield_t. This measure is supposed to
-    ! reduce complexity for offloading compilers
-
+MODULE fieldhelper_mod
     USE err_mod, ONLY: errr
+    USE field_mod, ONLY: field_t, intfield_t
     USE grids_mod, ONLY: get_mgdims, mygrids, nmygrids, level, get_imygrid
-    USE precision_mod
-    USE basefield_mod
-    USE intfield_mod
-    USE realfield_mod
+    USE precision_mod, ONLY: realk, intk, ifk
 
     IMPLICIT NONE(type, external)
+    PRIVATE
+
+    INTERFACE set_field_arr
+        PROCEDURE set_field_arr_realk
+        PROCEDURE set_field_arr_ifk
+    END INTERFACE set_field_arr
 
     PUBLIC :: get_grid1_real, get_grid3_real, get_grid3_real_linear, &
-        get_grid3_ifk, get_grid3_ifk_linear
-
+        get_grid3_ifk, get_grid3_ifk_linear, set_field_arr
 CONTAINS
-
     SUBROUTINE get_grid1_real(ptr, field, igrid)
+        !$omp declare target
         ! Subroutine arguments
         REAL(realk), POINTER, CONTIGUOUS, INTENT(out) :: ptr(:)
         TYPE(field_t), INTENT(in), TARGET :: field
@@ -34,7 +32,9 @@ CONTAINS
         ptr(1:len) => field%arr(ip:ip+len-1)
     END SUBROUTINE get_grid1_real
 
+
     SUBROUTINE get_grid3_real(ptr, field, igrid)
+        !$omp declare target
         ! Subroutine arguments
         REAL(realk), POINTER, CONTIGUOUS, INTENT(out) :: ptr(:, :, :)
         TYPE(field_t), INTENT(in), TARGET :: field
@@ -55,7 +55,9 @@ CONTAINS
         ptr(1:kk, 1:jj, 1:ii) => field%arr(ip:ip+kk*jj*ii-1)
     END SUBROUTINE get_grid3_real
 
+
     SUBROUTINE get_grid3_real_linear(ptr, field, igrid)
+        !$omp declare target
         ! Subroutine arguments
         REAL(realk), POINTER, CONTIGUOUS, INTENT(out) :: ptr(:)
         TYPE(field_t), INTENT(in), TARGET :: field
@@ -77,9 +79,8 @@ CONTAINS
     END SUBROUTINE get_grid3_real_linear
 
 
-    ! >>> Integer fields (ifk, not intk)
-
     SUBROUTINE get_grid3_ifk(ptr, field, igrid)
+        !$omp declare target
         ! Subroutine arguments
         INTEGER(ifk), POINTER, CONTIGUOUS, INTENT(out) :: ptr(:, :, :)
         TYPE(intfield_t), INTENT(in), TARGET :: field
@@ -100,7 +101,9 @@ CONTAINS
         ptr(1:kk, 1:jj, 1:ii) => field%arr(ip:ip+kk*jj*ii-1)
     END SUBROUTINE get_grid3_ifk
 
+
     SUBROUTINE get_grid3_ifk_linear(ptr, field, igrid)
+        !$omp declare target
         ! Subroutine arguments
         INTEGER(ifk), POINTER, CONTIGUOUS, INTENT(out) :: ptr(:)
         TYPE(intfield_t), INTENT(in), TARGET :: field
@@ -121,4 +124,63 @@ CONTAINS
         ptr(1:kk*jj*ii) => field%arr(ip:ip+kk*jj*ii-1)
     END SUBROUTINE get_grid3_ifk_linear
 
-END MODULE get_grid_mod
+
+    SUBROUTINE set_field_arr_realk(field, val, device)
+        ! Subroutine arguments
+        TYPE(field_t), INTENT(inout) :: field
+        REAL(realk), INTENT(in) :: val
+        LOGICAL, OPTIONAL, INTENT(in) :: device
+
+        ! Local variables
+        INTEGER(intk) :: i, n
+        LOGICAL :: device2
+
+        IF (PRESENT(device)) THEN
+            device2 = device
+        ELSE
+            device2 = .FALSE.
+        END IF
+
+        IF (device2) THEN
+            n = SIZE(field%arr)
+            !$omp target teams loop
+            DO i = 1, n
+                field%arr(i) = val
+            END DO
+            !$omp end target teams loop
+        ELSE
+            ! Faster than loop on CPU
+            field%arr = val
+        END IF
+    END SUBROUTINE set_field_arr_realk
+
+
+    SUBROUTINE set_field_arr_ifk(field, val, device)
+        ! Subroutine arguments
+        TYPE(intfield_t), INTENT(inout) :: field
+        INTEGER(ifk), INTENT(in) :: val
+        LOGICAL, OPTIONAL, INTENT(in) :: device
+
+        ! Local variables
+        INTEGER(intk) :: i, n
+        LOGICAL :: device2
+
+        IF (PRESENT(device)) THEN
+            device2 = device
+        ELSE
+            device2 = .FALSE.
+        END IF
+
+        IF (device2) THEN
+            n = SIZE(field%arr)
+            !$omp target teams loop
+            DO i = 1, n
+                field%arr(i) = val
+            END DO
+            !$omp end target teams loop
+        ELSE
+            ! Faster than loop on CPU
+            field%arr = val
+        END IF
+    END SUBROUTINE set_field_arr_ifk
+END MODULE fieldhelper_mod


### PR DESCRIPTION
The initial idea was that we need some setter that can write a field%arr field on either the CPU or GPU easily. I though we could use the previously added `get_grid_mod`, since it already holds offloading relevant getter functions, and just repurpose it as a general `fieldhelper_mod` (for offloading).