### PR TITLE
Skip Runtime Checks on Device in Non-Debug Builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ set(MGLET_Fortran_FLAGS_DEBUG "" CACHE STRING "MGLET Fortran flags (debug)")
 if(MGLET_OFFLOAD)
     set(MGLET_OFFLOAD_COMPILE_FLAGS "" CACHE STRING "MGLET Offload compile flags")
     set(MGLET_OFFLOAD_ARCH_FLAGS "" CACHE STRING "MGLET Offload architecture flags")
+    add_compile_definitions("$<$<NOT:$<CONFIG:Debug>>:_MGLET_OFFLOAD_PERFORMANCE_=1>") 
 endif()
 
 add_compile_options("$<$<COMPILE_LANGUAGE:C>:${MGLET_C_FLAGS}>"

--- a/src/core/fieldhelper_mod.F90
+++ b/src/core/fieldhelper_mod.F90
@@ -29,6 +29,10 @@ CONTAINS
         CALL get_imygrid(imygrid, igrid)
         ip = field%ptr(imygrid)
         len = field%length(imygrid)
+#ifndef _MGLET_OFFLOAD_PERFORMANCE_
+        IF (len <= 0) CALL errr(__FILE__, __LINE__)
+#endif
+
         ptr(1:len) => field%arr(ip:ip+len-1)
     END SUBROUTINE get_grid1_real
 
@@ -43,14 +47,14 @@ CONTAINS
         ! Local variables
         INTEGER(intk) :: kk, jj, ii, ip, imygrid, len
 
-        ! Getting and checking properties
         CALL get_imygrid(imygrid, igrid)
         CALL get_mgdims(kk, jj, ii, igrid)
         len = field%length(imygrid)
+#ifndef _MGLET_OFFLOAD_PERFORMANCE_
         IF (len <= 0) CALL errr(__FILE__, __LINE__)
         IF (len /= kk*jj*ii) CALL errr(__FILE__, __LINE__)
+#endif
 
-        ! Setting the pointer
         ip = field%ptr(imygrid)
         ptr(1:kk, 1:jj, 1:ii) => field%arr(ip:ip+kk*jj*ii-1)
     END SUBROUTINE get_grid3_real
@@ -66,14 +70,14 @@ CONTAINS
         ! Local variables
         INTEGER(intk) :: kk, jj, ii, ip, imygrid, len
 
-        ! Getting and checking properties
         CALL get_imygrid(imygrid, igrid)
         CALL get_mgdims(kk, jj, ii, igrid)
         len = field%length(imygrid)
+#ifndef _MGLET_OFFLOAD_PERFORMANCE_
         IF (len <= 0) CALL errr(__FILE__, __LINE__)
         IF (len /= kk*jj*ii) CALL errr(__FILE__, __LINE__)
+#endif
 
-        ! Setting the pointer
         ip = field%ptr(imygrid)
         ptr(1:kk*jj*ii) => field%arr(ip:ip+kk*jj*ii-1)
     END SUBROUTINE get_grid3_real_linear
@@ -89,14 +93,14 @@ CONTAINS
         ! Local variables
         INTEGER(intk) :: kk, jj, ii, ip, imygrid, len
 
-        ! Getting and checking properties
         CALL get_imygrid(imygrid, igrid)
         CALL get_mgdims(kk, jj, ii, igrid)
         len = field%length(imygrid)
+#ifndef _MGLET_OFFLOAD_PERFORMANCE_
         IF (len <= 0) CALL errr(__FILE__, __LINE__)
         IF (len /= kk*jj*ii) CALL errr(__FILE__, __LINE__)
+#endif
 
-        ! Setting the pointer
         ip = field%ptr(imygrid)
         ptr(1:kk, 1:jj, 1:ii) => field%arr(ip:ip+kk*jj*ii-1)
     END SUBROUTINE get_grid3_ifk
@@ -112,14 +116,14 @@ CONTAINS
         ! Local variables
         INTEGER(intk) :: kk, jj, ii, ip, imygrid, len
 
-        ! Getting and checking properties
         CALL get_imygrid(imygrid, igrid)
         CALL get_mgdims(kk, jj, ii, igrid)
         len = field%length(imygrid)
+#ifndef _MGLET_OFFLOAD_PERFORMANCE_
         IF (len <= 0) CALL errr(__FILE__, __LINE__)
         IF (len /= kk*jj*ii) CALL errr(__FILE__, __LINE__)
+#endif
 
-        ! Setting the pointer
         ip = field%ptr(imygrid)
         ptr(1:kk*jj*ii) => field%arr(ip:ip+kk*jj*ii-1)
     END SUBROUTINE get_grid3_ifk_linear

--- a/src/core/grids_mod.F90
+++ b/src/core/grids_mod.F90
@@ -481,7 +481,9 @@ CONTAINS
 
         imygrid = globalgrids(igrid)
 
+#ifndef _MGLET_OFFLOAD_PERFORMANCE_
         IF (imygrid == -1_intk) CALL errr(__FILE__, __LINE__)
+#endif
     END SUBROUTINE get_imygrid
 
 


### PR DESCRIPTION
After discussing for some time, we concluded for now that:
- No runtime checks should exist in our kernels when we are not in debug builds (performance has highest priority on the GPU)
- Any runtime check in a kernel should exit the program with errr (no errorcode that is checked later for now)
- ifdefs should be hidden as much as possible from kernels (put them in helper functions)