### PR TITLE
Performance enhancement of "conn2"

### DIFF
--- a/src/core/connect/conn2_mod.F90
+++ b/src/core/connect/conn2_mod.F90
@@ -10,6 +10,8 @@ MODULE conn2_mod
     USE field_mod
     USE connect_core_mod
     USE fieldhelper_mod
+    USE pointers_mod, ONLY: get_ip3
+    USE profile_tools_mod
 
     IMPLICIT NONE (type, external)
     PRIVATE
@@ -26,8 +28,25 @@ MODULE conn2_mod
 
     ! Workpackages containing individual tasks for packing / unpacking
     INTEGER(intk), ALLOCATABLE :: sendtasks(:, :), recvtasks(:, :), &
-        selftasks(:, :), mpisendtasks(:, :)
+        selftasks(:, :), mpisendtasks(:, :), mpirecvtasks(:, :)
     !$omp declare target(sendtasks, recvtasks, selftasks)
+
+    ! Type to hold condensed task arrays to execute a certain type of conn
+    TYPE :: work_t
+        LOGICAL :: is_init = .FALSE.
+        INTEGER(intk), ALLOCATABLE :: sendtasks(:, :)
+        INTEGER(intk), ALLOCATABLE :: recvtasks(:, :)
+        INTEGER(intk), ALLOCATABLE :: selftasks(:, :)
+        INTEGER(intk), ALLOCATABLE :: mpisendtasks(:, :)
+        INTEGER(intk), ALLOCATABLE :: mpirecvtasks(:, :)
+    END TYPE work_t
+
+    ! Multidimensional array to store work_t for different conn types
+    TYPE(work_t), ALLOCATABLE, TARGET :: workrecords(:, :, :, :, :, :)
+    LOGICAL :: is_recording = .FALSE.
+
+    TYPE(field_t), POINTER :: f1, f2, f3, f4, f5, f6
+    TYPE(field_t), TARGET :: pdummy, udummy, vdummy, wdummy
 
     PUBLIC :: conn2, init_conn2, finish_conn2
 
@@ -48,43 +67,63 @@ CONTAINS
 
         ! Local variables
         INTEGER(intk) :: minconlvl, maxconlvl, nplane, fwd, nvars
-        INTEGER(intk) :: nsendtasks, nselftasks, nmpisendtasks, nrecvtasks
+        INTEGER(intk) :: nsendtasks, nselftasks, nrecvtasks
+        INTEGER(intk) :: nmpisendtasks, nmpirecvtasks
         LOGICAL :: vertices, normal2
         CHARACTER(len=1) :: flag
-        TYPE(field_t), POINTER :: f1, f2, f3, f4, f5, f6
 
-        ! Setting all field pointers to NULL initially
-        f1 => NULL()
-        f2 => NULL()
-        f3 => NULL()
-        f4 => NULL()
-        f5 => NULL()
-        f6 => NULL()
+        ! Indices for the position within the workrecords array
+        INTEGER(intk) :: idx_ilevel, idx_layers, idx_args, idx_corners, &
+            idx_normal, idx_forward
+
+        ! Setting all field pointers to uninitialized dummy field
+        f1 => pdummy
+        f2 => pdummy
+        f3 => pdummy
+        f4 => pdummy
+        f5 => pdummy
+        f6 => pdummy
 
         IF (PRESENT(ilevel)) THEN
+            IF (ilevel < minlevel .OR. ilevel > maxlevel) THEN
+                CALL errr(__FILE__, __LINE__)
+            END IF
             minconlvl = ilevel
             maxconlvl = ilevel
+            idx_ilevel = ilevel
         ELSE
             minconlvl = minlevel
             maxconlvl = maxlevel
+            idx_ilevel = maxlevel+1
         END IF
 
         nplane = 1
+        idx_layers = 1
         IF (PRESENT(layers)) THEN
             nplane = layers
+            idx_layers = layers
         END IF
         IF (nplane < 1 .OR. nplane > 2) THEN
             CALL errr(__FILE__, __LINE__)
         END IF
 
         vertices = .FALSE.
+        idx_corners = 0
         IF (PRESENT(corners)) THEN
             vertices = corners
+            IF (corners) THEN
+                idx_corners = 1
+            END IF
         END IF
 
         fwd = 0
+        idx_forward = 0
         IF (PRESENT(forward)) THEN
+            IF (forward < -1 .OR. forward > 1) THEN
+                CALL errr(__FILE__, __LINE__)
+            END IF
             fwd = forward
+            idx_forward = forward
         END IF
 
         IF (fwd /= 0 .AND. vertices) THEN
@@ -93,45 +132,53 @@ CONTAINS
 
         flag = ' '
         IF (PRESENT(ityp)) THEN
-            IF (ityp == "W") THEN
-                flag = 'W'
-            ELSE
-                CALL errr(__FILE__, __LINE__)
-            END IF
+            ! Radical approach
+            CALL errr(__FILE__, __LINE__)
         END IF
 
+        idx_args = 0
         nvars = 0
         IF (PRESENT(v1)) THEN
             f1 => v1
             nvars = nvars + 1
+            idx_args = idx_args + 1 * 2**(0)
         END IF
         IF (PRESENT(v2)) THEN
             f2 => v2
             nvars = nvars + 1
+            idx_args = idx_args + 1 * 2**(1)
         END IF
         IF (PRESENT(v3)) THEN
             f3 => v3
             nvars = nvars + 1
+            idx_args = idx_args + 1 * 2**(2)
         END IF
         IF (PRESENT(s1)) THEN
             f4 => s1
             nvars = nvars + 1
+            idx_args = idx_args + 1 * 2**(3)
         END IF
         IF (PRESENT(s2)) THEN
             f5 => s2
             nvars = nvars + 1
+            idx_args = idx_args + 1 * 2**(4)
         END IF
         IF (PRESENT(s3)) THEN
             f6 => s3
             nvars = nvars + 1
+            idx_args = idx_args + 1 * 2**(5)
         END IF
         IF (nvars == 0) THEN
             CALL errr(__FILE__, __LINE__)
         END IF
 
         normal2 = .FALSE.
+        idx_normal = 0
         IF (PRESENT(normal)) THEN
             normal2 = normal
+            IF (normal) THEN
+                idx_normal = 1
+            END IF
         END IF
         IF (normal2) THEN
             IF (.NOT. PRESENT(v1) .OR. .NOT. PRESENT(v2) .OR. &
@@ -145,44 +192,156 @@ CONTAINS
         END IF
 
 
-        CALL prepare_tasks_all(nsendtasks, nselftasks, nmpisendtasks, &
-            minconlvl, maxconlvl, nplane, vertices, &
-            normal2, fwd, flag, nvars, v1, v2, v3, s1, s2, s3)
+        ! During the execution phase, the workpackage is already initialized
+        ! and can be used directly or the runtime variant is used
+        IF (.NOT. is_recording) THEN
 
-        !$omp target update to( &
-        !$omp&  sendtasks(1:buffertasksize, 1:nsendtasks+1), &
-        !$omp&  selftasks(1:selftasksize, 1:nselftasks+1)) nowait
+            ! Looking up the workpackage in the workrecords array
+            ASSOCIATE(wptr => workrecords(idx_ilevel, idx_layers, idx_args, &
+                idx_corners, idx_normal, idx_forward))
 
-        CALL recv_mpi_all(minconlvl, maxconlvl, nplane, vertices, normal2, &
-            fwd, flag, nvars)
+            IF (wptr%is_init) THEN
 
-        !$omp taskwait
+                ! Using the (offloaded) workpackage from the workrecords array
+                nmpirecvtasks = SIZE(wptr%mpirecvtasks, 2) - 1
+                nmpisendtasks = SIZE(wptr%mpisendtasks, 2) - 1
+                nsendtasks = SIZE(wptr%sendtasks, 2) - 1
+                nselftasks = SIZE(wptr%selftasks, 2) - 1
+                nrecvtasks = SIZE(wptr%recvtasks, 2) - 1
 
-        CALL process_sendtasks(nsendtasks, f1, f2, f3, f4, f5, f6)
-        CALL send_mpi_all(nmpisendtasks)
+                CALL profile_range_push("process_mpirecv")
+                CALL process_mpirecv(wptr%mpirecvtasks, nmpirecvtasks)
+                CALL profile_range_pop()
 
-        ! MPI messages are now on their way, we can do other work...
-        ! SIMON: We are here following a conservative variant, which allows
-        ! safety checks. For performance reasons, one could already execute
-        ! "prepare_recvtasks_all" BEFORE the messages are there. That is
-        ! without any checks, however (!)
+                CALL profile_range_push("process_sendtasks")
+                CALL process_sendtasks(wptr%sendtasks, nsendtasks)
+                CALL profile_range_pop()
 
-        CALL process_selftasks(nselftasks, f1, f2, f3, f4, f5, f6)
+                CALL profile_range_push("process_mpisend")
+                CALL process_mpisend(wptr%mpisendtasks, nmpisendtasks)
+                CALL profile_range_pop()
 
-        CALL prepare_recvtasks_all(nrecvtasks, &
-            nplane, normal2, flag, v1, v2, v3, s1, s2, s3)
+                CALL profile_range_push("process_selftasks")
+                CALL process_selftasks(wptr%selftasks, nselftasks)
+                CALL profile_range_pop()
 
-        !$omp target update to( &
-        !$omp&  recvtasks(1:buffertasksize, 1:nrecvtasks+1)) nowait
+                CALL MPI_Waitall(nrecv, recvreqs, MPI_STATUSES_IGNORE)
 
-        !$omp taskwait
+                CALL profile_range_push("process_recvtasks")
+                CALL process_recvtasks(wptr%recvtasks, nrecvtasks)
+                CALL profile_range_pop()
 
-        CALL process_recvtasks(nrecvtasks, f1, f2, f3, f4, f5, f6)
+                CALL MPI_Waitall(nsend, sendreqs, MPI_STATUSES_IGNORE)
+
+            ELSE
+
+                ! Manufacturing the workpackage just in-time and execute
+                CALL prepare_tasks_all(sendtasks, nsendtasks, &
+                    selftasks, nselftasks, mpisendtasks, nmpisendtasks, &
+                    minconlvl, maxconlvl, nplane, vertices, &
+                    normal2, fwd, flag, nvars, v1, v2, v3, s1, s2, s3)
+
+                !$omp target update to( &
+                !$omp&  sendtasks(1:buffertasksize, 1:nsendtasks+1), &
+                !$omp&  selftasks(1:selftasksize, 1:nselftasks+1)) nowait
+
+                CALL recv_mpi_all(minconlvl, maxconlvl, nplane, vertices, &
+                    normal2, fwd, flag, nvars)
+
+                !$omp taskwait
+
+                CALL process_sendtasks(sendtasks, nsendtasks)
+                CALL process_mpisend(mpisendtasks, nmpisendtasks)
+                CALL process_selftasks(selftasks, nselftasks)
+
+                CALL prepare_recvtasks_all(recvtasks, nrecvtasks, &
+                    nplane, normal2, flag, v1, v2, v3, s1, s2, s3)
+
+                !$omp target update to( &
+                !$omp&  recvtasks(1:buffertasksize, 1:nrecvtasks+1)) nowait
+
+                !$omp taskwait
+
+                CALL process_recvtasks(recvtasks, nrecvtasks)
+
+            END IF
+
+            END ASSOCIATE
+
+        END IF
+
+
+        ! During the recording phase, an uninitialized workpackage needs to be
+        ! created and data is offloaded for later efficient usage on device
+        IF (is_recording) THEN
+
+            ASSOCIATE(wptr => workrecords(idx_ilevel, idx_layers, idx_args, &
+                idx_corners, idx_normal, idx_forward))
+
+            IF (wptr%is_init) THEN
+                WRITE(*, *) "Combination already recorded."
+                CALL errr(__FILE__, __LINE__)
+            END IF
+
+            ! It is necessary to execute one cycle with communication
+            ! as otherwise many valuable checks are not possible
+
+            CALL prepare_mpirecvtasks(mpirecvtasks, nmpirecvtasks, &
+                minconlvl, maxconlvl, nplane, vertices, normal2, fwd, &
+                flag, nvars)
+
+            CALL prepare_tasks_all(sendtasks, nsendtasks, &
+                selftasks, nselftasks, mpisendtasks, nmpisendtasks, &
+                minconlvl, maxconlvl, nplane, vertices, &
+                normal2, fwd, flag, nvars, v1, v2, v3, s1, s2, s3)
+
+            !$omp target update to( &
+            !$omp&  sendtasks(1:buffertasksize, 1:nsendtasks+1), &
+            !$omp&  selftasks(1:selftasksize, 1:nselftasks+1))
+
+            CALL process_mpirecv(mpirecvtasks, nmpirecvtasks)
+            CALL process_sendtasks(sendtasks, nsendtasks)
+            CALL process_mpisend(mpisendtasks, nmpisendtasks)
+            CALL process_selftasks(selftasks, nselftasks)
+            CALL prepare_recvtasks_all(recvtasks, nrecvtasks, &
+                nplane, normal2, flag, v1, v2, v3, s1, s2, s3)
+            !$omp taskwait
+
+            !$omp target update to( &
+            !$omp&  recvtasks(1:buffertasksize, 1:nrecvtasks+1))
+            CALL process_recvtasks(recvtasks, nrecvtasks)
+
+            ! Allocate the workpackage arrays in the exact sizes
+            ALLOCATE(wptr%sendtasks(buffertasksize, nsendtasks+1))
+            ALLOCATE(wptr%recvtasks(buffertasksize, nrecvtasks+1))
+            ALLOCATE(wptr%selftasks(selftasksize, nselftasks+1))
+            ALLOCATE(wptr%mpisendtasks(mpitasksize, nmpisendtasks+1))
+            ALLOCATE(wptr%mpirecvtasks(mpitasksize, nmpirecvtasks+1))
+
+            ! Store the workpackage in the workrecords array and map
+            wptr%sendtasks = sendtasks(:, 1:nsendtasks+1)
+            wptr%recvtasks = recvtasks(:, 1:nrecvtasks+1)
+            wptr%selftasks = selftasks(:, 1:nselftasks+1)
+            wptr%mpisendtasks = mpisendtasks(:, 1:nmpisendtasks+1)
+            wptr%mpirecvtasks = mpirecvtasks(:, 1:nmpirecvtasks+1)
+
+            !$omp target enter data map(to: &
+            !$omp&  wptr%sendtasks(1:buffertasksize, 1:nsendtasks+1), &
+            !$omp&  wptr%recvtasks(1:buffertasksize, 1:nrecvtasks+1), &
+            !$omp&  wptr%selftasks(1:selftasksize, 1:nselftasks+1))
+
+            ! Mark the workpackage as initialized
+            wptr%is_init = .TRUE.
+            END ASSOCIATE
+
+        END IF
 
     END SUBROUTINE conn2
 
 
     SUBROUTINE init_conn2()
+
+        INTEGER(intk) :: ilevel
 
         ! The maximum number of concurrent communications are the number
         ! of processes
@@ -200,6 +359,7 @@ CONTAINS
         !$omp target enter data map(always, to: sendtasks, recvtasks, selftasks)
 
         ALLOCATE(mpisendtasks(mpitasksize, SIZE(sendconns, 2)+1))
+        ALLOCATE(mpirecvtasks(mpitasksize, SIZE(recvconns, 2)+1))
 
         recvidxlist = 0
         sendlist = 0
@@ -207,10 +367,41 @@ CONTAINS
         nrecv = 0
         nsend = 0
 
+        ! Allocate the workrecords array for all possible types of conn
+        ALLOCATE(workrecords(minlevel:maxlevel+1, 1:2, 1:63, 0:1, 0:1, -1:1))
+
+        ! dimension 1 = ilevel (including maxlevel+1 for "all levels")
+        ! dimension 2 = layers (1 or 2)
+        ! dimension 3 = argument combination (6 bits = 2^6-1 = 63)
+        ! dimension 4 = corners (0 or 1)
+        ! dimension 5 = normal (0 or 1)
+        ! dimension 6 = forward (-1, 0, 1)
+
+        ! Recording relevant conn calls for later efficient reusage on device
+        is_recording = .TRUE.
+        CALL pdummy%init("DUMMY")
+        CALL udummy%init("DUMMY", istag=1)
+        CALL vdummy%init("DUMMY", jstag=1)
+        CALL wdummy%init("DUMMY", kstag=1)
+
+        DO ilevel = minlevel, maxlevel
+            CALL conn2(ilevel, layers=1, s1=pdummy)
+            CALL conn2(ilevel, layers=1, s1=pdummy, forward=-1)
+        END DO
+
+        CALL pdummy%finish()
+        CALL udummy%finish()
+        CALL vdummy%finish()
+        CALL wdummy%finish()
+        is_recording = .FALSE.
+
     END SUBROUTINE init_conn2
 
 
     SUBROUTINE finish_conn2()
+        ! Local variables
+        TYPE(work_t), POINTER :: wr1d(:)
+        INTEGER(intk) :: i
 
         DEALLOCATE(recvidxlist)
         DEALLOCATE(sendlist)
@@ -224,6 +415,30 @@ CONTAINS
         DEALLOCATE(selftasks)
 
         DEALLOCATE(mpisendtasks)
+        DEALLOCATE(mpirecvtasks)
+
+        ! Deallocate the workpackage arrays in the workrecords array
+        wr1d(1:SIZE(workrecords)) => workrecords
+        DO i = 1, SIZE(wr1d)
+            IF (.NOT. wr1d(i)%is_init) CYCLE
+
+            !$omp target exit data map(delete: &
+            !$omp&  wr1d(i)%sendtasks(:, :), &
+            !$omp&  wr1d(i)%recvtasks(:, :), &
+            !$omp&  wr1d(i)%selftasks(:, :))
+
+            IF (ALLOCATED(wr1d(i)%sendtasks)) DEALLOCATE(wr1d(i)%sendtasks)
+            IF (ALLOCATED(wr1d(i)%recvtasks)) DEALLOCATE(wr1d(i)%recvtasks)
+            IF (ALLOCATED(wr1d(i)%selftasks)) DEALLOCATE(wr1d(i)%selftasks)
+            IF (ALLOCATED(wr1d(i)%mpisendtasks)) &
+                DEALLOCATE(wr1d(i)%mpisendtasks)
+            IF (ALLOCATED(wr1d(i)%mpirecvtasks)) &
+                DEALLOCATE(wr1d(i)%mpirecvtasks)
+            wr1d(i)%is_init = .FALSE.
+        END DO
+
+        ! Deallocate the workrecords array
+        DEALLOCATE(workrecords)
 
     END SUBROUTINE finish_conn2
 
@@ -233,14 +448,18 @@ CONTAINS
     ! Host routine for preparing the sendtasks, selftasks and mpisendtasks
     ! Task parameters are gathered in arrays but tasks are not executed.
     !
-    SUBROUTINE prepare_tasks_all(nsendtasks, nselftasks, nmpisendtasks, &
-            minconlvl, maxconlvl, nplane, vertices, normal, fwd, flag, nvars, &
-            v1, v2, v3, s1, s2, s3)
+    SUBROUTINE prepare_tasks_all(stasks, nstasks, &
+            etasks, netasks, mpistasks, nmpistasks, &
+            minconlvl, maxconlvl, nplane, vertices, &
+            normal, fwd, flag, nvars, v1, v2, v3, s1, s2, s3)
 
         ! Subroutine arguments
-        INTEGER(intk), INTENT(out) :: nsendtasks
-        INTEGER(intk), INTENT(out) :: nselftasks
-        INTEGER(intk), INTENT(out) :: nmpisendtasks
+        INTEGER(intk), INTENT(inout) :: stasks(buffertasksize, maxtasks)
+        INTEGER(intk), INTENT(out) :: nstasks
+        INTEGER(intk), INTENT(inout) :: etasks(selftasksize, maxtasks)
+        INTEGER(intk), INTENT(out) :: netasks
+        INTEGER(intk), INTENT(inout) :: mpistasks(mpitasksize, maxtasks)
+        INTEGER(intk), INTENT(out) :: nmpistasks
 
         INTEGER(intk), INTENT(in) :: minconlvl, maxconlvl, nplane
         LOGICAL, INTENT(in) :: vertices, normal
@@ -251,7 +470,7 @@ CONTAINS
 
         ! Local variables
         INTEGER(intk) :: i, iprocnbr, igrid, ifacerecv, facearea
-        INTEGER(intk) :: isendtask, iselftask, impisendtasks
+        INTEGER(intk) :: istask, ietask, impistasks
         LOGICAL :: exchange, geometry
         INTEGER(int32) :: sendcounter, messagelength
 
@@ -263,9 +482,9 @@ CONTAINS
         nsend = 0
 
         ! Initializing the task counters to zero
-        isendtask = 0
-        iselftask = 0
-        impisendtasks = 0
+        istask = 0
+        ietask = 0
+        impistasks = 0
 
         DO i = 1, SIZE(sendconns, 2)
 
@@ -278,8 +497,8 @@ CONTAINS
             IF (iprocnbr == myid .AND. exchange) THEN
 
                 ! >>> adding entries to selftasks (= "connect_self")
-                CALL prepare_selftasks(iselftask, i, nplane, normal, flag, &
-                    v1, v2, v3, s1, s2, s3)
+                CALL prepare_selftasks(etasks, ietask, i, nplane, &
+                    normal, flag, v1, v2, v3, s1, s2, s3)
                 CYCLE
 
             END IF
@@ -292,7 +511,7 @@ CONTAINS
                 facearea = face_area(igrid, ifacerecv, nplane, flag)
 
                 ! >>> adding entries to sendtasks (= "write_buffer")
-                CALL prepare_sendtasks(isendtask, i, messagelength, &
+                CALL prepare_sendtasks(stasks, istask, i, messagelength, &
                     sendcounter, nplane, normal, flag, nvars, v1, v2, v3, &
                     s1, s2, s3)
 
@@ -304,34 +523,35 @@ CONTAINS
             ! >>> adding entries to mpisendtasks (= "post_send")
             IF (messagelength > 0) THEN
                 IF (i == SIZE(sendconns, 2)) THEN
-                    CALL add_mpisend_task(impisendtasks, &
-                        iprocnbr, messagelength, sendcounter)
+                    CALL add_mpi_task(mpistasks, impistasks, &
+                        iprocnbr, messagelength, sendcounter, "send")
                 ELSE IF (sendconns(1, i + 1) /= iprocnbr) THEN
-                    CALL add_mpisend_task(impisendtasks, &
-                        iprocnbr, messagelength, sendcounter)
+                    CALL add_mpi_task(mpistasks, impistasks, &
+                        iprocnbr, messagelength, sendcounter, "send")
                 END IF
             END IF
 
         END DO
 
         ! Set the output task counters
-        nsendtasks = isendtask
-        nselftasks = iselftask
-        nmpisendtasks = impisendtasks
+        nstasks = istask
+        netasks = ietask
+        nmpistasks = impistasks
 
         ! Add a harmful dummy task at (ntasks+1) for checking
-        sendtasks(:, nsendtasks+1) = -1
-        selftasks(:, nselftasks+1) = -1
-        mpisendtasks(:, nmpisendtasks+1) = -1
+        stasks(:, nstasks+1) = -1
+        etasks(:, netasks+1) = -1
+        mpistasks(:, nmpistasks+1) = -1
 
     END SUBROUTINE prepare_tasks_all
 
 
-    SUBROUTINE prepare_sendtasks(isendtask, sendid, messagelength, &
+    SUBROUTINE prepare_sendtasks(stasks, istask, sendid, messagelength, &
             sendcounter, nplane, normal, flag, nvars, v1, v2, v3, s1, s2, s3)
 
         ! Subroutine arguments
-        INTEGER(intk), INTENT(inout) :: isendtask
+        INTEGER(intk), INTENT(inout) :: stasks(buffertasksize, maxtasks)
+        INTEGER(intk), INTENT(inout) :: istask
         INTEGER(intk), INTENT(in) :: sendid
         INTEGER(intk), INTENT(inout) :: messagelength
         INTEGER(intk), INTENT(inout) :: sendcounter
@@ -346,13 +566,12 @@ CONTAINS
 
         ! Grid to send from
         ! Must be intk because it intreface with MGLET
-        INTEGER(intk) :: igrid, ifacerecv, ifacesend
+        INTEGER(intk) :: igrid, ifacerecv, ifacesend, fieldid
 
         ! Message sizes
         ! Must be int32 because it iterface with MPI
         INTEGER(int32) :: thismessagelength, facearea
         INTEGER(int32) :: icount, offset
-        INTEGER(int32) :: fieldid
 
         ! Flags to indicate exchange of U, V, W
         LOGICAL :: exU, exV, exW, exp1
@@ -390,8 +609,8 @@ CONTAINS
         END IF
         IF (PRESENT(v1) .AND. exU) THEN
             fieldid = 1   ! (for v1)
-            isendtask = isendtask + 1
-            CALL add_single_task(sendtasks(:, isendtask), fieldid, icount, &
+            istask = istask + 1
+            CALL add_single_task(stasks(:, istask), fieldid, icount, &
                 igrid, istart, istop, jstart, jstop, kstart, kstop)
         END IF
 
@@ -403,8 +622,8 @@ CONTAINS
         END IF
         IF (PRESENT(v2) .AND. exV) THEN
             fieldid = 2   ! (for v2)
-            isendtask = isendtask + 1
-            CALL add_single_task(sendtasks(:, isendtask), fieldid, icount, &
+            istask = istask + 1
+            CALL add_single_task(stasks(:, istask), fieldid, icount, &
                 igrid, istart, istop, jstart, jstop, kstart, kstop)
         END IF
 
@@ -415,8 +634,8 @@ CONTAINS
         END IF
         IF (PRESENT(v3) .AND. exW) THEN
             fieldid = 3   ! (for v3)
-            isendtask = isendtask + 1
-            CALL add_single_task(sendtasks(:, isendtask), fieldid, icount, &
+            istask = istask + 1
+            CALL add_single_task(stasks(:, istask), fieldid, icount, &
                 igrid, istart, istop, jstart, jstop, kstart, kstop)
         END IF
 
@@ -428,22 +647,22 @@ CONTAINS
         END IF
         IF (PRESENT(s1) .AND. exp1) THEN
             fieldid = 4   ! (for s1)
-            isendtask = isendtask + 1
-            CALL add_single_task(sendtasks(:, isendtask), fieldid, icount, &
+            istask = istask + 1
+            CALL add_single_task(stasks(:, istask), fieldid, icount, &
                 igrid, istart, istop, jstart, jstop, kstart, kstop)
         END IF
 
         IF (PRESENT(s2)) THEN
             fieldid = 5   ! (for s2)
-            isendtask = isendtask + 1
-            CALL add_single_task(sendtasks(:, isendtask), fieldid, icount, &
+            istask = istask + 1
+            CALL add_single_task(stasks(:, istask), fieldid, icount, &
                 igrid, istart, istop, jstart, jstop, kstart, kstop)
         END IF
 
         IF (PRESENT(s3)) THEN
             fieldid = 6   ! (for s3)
-            isendtask = isendtask + 1
-            CALL add_single_task(sendtasks(:, isendtask), fieldid, icount, &
+            istask = istask + 1
+            CALL add_single_task(stasks(:, istask), fieldid, icount, &
                 igrid, istart, istop, jstart, jstop, kstart, kstop)
         END IF
 
@@ -459,11 +678,12 @@ CONTAINS
 
     ! Routine to prepare the workpackage for intra-rank self connect
     !
-    SUBROUTINE prepare_selftasks(iselftask, sendid, nplane, normal, flag, &
-            v1, v2, v3, s1, s2, s3)
+    SUBROUTINE prepare_selftasks(etasks, ietask, sendid, nplane, &
+            normal, flag, v1, v2, v3, s1, s2, s3)
 
         ! Subroutine arguments
-        INTEGER(int32), INTENT(inout) :: iselftask
+        INTEGER(intk), INTENT(inout) :: etasks(selftasksize, maxtasks)
+        INTEGER(intk), INTENT(inout) :: ietask
         INTEGER(int32), INTENT(in) :: sendid
         INTEGER(int32), INTENT(in) :: nplane
         LOGICAL, INTENT(in) :: normal
@@ -480,11 +700,11 @@ CONTAINS
 
         ! Grid to send from
         ! Must be intk because it intreface with MGLET
-        INTEGER(intk) :: igrid, igrid_d, ifacerecv, ifacesend
+        INTEGER(intk) :: igrid, igrid_d, ifacerecv, ifacesend, fieldid
 
         ! Message sizes
         ! Must be int32 because it iterface with MPI
-        INTEGER(int32) :: dest_size, source_size, fieldid
+        INTEGER(int32) :: dest_size, source_size
 
         ! Flags to indicate exchange of U, V, W
         LOGICAL :: exU, exV, exW, exp1
@@ -521,8 +741,8 @@ CONTAINS
         END IF
         IF (PRESENT(v1) .AND. exU) THEN
             fieldid = 1   ! (for v1)
-            iselftask = iselftask + 1
-            CALL add_self_task(selftasks(:, iselftask), fieldid, igrid, &
+            ietask = ietask + 1
+            CALL add_self_task(etasks(:, ietask), fieldid, igrid, &
                 igrid_d, istart, istop, jstart, jstop, kstart, kstop, &
                 istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d)
         END IF
@@ -535,8 +755,8 @@ CONTAINS
         END IF
         IF (PRESENT(v2) .AND. exV) THEN
             fieldid = 2   ! (for v2)
-            iselftask = iselftask + 1
-            CALL add_self_task(selftasks(:, iselftask), fieldid, igrid, &
+            ietask = ietask + 1
+            CALL add_self_task(etasks(:, ietask), fieldid, igrid, &
                 igrid_d, istart, istop, jstart, jstop, kstart, kstop, &
                 istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d)
         END IF
@@ -548,8 +768,8 @@ CONTAINS
         END IF
         IF (PRESENT(v3) .AND. exW) THEN
             fieldid = 3   ! (for v3)
-            iselftask = iselftask + 1
-            CALL add_self_task(selftasks(:, iselftask), fieldid, igrid, &
+            ietask = ietask + 1
+            CALL add_self_task(etasks(:, ietask), fieldid, igrid, &
                 igrid_d, istart, istop, jstart, jstop, kstart, kstop, &
                 istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d)
         END IF
@@ -562,24 +782,24 @@ CONTAINS
         END IF
         IF (PRESENT(s1) .AND. exp1) THEN
             fieldid = 4   ! (for s1)
-            iselftask = iselftask + 1
-            CALL add_self_task(selftasks(:, iselftask), fieldid, igrid, &
+            ietask = ietask + 1
+            CALL add_self_task(etasks(:, ietask), fieldid, igrid, &
                 igrid_d, istart, istop, jstart, jstop, kstart, kstop, &
                 istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d)
         END IF
 
         IF (PRESENT(s2)) THEN
             fieldid = 5   ! (for s2)
-            iselftask = iselftask + 1
-            CALL add_self_task(selftasks(:, iselftask), fieldid, igrid, &
+            ietask = ietask + 1
+            CALL add_self_task(etasks(:, ietask), fieldid, igrid, &
                 igrid_d, istart, istop, jstart, jstop, kstart, kstop, &
                 istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d)
         END IF
 
         IF (PRESENT(s3)) THEN
             fieldid = 6   ! (for s3)
-            iselftask = iselftask + 1
-            CALL add_self_task(selftasks(:, iselftask), fieldid, igrid, &
+            ietask = ietask + 1
+            CALL add_self_task(etasks(:, ietask), fieldid, igrid, &
                 igrid_d, istart, istop, jstart, jstop, kstart, kstop, &
                 istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d)
         END IF
@@ -588,41 +808,51 @@ CONTAINS
 
     ! Store the paremters for a single non-blocking MPI send call
     !
-    SUBROUTINE add_mpisend_task(impisendtask, iprocnbr, messagelength, &
-        sendcounter)
+    SUBROUTINE add_mpi_task(mpitasks, impitask, iprocnbr, &
+        messagelength, counter, type)
 
         ! Subroutine arguments
-        INTEGER(intk), INTENT(inout) :: impisendtask
+        INTEGER(intk), INTENT(inout) :: mpitasks(mpitasksize, maxtasks)
+        INTEGER(intk), INTENT(inout) :: impitask
         INTEGER(intk), INTENT(in) :: iprocnbr
         INTEGER(intk), INTENT(inout) :: messagelength
-        INTEGER(intk), INTENT(inout) :: sendcounter
+        INTEGER(intk), INTENT(inout) :: counter
+        CHARACTER(len=4), INTENT(in) :: type
 
         ! Local variables
         ! none...
 
-        nsend = nsend + 1
-        sendlist(nsend) = iprocnbr
+        IF (type == 'send') THEN
+            nsend = nsend + 1
+            sendlist(nsend) = iprocnbr
+        ELSE IF (type == 'recv') THEN
+            nrecv = nrecv + 1
+            recvlist(nrecv) = iprocnbr
+        ELSE
+            CALL errr(__FILE__, __LINE__)
+        END IF
 
-        ! Add the MPI send task to the mpisendtasks array
-        impisendtask = impisendtask + 1
+        ! Add the MPI send task to the mpitasks array
+        impitask = impitask + 1
 
-        mpisendtasks(1, impisendtask) = iprocnbr
-        mpisendtasks(2, impisendtask) = messagelength
-        mpisendtasks(3, impisendtask) = sendcounter
+        mpitasks(1, impitask) = iprocnbr
+        mpitasks(2, impitask) = messagelength
+        mpitasks(3, impitask) = counter
 
-        sendcounter = sendcounter + messagelength
+        counter = counter + messagelength
         messagelength = 0
 
-    END SUBROUTINE add_mpisend_task
+    END SUBROUTINE add_mpi_task
 
 
     ! Routine to prepare all workpackages for processing the receive buffer
     !
-    SUBROUTINE prepare_recvtasks_all(nrecvtasks, nplane, normal, flag, v1, v2, &
-        v3, s1, s2, s3)
+    SUBROUTINE prepare_recvtasks_all(rtasks, nrtasks, nplane, normal, &
+            flag, v1, v2, v3, s1, s2, s3)
 
         ! Subroutine arguments
-        INTEGER(int32), INTENT(out) :: nrecvtasks
+        INTEGER(intk), INTENT(inout) :: rtasks(buffertasksize, maxtasks)
+        INTEGER(intk), INTENT(out) :: nrtasks
         INTEGER(int32), INTENT(in) :: nplane
         LOGICAL, INTENT(in) :: normal
         CHARACTER(len=1), INTENT(in) :: flag
@@ -634,9 +864,9 @@ CONTAINS
         TYPE(MPI_Status) :: recvstatus
         INTEGER(int32) :: recvmessagelen
         INTEGER(int32) :: unpacklen
-        INTEGER(int32) :: irecvtask
+        INTEGER(intk) :: irtask
 
-        irecvtask = 0
+        irtask = 0
 
         DO WHILE (.TRUE.)
             IF (nrecv == 0) EXIT
@@ -653,10 +883,9 @@ CONTAINS
                     IF (recvidxlist(1, i) == recvlist(idx) &
                             .AND. recvidxlist(2, i) > 0) THEN
 
-                        ! >>> adding entries to recvtasks (no execution)
-                        ! (replaces "read_buffer")
-                        CALL prepare_recvtasks(irecvtask, i, nplane, normal, &
-                            flag, v1, v2, v3, s1, s2, s3)
+                        ! >>> adding entries to recvtasks ("read_buffer")
+                        CALL prepare_recvtasks(rtasks, irtask, &
+                            i, nplane, normal, flag, v1, v2, v3, s1, s2, s3)
 
                         unpacklen = unpacklen + recvidxlist(2, i)
                     END IF
@@ -675,21 +904,22 @@ CONTAINS
         CALL MPI_Waitall(nsend, sendreqs, MPI_STATUSES_IGNORE)
 
         ! Setting the number of recvtasks to the actual number of tasks
-        nrecvtasks = irecvtask
+        nrtasks = irtask
 
         ! Add a harmful dummy task at (ntasks+1) to detect execution overshoot
-        recvtasks(:, nrecvtasks+1) = -1
+        rtasks(:, nrtasks+1) = -1
 
     END SUBROUTINE prepare_recvtasks_all
 
 
     ! Routine to prepare a workpackage for reading received values from buffer
     !
-    SUBROUTINE prepare_recvtasks(irecvtask, recvid, nplane, normal, flag, &
-        v1, v2, v3, s1, s2, s3)
+    SUBROUTINE prepare_recvtasks(rtasks, irtask, recvid, nplane, &
+            normal, flag, v1, v2, v3, s1, s2, s3)
 
         ! Subroutine arguments
-        INTEGER(int32), INTENT(inout) :: irecvtask
+        INTEGER(intk), INTENT(inout) :: rtasks(buffertasksize, maxtasks)
+        INTEGER(intk), INTENT(inout) :: irtask
         INTEGER(intk), INTENT(in) :: recvid
         INTEGER(int32), INTENT(in) :: nplane
         LOGICAL, INTENT(in) :: normal
@@ -701,11 +931,11 @@ CONTAINS
 
         ! Grid to send from
         ! Must be intk because it intreface with MGLET
-        INTEGER(intk) :: igrid, ifacerecv
+        INTEGER(intk) :: igrid, ifacerecv, fieldid
 
         ! Message sizes
         ! Must be int32 because it iterface with MPI
-        INTEGER(int32) :: offset, icount, fieldid
+        INTEGER(int32) :: offset, icount
 
         ! Flags to indicate exchange of U, V, W
         LOGICAL :: exU, exV, exW, exp1
@@ -734,9 +964,9 @@ CONTAINS
             exU = (normal .AND. ifacerecv < 3) .OR. (.NOT. normal)
         END IF
         IF (PRESENT(v1) .AND. exU) THEN
-            irecvtask = irecvtask + 1
+            irtask = irtask + 1
             fieldid = 1   ! (for v1)
-            CALL add_single_task(recvtasks(:, irecvtask), fieldid, icount, &
+            CALL add_single_task(rtasks(:, irtask), fieldid, icount, &
                 igrid, istart, istop, jstart, jstop, kstart, kstop)
         END IF
 
@@ -747,9 +977,9 @@ CONTAINS
                 (.NOT. normal)
         END IF
         IF (PRESENT(v2) .AND. exV) THEN
-            irecvtask = irecvtask + 1
+            irtask = irtask + 1
             fieldid = 2   ! (for v2)
-            CALL add_single_task(recvtasks(:, irecvtask), fieldid, icount, &
+            CALL add_single_task(rtasks(:, irtask), fieldid, icount, &
                 igrid, istart, istop, jstart, jstop, kstart, kstop)
         END IF
 
@@ -759,9 +989,9 @@ CONTAINS
             exW = (normal .AND. ifacerecv > 4) .OR. (.NOT. normal)
         END IF
         IF (PRESENT(v3) .AND. exW) THEN
-            irecvtask = irecvtask + 1
+            irtask = irtask + 1
             fieldid = 3   ! (for v3)
-            CALL add_single_task(recvtasks(:, irecvtask), fieldid, icount, &
+            CALL add_single_task(rtasks(:, irtask), fieldid, icount, &
                 igrid, istart, istop, jstart, jstop, kstart, kstop)
         END IF
 
@@ -772,23 +1002,23 @@ CONTAINS
             exp1 = .TRUE.
         END IF
         IF (PRESENT(s1) .AND. exp1) THEN
-            irecvtask = irecvtask + 1
+            irtask = irtask + 1
             fieldid = 4   ! (for s1)
-            CALL add_single_task(recvtasks(:, irecvtask), fieldid, icount, &
+            CALL add_single_task(rtasks(:, irtask), fieldid, icount, &
                 igrid, istart, istop, jstart, jstop, kstart, kstop)
         END IF
 
         IF (PRESENT(s2)) THEN
-            irecvtask = irecvtask + 1
+            irtask = irtask + 1
             fieldid = 5   ! (for s2)
-            CALL add_single_task(recvtasks(:, irecvtask), fieldid, icount, &
+            CALL add_single_task(rtasks(:, irtask), fieldid, icount, &
                 igrid, istart, istop, jstart, jstop, kstart, kstop)
         END IF
 
         IF (PRESENT(s3)) THEN
-            irecvtask = irecvtask + 1
+            irtask = irtask + 1
             fieldid = 6   ! (for s3)
-            CALL add_single_task(recvtasks(:, irecvtask), fieldid, icount, &
+            CALL add_single_task(rtasks(:, irtask), fieldid, icount, &
                 igrid, istart, istop, jstart, jstop, kstart, kstop)
         END IF
 
@@ -877,256 +1107,328 @@ CONTAINS
 
     ! Routine with offloaded kernel to process all sendtasks on the device
     !
-    SUBROUTINE process_sendtasks(nsendtasks, f1, f2, f3, f4, f5, f6)
+    SUBROUTINE process_sendtasks(stasks, nstasks)
 
         ! Subroutine arguments
-        INTEGER(intk), INTENT(in) :: nsendtasks
-        TYPE(field_t), POINTER, INTENT(inout) :: f1, f2, f3, f4, f5, f6
+        INTEGER(intk), INTENT(in) :: stasks(buffertasksize, maxtasks)
+        INTEGER(intk), INTENT(in) :: nstasks
 
         ! Local variables
         INTEGER(intk) :: itask, fieldid, icount, igrid, istart, istop, &
-            jstart, jstop, kstart, kstop, jjl, kkl, idx
-        INTEGER(intk) :: i, j, k
-        TYPE(field_t), POINTER :: field
-        REAL(realk), POINTER, CONTIGUOUS :: rarr(:, :, :)
+            jstart, jstop, kstart, kstop, ii, jj, kk, ip3
 
-        IF (nsendtasks == 0) THEN
+        IF (nstasks == 0) THEN
             RETURN
         END IF
 
+        ! At all cost, avoid pointers within the kernel or, even worse,
+        ! pointer operations within the kernel!
+        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
+                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr)
+
         !$omp target teams distribute private(itask, fieldid, icount, &
-        !$omp&  igrid, istart, istop, jstart, jstop, kstart, kstop, jjl, kkl, &
-        !$omp&  idx, i, j, k, field, rarr)
-        DO itask = 1, nsendtasks
+        !$omp&  igrid, istart, istop, jstart, jstop, kstart, kstop, &
+        !$omp&  ii, jj, kk, ip3)
+        DO itask = 1, nstasks
 
             ! Set variables from sendtasks workpackage
-            fieldid = sendtasks(1, itask)
-            icount = sendtasks(2, itask)
-            igrid = sendtasks(3, itask)
-            istart = sendtasks(4, itask)
-            istop = sendtasks(5, itask)
-            jstart = sendtasks(6, itask)
-            jstop = sendtasks(7, itask)
-            kstart = sendtasks(8, itask)
-            kstop = sendtasks(9, itask)
+            fieldid = stasks(1, itask)
+            icount = stasks(2, itask)
+            igrid = stasks(3, itask)
+            istart = stasks(4, itask)
+            istop = stasks(5, itask)
+            jstart = stasks(6, itask)
+            jstop = stasks(7, itask)
+            kstart = stasks(8, itask)
+            kstop = stasks(9, itask)
 
-            ! Dimensions of the subarray to be treated
-            kkl = kstop - kstart + 1
-            jjl = jstop - jstart + 1
+            ! The following replaces "read_single_buffer"
+            CALL get_ip3(ip3, igrid)
+            CALL get_mgdims(kk, jj, ii, igrid)
 
             ! Assign the correct field pointer based on ifield
             SELECT CASE (fieldid)
             CASE (1)
-                field => f1
+                CALL arr_to_buf(kk, jj, ii, a1(ip3), istart, istop, &
+                    jstart, jstop, kstart, kstop, icount)
             CASE (2)
-                field => f2
+                CALL arr_to_buf(kk, jj, ii, a2(ip3), istart, istop, &
+                    jstart, jstop, kstart, kstop, icount)
             CASE (3)
-                field => f3
+                CALL arr_to_buf(kk, jj, ii, a3(ip3), istart, istop, &
+                    jstart, jstop, kstart, kstop, icount)
             CASE (4)
-                field => f4
+                CALL arr_to_buf(kk, jj, ii, a4(ip3), istart, istop, &
+                    jstart, jstop, kstart, kstop, icount)
             CASE (5)
-                field => f5
+                CALL arr_to_buf(kk, jj, ii, a5(ip3), istart, istop, &
+                    jstart, jstop, kstart, kstop, icount)
             CASE (6)
-                field => f6
+                CALL arr_to_buf(kk, jj, ii, a6(ip3), istart, istop, &
+                    jstart, jstop, kstart, kstop, icount)
             CASE DEFAULT
                 CALL errr(__FILE__, __LINE__)
             END SELECT
 
-            ! The following replaces "write_single_buffer"
-            CALL get_grid3_real(rarr, field, igrid)
-
-            ! Fully parallelizable copy loop
-            !$omp parallel do collapse(3) private(i, j, k, idx)
-            DO i = istart, istop
-                DO j = jstart, jstop
-                    DO k = kstart, kstop
-
-                        ! Computation of count to avoid incremental
-                        idx = 1 + (k - kstart) + (j - jstart)*kkl + &
-                            (i - istart)*jjl*kkl + icount
-
-                        sendbuf(idx) = rarr(k, j, i)
-
-                    END DO
-                END DO
-            END DO
-            !$omp end parallel do
-
         END DO
         !$omp end target teams distribute
 
+        END ASSOCIATE
+
     END SUBROUTINE process_sendtasks
+
+    SUBROUTINE arr_to_buf(kk, jj, ii, arr, istart, istop, &
+        jstart, jstop, kstart, kstop, icount)
+        !$omp declare target
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(in) :: arr(kk, jj, ii)
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, &
+            kstop, icount
+        ! Local variables
+        INTEGER(intk) :: i, j, k, idx_b, kkl, jjl
+
+        kkl = kstop - kstart + 1
+        jjl = jstop - jstart + 1
+
+        !$omp parallel do collapse(3) private(i, j, k, idx_b)
+        DO i = istart, istop
+            DO j = jstart, jstop
+                DO k = kstart, kstop
+                    idx_b = 1 + (k-kstart) + (j-jstart)*kkl + &
+                        (i-istart)*jjl*kkl + icount
+                    sendbuf(idx_b) = arr(k, j, i)
+                END DO
+            END DO
+        END DO
+        !$omp end parallel do
+
+    END SUBROUTINE arr_to_buf
+
 
 
     ! Routine with offloaded kernel to process all receive tasks on the device
     !
-    SUBROUTINE process_recvtasks(nrecvtasks, f1, f2, f3, f4, f5, f6)
+    SUBROUTINE process_recvtasks(rtasks, nrtasks)
 
         ! Subroutine arguments
-        INTEGER(intk), INTENT(in) :: nrecvtasks
-        TYPE(field_t), POINTER, INTENT(inout) :: f1, f2, f3, f4, f5, f6
+        INTEGER(intk), INTENT(in) :: rtasks(buffertasksize, maxtasks)
+        INTEGER(intk), INTENT(in) :: nrtasks
 
         ! Local variables
-        INTEGER(int32) :: itask, fieldid, icount, igrid, istart, istop, &
-            jstart, jstop, kstart, kstop, kkl, jjl, idx
-        TYPE(field_t), POINTER :: field
-        REAL(realk), POINTER, CONTIGUOUS :: rarr(:, :, :)
-        INTEGER(intk) :: i, j, k
+        INTEGER(intk) :: itask, fieldid, icount, igrid, istart, istop, &
+            jstart, jstop, kstart, kstop, ii, jj, kk, ip3
 
-        IF (nrecvtasks == 0) THEN
+        IF (nrtasks == 0) THEN
             RETURN
         END IF
 
+        ! At all cost, avoid pointers within the kernel or, even worse,
+        ! pointer operations within the kernel!
+        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
+                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr)
+
         !$omp target teams distribute private(itask, fieldid, icount, &
-        !$omp&  igrid, istart, istop, jstart, jstop, kstart, kstop, jjl, kkl, &
-        !$omp&  idx, i, j, k, field, rarr)
-        DO itask = 1, nrecvtasks
+        !$omp&  igrid, istart, istop, jstart, jstop, kstart, kstop, &
+        !$omp&  ii, jj, kk, ip3)
+        DO itask = 1, nrtasks
 
             ! Set variables from recvtasks workpackage
-            fieldid = recvtasks(1, itask)
-            icount  = recvtasks(2, itask)
-            igrid   = recvtasks(3, itask)
-            istart  = recvtasks(4, itask)
-            istop   = recvtasks(5, itask)
-            jstart  = recvtasks(6, itask)
-            jstop   = recvtasks(7, itask)
-            kstart  = recvtasks(8, itask)
-            kstop   = recvtasks(9, itask)
+            fieldid = rtasks(1, itask)
+            icount  = rtasks(2, itask)
+            igrid   = rtasks(3, itask)
+            istart  = rtasks(4, itask)
+            istop   = rtasks(5, itask)
+            jstart  = rtasks(6, itask)
+            jstop   = rtasks(7, itask)
+            kstart  = rtasks(8, itask)
+            kstop   = rtasks(9, itask)
 
-            ! Dimensions of the subarray to be treated
-            kkl = kstop - kstart + 1
-            jjl = jstop - jstart + 1
+            ! The following replaces "read_single_buffer"
+            CALL get_ip3(ip3, igrid)
+            CALL get_mgdims(kk, jj, ii, igrid)
 
             ! Assign the correct field pointer
             SELECT CASE (fieldid)
             CASE (1)
-                field => f1
+                CALL buf_to_arr(kk, jj, ii, a1(ip3), istart, istop, &
+                    jstart, jstop, kstart, kstop, icount)
             CASE (2)
-                field => f2
+                CALL buf_to_arr(kk, jj, ii, a2(ip3), istart, istop, &
+                    jstart, jstop, kstart, kstop, icount)
             CASE (3)
-                field => f3
+                CALL buf_to_arr(kk, jj, ii, a3(ip3), istart, istop, &
+                    jstart, jstop, kstart, kstop, icount)
             CASE (4)
-                field => f4
+                CALL buf_to_arr(kk, jj, ii, a4(ip3), istart, istop, &
+                    jstart, jstop, kstart, kstop, icount)
             CASE (5)
-                field => f5
+                CALL buf_to_arr(kk, jj, ii, a5(ip3), istart, istop, &
+                    jstart, jstop, kstart, kstop, icount)
             CASE (6)
-                field => f6
+                CALL buf_to_arr(kk, jj, ii, a6(ip3), istart, istop, &
+                    jstart, jstop, kstart, kstop, icount)
             CASE DEFAULT
                 CALL errr(__FILE__, __LINE__)
             END SELECT
 
-            ! The following replaces "read_single_buffer"
-            CALL get_grid3_real(rarr, field, igrid)
-
-            ! Fully parallelizable copy loop
-            !$omp parallel do collapse(3) private(i, j, k, idx)
-            DO i = istart, istop
-                DO j = jstart, jstop
-                    DO k = kstart, kstop
-
-                        idx = 1 + (k - kstart) + (j - jstart)*kkl + &
-                            (i - istart)*jjl*kkl + icount
-
-                        rarr(k, j, i) = recvbuf(idx)
-
-                    END DO
-                END DO
-            END DO
-            !$omp end parallel do
-
         END DO
         !$omp end target teams distribute
+
+        END ASSOCIATE
 
     END SUBROUTINE process_recvtasks
 
 
+    SUBROUTINE buf_to_arr(kk, jj, ii, arr, istart, istop, &
+        jstart, jstop, kstart, kstop, icount)
+        !$omp declare target
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(inout) :: arr(kk, jj, ii)
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, &
+            kstop, icount
+        ! Local variables
+        INTEGER(intk) :: i, j, k, idx_b, kkl, jjl
+
+        kkl = kstop - kstart + 1
+        jjl = jstop - jstart + 1
+
+        !$omp parallel do collapse(3) private(i, j, k, idx_b)
+        DO i = istart, istop
+            DO j = jstart, jstop
+                DO k = kstart, kstop
+                    idx_b = 1 + (k-kstart) + (j-jstart)*kkl + &
+                        (i-istart)*jjl*kkl + icount
+                    arr(k, j, i) = recvbuf(idx_b)
+                END DO
+            END DO
+        END DO
+        !$omp end parallel do
+
+    END SUBROUTINE buf_to_arr
+
+
+
+
+
+
     ! Routine with offloaded kernel to process all selftasks on the device
     !
-    SUBROUTINE process_selftasks(nselftasks, f1, f2, f3, f4, f5, f6)
+    SUBROUTINE process_selftasks(stasks, nstasks)
 
         ! Subroutine arguments
-        INTEGER(int32), INTENT(in) :: nselftasks
-        TYPE(field_t), POINTER, INTENT(inout) :: f1, f2, f3, f4, f5, f6
+        INTEGER(intk), INTENT(in) :: stasks(selftasksize, maxtasks)
+        INTEGER(intk), INTENT(in) :: nstasks
 
         ! Local variables
-        INTEGER(int32) :: itask, fieldid
-        INTEGER(int32) :: igrid, igrid_d
-        INTEGER(int32) :: istart, istop, jstart, jstop, kstart, kstop, &
+        INTEGER(intk) :: itask, fieldid, igrid, igrid_d, ip3, ip3_d, &
+            kk, jj, ii, istart, istop, jstart, jstop, kstart, kstop, &
             istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d
-        INTEGER(int32) :: koff, joff, ioff
-        INTEGER(int32) :: i, j, k
-        TYPE(field_t), POINTER :: field
-        REAL(realk), POINTER, CONTIGUOUS :: src_rarr(:, :, :), dst_rarr(:, :, :)
 
         ! Precheck to avoid kernel launch overhead
-        IF (nselftasks == 0) THEN
+        IF (nstasks == 0) THEN
             RETURN
         END IF
+
+        ! At all cost, avoid pointers within the kernel or, even worse,
+        ! pointer operations within the kernel!
+        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
+                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr)
 
         !$omp target teams distribute private(itask, fieldid, igrid, igrid_d, &
         !$omp&  istart, istop, jstart, jstop, kstart, kstop, &
         !$omp&  istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d, &
-        !$omp&  koff, joff, ioff, i, j, k, field, src_rarr, dst_rarr) nowait
-        DO itask = 1, nselftasks
+        !$omp&  ip3, ip3_d, kk, jj, ii)
+        DO itask = 1, nstasks
 
             ! Set variables from selftasks workpackage
-            fieldid  = selftasks(1, itask)
-            igrid    = selftasks(2, itask)
-            igrid_d  = selftasks(3, itask)
-            istart   = selftasks(4, itask)
-            istop    = selftasks(5, itask)
-            jstart   = selftasks(6, itask)
-            jstop    = selftasks(7, itask)
-            kstart   = selftasks(8, itask)
-            kstop    = selftasks(9, itask)
-            istart_d = selftasks(10, itask)
-            istop_d  = selftasks(11, itask)
-            jstart_d = selftasks(12, itask)
-            jstop_d  = selftasks(13, itask)
-            kstart_d = selftasks(14, itask)
-            kstop_d  = selftasks(15, itask)
+            fieldid  = stasks(1, itask)
+            igrid    = stasks(2, itask)
+            igrid_d  = stasks(3, itask)
+            istart   = stasks(4, itask)
+            istop    = stasks(5, itask)
+            jstart   = stasks(6, itask)
+            jstop    = stasks(7, itask)
+            kstart   = stasks(8, itask)
+            kstop    = stasks(9, itask)
+            istart_d = stasks(10, itask)
+            istop_d  = stasks(11, itask)
+            jstart_d = stasks(12, itask)
+            jstop_d  = stasks(13, itask)
+            kstart_d = stasks(14, itask)
+            kstop_d  = stasks(15, itask)
 
-            koff = kstart - kstart_d
-            joff = jstart - jstart_d
-            ioff = istart - istart_d
+            ! The following replaces "read_single_buffer"
+            CALL get_ip3(ip3, igrid)
+            CALL get_ip3(ip3_d, igrid_d)
+            CALL get_mgdims(kk, jj, ii, igrid)
 
-            ! Assign the correct field pointer based on ifield
             SELECT CASE (fieldid)
             CASE (1)
-                field => f1
+                CALL arr_to_arr(kk, jj, ii, a1(ip3_d), a1(ip3), &
+                    istart, istop, jstart, jstop, kstart, kstop, &
+                    istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d)
             CASE (2)
-                field => f2
+                CALL arr_to_arr(kk, jj, ii, a2(ip3_d), a2(ip3), &
+                    istart, istop, jstart, jstop, kstart, kstop, &
+                    istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d)
             CASE (3)
-                field => f3
+                CALL arr_to_arr(kk, jj, ii, a3(ip3_d), a3(ip3), &
+                    istart, istop, jstart, jstop, kstart, kstop, &
+                    istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d)
             CASE (4)
-                field => f4
+                CALL arr_to_arr(kk, jj, ii, a4(ip3_d), a4(ip3), &
+                    istart, istop, jstart, jstop, kstart, kstop, &
+                    istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d)
             CASE (5)
-                field => f5
+                CALL arr_to_arr(kk, jj, ii, a5(ip3_d), a5(ip3), &
+                    istart, istop, jstart, jstop, kstart, kstop, &
+                    istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d)
             CASE (6)
-                field => f6
+                CALL arr_to_arr(kk, jj, ii, a6(ip3_d), a6(ip3), &
+                    istart, istop, jstart, jstop, kstart, kstop, &
+                    istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d)
             CASE DEFAULT
                 CALL errr(__FILE__, __LINE__)
             END SELECT
 
-            ! The following replaces "connect_self_single"
-            CALL get_grid3_real(src_rarr, field, igrid)
-            CALL get_grid3_real(dst_rarr, field, igrid_d)
-
-            !$omp parallel do collapse(3) private(i, j, k)
-            DO i = istart_d, istop_d
-                DO j = jstart_d, jstop_d
-                    DO k = kstart_d, kstop_d
-                        dst_rarr(k, j, i) = &
-                            src_rarr(k + koff, j + joff, i + ioff)
-                    END DO
-                END DO
-            END DO
-            !$omp end parallel do
-
         END DO
         !$omp end target teams distribute
 
+        END ASSOCIATE
+
     END SUBROUTINE process_selftasks
+
+    PURE SUBROUTINE arr_to_arr(kk, jj, ii, dst_rarr, src_rarr, &
+            istart, istop, jstart, jstop, kstart, kstop, &
+            istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d)
+        !$omp declare target
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(inout) :: dst_rarr(kk, jj, ii)
+        REAL(realk), INTENT(in) :: src_rarr(kk, jj, ii)
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, &
+             kstop, istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d
+        ! Local variables
+        INTEGER(intk) :: koff, joff, ioff, i, j, k
+
+        koff = kstart - kstart_d
+        joff = jstart - jstart_d
+        ioff = istart - istart_d
+
+        !$omp parallel do collapse(3) private(i, j, k)
+        DO i = istart_d, istop_d
+            DO j = jstart_d, jstop_d
+                DO k = kstart_d, kstop_d
+                    dst_rarr(k, j, i) = &
+                        src_rarr(k + koff, j + joff, i + ioff)
+                END DO
+            END DO
+        END DO
+        !$omp end parallel do
+
+    END SUBROUTINE arr_to_arr
 
 
 
@@ -1159,20 +1461,21 @@ CONTAINS
 
     ! Perform all non-blocking MPI Send calls based on the mpisendtasks
     !
-    SUBROUTINE send_mpi_all(nmpisendtasks)
+    SUBROUTINE process_mpisend(mpistasks, nmpistasks)
 
         ! Subroutine arguments
-        INTEGER(int32), INTENT(in) :: nmpisendtasks
+        INTEGER(intk), INTENT(in) :: mpistasks(mpitasksize, maxtasks)
+        INTEGER(intk), INTENT(in) :: nmpistasks
 
         ! Local variables
         INTEGER(int32) :: itask, iprocnbr, messagelength, sendcounter
 
         ! Iterate over task and post all non-blocking MPI send calls
-        DO itask = 1, nmpisendtasks
+        DO itask = 1, nmpistasks
 
-            iprocnbr      = mpisendtasks(1, itask)
-            messagelength = mpisendtasks(2, itask)
-            sendcounter   = mpisendtasks(3, itask)
+            iprocnbr      = INT(mpistasks(1, itask), int32)
+            messagelength = INT(mpistasks(2, itask), int32)
+            sendcounter   = INT(mpistasks(3, itask), int32)
 
             !$omp target data use_device_addr(sendbuf)
             CALL MPI_Isend(sendbuf(sendcounter + 1), messagelength, &
@@ -1181,15 +1484,127 @@ CONTAINS
             !$omp end target data
         END DO
 
+        nsend = nmpistasks
+
         ! Safety check based on final dummy entry
-        IF (nmpisendtasks < maxtasks) THEN
-            IF (.NOT. ALL(mpisendtasks(:, nmpisendtasks+1) == -1)) THEN
+        IF (nmpistasks < maxtasks) THEN
+            IF (.NOT. ALL(mpistasks(:, nmpistasks+1) == -1)) THEN
                 WRITE(*, *) "Did not encounter the expected dummy task."
                 CALL errr(__FILE__, __LINE__)
             END IF
         END IF
 
-    END SUBROUTINE send_mpi_all
+    END SUBROUTINE process_mpisend
+
+
+    ! Perform all non-blocking MPI Send calls based on the mpisendtasks
+    !
+    SUBROUTINE process_mpirecv(mpirtasks, nmpirtasks)
+
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: mpirtasks(mpitasksize, maxtasks)
+        INTEGER(intk), INTENT(in) :: nmpirtasks
+
+        ! Local variables
+        INTEGER(int32) :: itask, iprocnbr, messagelength, recvcounter
+
+        ! Iterate over task and post all non-blocking MPI send calls
+        DO itask = 1, nmpirtasks
+
+            iprocnbr      = INT(mpirtasks(1, itask), int32)
+            messagelength = INT(mpirtasks(2, itask), int32)
+            recvcounter   = INT(mpirtasks(3, itask), int32)
+
+            !$omp target data use_device_addr(recvbuf)
+            CALL MPI_Irecv(recvbuf(recvcounter+1), messagelength, &
+                mglet_mpi_real, iprocnbr, 1, MPI_COMM_WORLD, recvreqs(itask))
+            !$omp end target data
+
+        END DO
+
+        nrecv = nmpirtasks
+
+        ! Safety check based on final dummy entry
+        IF (nmpirtasks < maxtasks) THEN
+            IF (.NOT. ALL(mpirtasks(:, nmpirtasks+1) == -1)) THEN
+                WRITE(*, *) "Did not encounter the expected dummy task."
+                CALL errr(__FILE__, __LINE__)
+            END IF
+        END IF
+
+    END SUBROUTINE process_mpirecv
+
+
+    ! Perform all non-blocking MPI Recv calls
+    !
+    SUBROUTINE prepare_mpirecvtasks(mpirtasks, nmpirtasks, &
+            minconlvl, maxconlvl, nplane, vertices, &
+            normal, fwd, flag, nvars)
+
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(inout) :: mpirtasks(mpitasksize, maxtasks)
+        INTEGER(intk), INTENT(out) :: nmpirtasks
+        INTEGER(intk), INTENT(in) :: minconlvl, maxconlvl, nplane
+        LOGICAL, INTENT(in) :: vertices, normal
+        INTEGER(intk), INTENT(in) :: fwd
+        CHARACTER(len=1), INTENT(in) :: flag
+        INTEGER(intk), INTENT(in) :: nvars
+
+
+        ! Local variables
+        INTEGER(intk) :: i, iprocnbr, igrid, iface, facearea, impirtask
+        LOGICAL :: exchange, geometry
+        INTEGER(int32) :: recvcounter, messagelength
+
+        geometry = .FALSE.
+
+        ! Post all receive calls
+        recvcounter = 0
+        messagelength = 0
+        nrecv = 0
+        recvidxlist = 0
+        impirtask = 0
+
+        DO i = 1, SIZE(recvconns, 2)
+            exchange = decide(i, recvconns, geometry, vertices, fwd, &
+                minconlvl, maxconlvl)
+            iprocnbr = recvconns(2, i)
+
+            ! Communication with self is handled specially in
+            ! send_all - nothing to do here
+            IF (iprocnbr == myid) THEN
+                CYCLE
+            END IF
+
+            IF (exchange) THEN
+                igrid = recvconns(3, i)
+                iface = recvconns(5, i)
+
+                facearea = face_area(igrid, iface, nplane, flag)
+                recvidxlist(1, i) = iprocnbr
+                recvidxlist(2, i) = nvars*facearea
+                recvidxlist(3, i) = recvcounter + messagelength
+                messagelength = messagelength + nvars*facearea
+            END IF
+
+            IF (messagelength > 0) THEN
+                IF (i == SIZE(recvconns, 2)) THEN
+                    CALL add_mpi_task(mpirtasks, impirtask, &
+                        iprocnbr, messagelength, recvcounter, "recv")
+                ELSE IF (recvconns(2, i + 1) /= iprocnbr) THEN
+                    CALL add_mpi_task(mpirtasks, impirtask, &
+                        iprocnbr, messagelength, recvcounter, "recv")
+                END IF
+            END IF
+        END DO
+
+        ! Set the output task counters
+        nmpirtasks = impirtask
+
+        ! Add a harmful dummy task at (ntasks+1) for checking
+        mpirtasks(:, nmpirtasks+1) = -1
+
+    END SUBROUTINE prepare_mpirecvtasks
 
 
     ! Perform all non-blocking MPI Recv calls

--- a/src/core/core_mod.F90
+++ b/src/core/core_mod.F90
@@ -33,6 +33,7 @@ MODULE core_mod
     USE qsort_mod
     USE readstl_mod
     USE rungekutta_mod
+    USE profile_tools_mod
     USE shmem_mod
     USE simdfunctions_mod
     USE statistics_mod

--- a/src/core/pointers_mod.F90
+++ b/src/core/pointers_mod.F90
@@ -11,7 +11,7 @@ MODULE pointers_mod
     INTEGER(intk), PROTECTED :: idim3d, idimbb
     INTEGER(intk), ALLOCATABLE, PROTECTED :: ip3d(:)
     INTEGER(intk), ALLOCATABLE, PROTECTED :: ipbb(:, :)
-    !$omp declare target(ipbb)
+    !$omp declare target(ipbb, ip3d)
 
     PUBLIC :: init_pointers, finish_pointers, get_ip3, get_ip3n, get_ibb, &
         idim3d, idimbb, get_len3
@@ -73,7 +73,7 @@ CONTAINS
             END DO
         END BLOCK
 
-        !$omp target enter data map(always, to: ipbb)
+        !$omp target enter data map(always, to: ipbb, ip3d)
 
         IF (myid == 0) THEN
             WRITE(*, '("ARRAY DIMENSIONS:")')
@@ -88,13 +88,14 @@ CONTAINS
         idim3d = 0
         idimbb = 0
 
+        !$omp target exit data map(always, delete: ipbb, ip3d)
         DEALLOCATE(ip3d)
-        !$omp target exit data map(always, delete: ipbb)
         DEALLOCATE(ipbb)
     END SUBROUTINE finish_pointers
 
 
     SUBROUTINE get_ip3(ip3, igrid)
+        !$omp declare target
         INTEGER(intk), INTENT(in) :: igrid
         INTEGER(intk), INTENT(out) :: ip3
 

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -395,6 +395,7 @@ CONTAINS
         CALL map_arr_to_device(dp, message="to:dp%arr")
 
         DO iloop = 1, ninner
+            ! TODO(offload): Remove once surrounding subroutines are offloaded
             CALL bound_pressure(ilevel, dp, bp)
 
             IF (ityp == 1 .AND. ilevel > minlevel) THEN
@@ -406,6 +407,7 @@ CONTAINS
                 ! Use the SIP solver
                 CALL sip(ilevel, iloop, dp, res, rhs, siplw, sipls, siplb, &
                     sipue, sipun, siput, siplpr, bp)
+                ! TODO(offload): Remove once surrounding subroutines offloaded
             END IF
 
             CALL conn(ilevel, 1, s1=dp)
@@ -448,8 +450,10 @@ CONTAINS
             CALL sipiter1_classic_level(ilevel, res, rhs, siplw, sipls, siplb, &
                 siplpr)
         ELSE
+            CALL profile_range_push("sip1_hp")
             CALL sipiter1_hyperplane_level(ilevel, res, rhs, siplw, sipls, &
                 siplb, siplpr)
+            CALL profile_range_pop()
         END IF
 
         IF (iloop < ninner) THEN
@@ -461,8 +465,10 @@ CONTAINS
         IF (ityp == 2) THEN
             CALL sipiter2_classic_level(ilevel, dp, res, sipue, sipun, siput)
         ELSE
+            CALL profile_range_push("sip2_hp")
             CALL sipiter2_hyperplane_level(ilevel, dp, res, sipue, sipun, &
                 siput)
+            CALL profile_range_pop()
         END IF
     END SUBROUTINE sip
 


### PR DESCRIPTION
Performance enhancement of "conn2" by (i) recording communication workpackages and (ii) avoidance of pointers, which kill performance with additional mapping operations.

@jfuchs-kmt Instead of declaring it "conn3", I would like to overwrite "conn2", as the "recording" is ruther an extension than a new conceptual branch. Do you agree?

Best regards,

Simon