### PR TITLE
Communication Batching and Modernization of ctof

### DIFF
--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -217,7 +217,7 @@ CONTAINS
             ! HINT: 'res' is passed into mgpoisit as a temporary storage!!
             CALL start_timer(322)
             DO ilevel = minlevel, maxlevel
-                CALL ctof(ilevel, hilf%arr, hilf%arr)
+                CALL ctof(ilevel, hilf, hilf)
                 CALL parent(ilevel, s1=hilf)
 
                 ! TODO(offload): Remove once surrounding subroutines offloaded

--- a/src/ib/ctof_mod.F90
+++ b/src/ib/ctof_mod.F90
@@ -1,4 +1,5 @@
 MODULE ctof_mod
+
     USE core_mod
     USE MPI_f08
 
@@ -27,7 +28,9 @@ MODULE ctof_mod
     LOGICAL :: is_init = .FALSE.
 
     PUBLIC :: ctof, init_ctof, finish_ctof
+
 CONTAINS
+
     SUBROUTINE ctof(ilevel, ff, fc)
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: ilevel  ! Level of the *fine* side
@@ -41,8 +44,13 @@ CONTAINS
 
         IF (.NOT. is_init) CALL errr(__FILE__, __LINE__)
 
+        ! Posting non-blocking receives and preparing lists for unpacking
         CALL recv_all(ilevel)
+
+        ! Packing data into send buffer and posting non-blocking sends
         CALL send_all(ilevel, fc)
+
+        ! Querying MPI for completed receives and unpacking the recv buffer
         CALL process_bufs(ff)
 
         CALL stop_timer(230)
@@ -54,16 +62,17 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: ilevel   ! Level of the *fine* side
 
         ! Local variables
-        INTEGER(intk) :: i, iprocnbr, igridf, kk, jj, ii
-        INTEGER(int32) :: recvcounter, messagelength, ncells
+        INTEGER(intk) :: kk, jj, ii, ncells, i, iprocnbr, igridf
+        INTEGER(int32) :: recvcounter, messagelength
 
         ! Post all receive calls
         recvcounter = 0
         messagelength = 0
         nrecv = 0
-        recvidxlist = -HUGE(1_intk)
+        recvidxlist = -1
         recvlist = 0
 
+        ! Iteration over all receive connections
         DO i = 1, irecv
             igridf = recvconns(3, i)
             IF (ilevel == level(igridf)) THEN
@@ -72,6 +81,7 @@ CONTAINS
                 CALL get_mgdims(kk, jj, ii, igridf)
                 ncells = kk*jj*ii/8
 
+                ! Entering the information needed for unpacking
                 recvidxlist(1, i) = iprocnbr
                 recvidxlist(2, i) = ncells
                 recvidxlist(3, i) = recvcounter + messagelength
@@ -84,8 +94,10 @@ CONTAINS
 
             IF (messagelength > 0) THEN
                 IF (i == irecv) THEN
+                    ! Posting at final receive connection
                     CALL post_recv(iprocnbr, messagelength, recvcounter)
                 ELSE IF (recvconns(2, i + 1) /= iprocnbr) THEN
+                    ! Posting at final receive connections from current sender
                     CALL post_recv(iprocnbr, messagelength, recvcounter)
                 END IF
             END IF
@@ -104,11 +116,13 @@ CONTAINS
 
         nrecv = nrecv + 1
         recvlist(nrecv) = iprocnbr
+
         CALL MPI_Irecv(recvbuf(recvcounter+1), messagelength, &
             mglet_mpi_real, iprocnbr, 1, MPI_COMM_WORLD, recvreqs(nrecv))
 
         recvcounter = recvcounter + messagelength
         messagelength = 0
+
     END SUBROUTINE post_recv
 
 
@@ -126,20 +140,25 @@ CONTAINS
         messagelength = 0
         nsend = 0
 
+        ! Iteration over all send connections
         DO i = 1, isend
             igridf = sendconns(3, i)
             iprocnbr = sendconns(1, i)
             IF (ilevel == level(igridf)) THEN
+                ! Extract data from the coarse grid and compact it into buffer
                 CALL write_buffer(i, messagelength, sendcounter, fc)
             END IF
 
             IF (messagelength > 0) THEN
                 IF (i == isend) THEN
+                    ! Posting at final send connection
                     CALL post_send(iprocnbr, messagelength, sendcounter)
                 ELSE IF (sendconns(1, i + 1) /= iprocnbr) THEN
+                    ! Posting at final send connection to this receiver
                     CALL post_send(iprocnbr, messagelength, sendcounter)
                 END IF
             END IF
+
         END DO
     END SUBROUTINE send_all
 
@@ -242,13 +261,17 @@ CONTAINS
         INTEGER(int32) :: idx, recvmessagelen, unpacklen
 
         DO WHILE (.TRUE.)
+
             IF (nrecv == 0) EXIT
             CALL MPI_Waitany(nrecv, recvreqs, idx, recvstatus)
 
             IF (idx /= MPI_UNDEFINED) THEN
-                CALL MPI_Get_count(recvstatus, mglet_mpi_real, recvmessagelen)
+                ! The index "idx" is returned and can be used to identify the
+                ! connection as recvlist(nrecv) = iprocnbr
 
                 unpacklen = 0
+
+                ! Check which non-zero packages belong to this sender and unpack
                 DO i = 1, irecv
                     IF (recvidxlist(1, i) == recvlist(idx) &
                             .AND. recvidxlist(2, i) > 0) THEN
@@ -257,15 +280,21 @@ CONTAINS
                     END IF
                 END DO
 
+                ! Ensure that the complete message has been unpacked
+                CALL MPI_Get_count(recvstatus, mglet_mpi_real, recvmessagelen)
                 IF (recvmessagelen /= unpacklen) THEN
                     CALL errr(__FILE__, __LINE__)
                 END IF
+
             ELSE
+                ! If idx = MPI_UNDEFINED, then all requests are complete
                 EXIT
             END IF
         END DO
 
+        ! Make sure that also all non-blocking sends have completed
         CALL MPI_Waitall(nsend, sendreqs, MPI_STATUSES_IGNORE)
+
     END SUBROUTINE process_bufs
 
 
@@ -327,6 +356,7 @@ CONTAINS
         INTEGER(int32), ALLOCATABLE :: sendcounts(:), sdispls(:)
         INTEGER(int32), ALLOCATABLE :: recvcounts(:), rdispls(:)
         INTEGER(intk), PARAMETER :: ncols = 4
+        INTEGER(intk), ALLOCATABLE :: recvtmp(:, :)
 
         CALL set_timer(230, "CTOF")
 
@@ -336,19 +366,23 @@ CONTAINS
         maxconns = nmygrids
         ALLOCATE(recvconns(ncols, maxconns))
 
-        ALLOCATE(recvcounts(0:numprocs-1), source=0_intk)
-        ALLOCATE(rdispls(0:numprocs-1), source=0_intk)
-        ALLOCATE(sendcounts(0:numprocs-1), source=0_intk)
-        ALLOCATE(sdispls(0:numprocs-1), source=0_intk)
+        ALLOCATE(recvcounts(0:numprocs-1), source=0_int32)
+        ALLOCATE(rdispls(0:numprocs-1), source=0_int32)
+        ALLOCATE(sendcounts(0:numprocs-1), source=0_int32)
+        ALLOCATE(sdispls(0:numprocs-1), source=0_int32)
 
         nrecv = 0
         DO i = 1, nmygrids
+
+            ! Obtaining the grid ID of the fine grid and its parent
             igrid = mygrids(i)
             ipar = iparent(igrid)
             IF (ipar == 0) CYCLE
 
+            ! Obtaining the process ID of the coarse parent grid
             iprocc = idprocofgrd(ipar)
 
+            ! Adding a receive connection
             nrecv = nrecv + 1
             IF (nrecv > maxconns) THEN
                 CALL errr(__FILE__, __LINE__)
@@ -359,6 +393,7 @@ CONTAINS
             recvconns(3, nrecv) = igrid
             recvconns(4, nrecv) = ipar
 
+            ! Storing information used later in the context of AllToAll
             recvcounts(iprocc) = recvcounts(iprocc) + ncols
         END DO
         irecv = nrecv
@@ -376,7 +411,7 @@ CONTAINS
         CALL MPI_Alltoall(recvcounts, 1, MPI_INTEGER, sendcounts, 1, &
             MPI_INTEGER, MPI_COMM_WORLD)
 
-        ! Calculate sdispl offset
+        ! Array sendcounts is now filled and offsets can be computed
         DO i = 1, numprocs-1
             sdispls(i) = sdispls(i-1) + sendcounts(i-1)
         END DO
@@ -389,19 +424,40 @@ CONTAINS
         CALL MPI_Alltoallv(recvconns, recvcounts, rdispls, MPI_INTEGER, &
             sendconns, sendcounts, sdispls, MPI_INTEGER, MPI_COMM_WORLD)
 
-        DEALLOCATE(sdispls)
-        DEALLOCATE(sendcounts)
+        ! Both recvconns and sendconns should be fully populated and ordered
+        DO i = 1, isend-1
+            IF (sendconns(1, i) > sendconns(1, i+1)) THEN
+                WRITE(*, *) "Sendconns not sorted by receiving rank"
+                CALL errr(__FILE__, __LINE__)
+            END IF
+        END DO
+
+        DO i = 1, irecv-1
+            IF (recvconns(2, i) > recvconns(2, i+1)) THEN
+                WRITE(*, *) "Recvconns not sorted by sending rank"
+                CALL errr(__FILE__, __LINE__)
+            END IF
+        END DO
+
+        ! Deallocate arrays which were only needed to operate MPI_Alltoallv
         DEALLOCATE(rdispls)
         DEALLOCATE(recvcounts)
+        DEALLOCATE(sdispls)
+        DEALLOCATE(sendcounts)
 
-        ALLOCATE(sendreqs(numprocs))
-        ALLOCATE(recvreqs(numprocs))
+        ALLOCATE(sendreqs(isend))
+        ALLOCATE(recvreqs(irecv))
         ALLOCATE(recvlist(irecv))
         ALLOCATE(recvidxlist(3, irecv))
 
-        is_init = .TRUE.
+        ! Reallocating recvconns to the actual size
+        ALLOCATE(recvtmp(ncols, irecv), SOURCE=recvconns(:, 1:irecv))
+        CALL move_alloc(recvtmp, recvconns)
+
         nrecv = 0
         nsend = 0
+        is_init = .TRUE.
+
     END SUBROUTINE init_ctof
 
 
@@ -412,11 +468,14 @@ CONTAINS
         isend = 0
         irecv = 0
 
+        ! Deallocation of infrastructure arrays
         DEALLOCATE(sendconns)
         DEALLOCATE(recvconns)
         DEALLOCATE(sendreqs)
         DEALLOCATE(recvreqs)
         DEALLOCATE(recvlist)
         DEALLOCATE(recvidxlist)
+
     END SUBROUTINE finish_ctof
+
 END MODULE ctof_mod

--- a/src/ib/ctof_mod.F90
+++ b/src/ib/ctof_mod.F90
@@ -5,130 +5,120 @@ MODULE ctof_mod
     IMPLICIT NONE (type, external)
     PRIVATE
 
-    ! Variable to indicate if the required data structures and MPI-types
-    ! have been created
-    LOGICAL :: isinit = .FALSE.
-
-    ! If .TRUE., a prolongation is already in process and you cannot start
-    ! another one
-    LOGICAL :: in_progress = .FALSE.
-
-    ! Maximum allowed number of childs per parent (i.e. maximum number of
-    ! send-conenctions per grid)
-    INTEGER(intk), PARAMETER :: maxchilds = 8
+    ! The information in the first dimension is sorted as follows:
+    !   Field 1: Rank of receiving process
+    !   Field 2: Rank of sending process
+    !   Field 3: ID of receiving grid (fine grid)
+    !   Field 4: ID of sending grid (coarse grid)
+    INTEGER(intk), ALLOCATABLE :: sendconns(:, :), recvconns(:, :)
 
     ! Lists that hold the send and receive request arrays
     TYPE(MPI_Request), ALLOCATABLE :: sendreqs(:), recvreqs(:)
 
-    ! Actual number of messages that are to be sendt and received in one
-    ! "round" of operations
+    ! Lists that hold the messages that are ACTUALLY sent and received
     INTEGER(intk) :: nsend, nrecv
+    INTEGER(int32), ALLOCATABLE :: recvlist(:)
+    INTEGER(intk), ALLOCATABLE :: recvidxlist(:, :)
 
-    ! List of grids to receive data on
-    INTEGER(intk), ALLOCATABLE :: recvgrids(:), recvpos(:)
+    ! Number of send and receive connections
+    INTEGER(intk) :: isend = 0, irecv = 0
+
+    ! Variable to indicate if the required data structures have been created
+    LOGICAL :: is_init = .FALSE.
 
     PUBLIC :: ctof, init_ctof, finish_ctof
-
 CONTAINS
     SUBROUTINE ctof(ilevel, ff, fc)
+        ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: ilevel  ! Level of the *fine* side
-        REAL(realk), INTENT(inout) :: ff(:)
-        REAL(realk), INTENT(in) :: fc(:)
+        TYPE(field_t), INTENT(inout) :: ff
+        TYPE(field_t), INTENT(in) :: fc
+
+        ! Local variables
+        ! none...
 
         CALL start_timer(230)
 
-        CALL ctof_begin(ilevel, fc)
-        CALL ctof_end(ff)
+        IF (.NOT. is_init) CALL errr(__FILE__, __LINE__)
+
+        CALL recv_all(ilevel)
+        CALL send_all(ilevel, fc)
+        CALL process_bufs(ff)
 
         CALL stop_timer(230)
     END SUBROUTINE ctof
 
 
-    ! Initiate prolongation
-    !
-    ! Interpolate the results from a coarse level to a fine level
-    ! This function initiate the process, and the ctof_finish
-    ! must be called afterwards to clean up.
-    SUBROUTINE ctof_begin(ilevel, fc)
-        ! Subroutine arguments
-        INTEGER(intk), INTENT(in) :: ilevel
-        REAL(realk), INTENT(in) :: fc(:)
-
-        ! Local variables
-        ! none...
-
-        CALL start_timer(231)
-
-        IF (.NOT. isInit) THEN
-            CALL errr(__FILE__, __LINE__)
-        END IF
-        IF (in_progress) THEN
-            CALL errr(__FILE__, __LINE__)
-        END IF
-        in_progress = .TRUE.
-
-        CALL recv_all(ilevel)
-        CALL send_all(ilevel, fc)
-
-        CALL stop_timer(231)
-    END SUBROUTINE ctof_begin
-
-
-    ! Perform all Recv-calls
     SUBROUTINE recv_all(ilevel)
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: ilevel   ! Level of the *fine* side
 
         ! Local variables
-        INTEGER(intk) :: i, igridf, igridc, iprocc, iprocf
-        INTEGER(intk) :: kk, jj, ii
-        INTEGER(int32) :: recvcounter, messagelength
+        INTEGER(intk) :: i, iprocnbr, igridf, kk, jj, ii
+        INTEGER(int32) :: recvcounter, messagelength, ncells
 
         ! Post all receive calls
         recvcounter = 0
         messagelength = 0
         nrecv = 0
+        recvidxlist = -HUGE(1_intk)
+        recvlist = 0
 
-        DO i = 1, noflevel(ilevel)
-            igridf = igrdoflevel(i, ilevel)
-            igridc = iparent(igridf)
-            IF (igridc == 0) CYCLE
-
-            iprocc = idprocofgrd(igridc)
-            iprocf = idprocofgrd(igridf)
-
-            IF (myid == iprocf) THEN
-                nrecv = nrecv + 1
+        DO i = 1, irecv
+            igridf = recvconns(3, i)
+            IF (ilevel == level(igridf)) THEN
+                iprocnbr = recvconns(2, i) ! The sender process (coarse side)
 
                 CALL get_mgdims(kk, jj, ii, igridf)
-                messagelength = kk*jj*ii/8
+                ncells = kk*jj*ii/8
 
-                IF (recvcounter + messagelength > SIZE(sendbuf)) THEN
+                recvidxlist(1, i) = iprocnbr
+                recvidxlist(2, i) = ncells
+                recvidxlist(3, i) = recvcounter + messagelength
+                messagelength = messagelength + ncells
+
+                IF (recvcounter + messagelength > idim_mg_bufs) THEN
                     CALL errr(__FILE__, __LINE__)
                 END IF
+            END IF
 
-                CALL MPI_Irecv(recvbuf(recvcounter+1), messagelength, &
-                    mglet_mpi_real, iprocc, igridf, MPI_COMM_WORLD, &
-                    recvreqs(nrecv))
-
-                recvgrids(nrecv) = igridf
-                recvpos(nrecv) = recvcounter + 1
-                recvcounter = recvcounter + messagelength
+            IF (messagelength > 0) THEN
+                IF (i == irecv) THEN
+                    CALL post_recv(iprocnbr, messagelength, recvcounter)
+                ELSE IF (recvconns(2, i + 1) /= iprocnbr) THEN
+                    CALL post_recv(iprocnbr, messagelength, recvcounter)
+                END IF
             END IF
         END DO
     END SUBROUTINE recv_all
 
 
-    ! Perform all Send-calls
+    SUBROUTINE post_recv(iprocnbr, messagelength, recvcounter)
+        ! Subroutine arguments
+        INTEGER(int32), INTENT(in) :: iprocnbr
+        INTEGER(int32), INTENT(inout) :: messagelength
+        INTEGER(int32), INTENT(inout) :: recvcounter
+
+        ! Local variables
+        ! none...
+
+        nrecv = nrecv + 1
+        recvlist(nrecv) = iprocnbr
+        CALL MPI_Irecv(recvbuf(recvcounter+1), messagelength, &
+            mglet_mpi_real, iprocnbr, 1, MPI_COMM_WORLD, recvreqs(nrecv))
+
+        recvcounter = recvcounter + messagelength
+        messagelength = 0
+    END SUBROUTINE post_recv
+
+
     SUBROUTINE send_all(ilevel, fc)
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: ilevel   ! Level of the *fine* grid
-        REAL(realk), INTENT(in) :: fc(*)      ! Field on the coarse grid
+        TYPE(field_t), INTENT(in) :: fc
 
         ! Local variables
-        INTEGER(intk) :: i, igridf, igridc, iprocc, iprocf, ip3
-        INTEGER(intk) :: kk, jj, ii
-        INTEGER(intk) :: kkf, jjf, iif
+        INTEGER(intk) :: i, igridf, iprocnbr
         INTEGER(int32) :: sendcounter, messagelength
 
         ! Post all receive calls
@@ -136,53 +126,58 @@ CONTAINS
         messagelength = 0
         nsend = 0
 
-        DO i = 1, noflevel(ilevel)
-            igridf = igrdoflevel(i, ilevel)
-            igridc = iparent(igridf)
-            IF (igridc == 0) CYCLE
+        DO i = 1, isend
+            igridf = sendconns(3, i)
+            iprocnbr = sendconns(1, i)
+            IF (ilevel == level(igridf)) THEN
+                CALL write_buffer(i, messagelength, sendcounter, fc)
+            END IF
 
-            iprocc = idprocofgrd(igridc)
-            iprocf = idprocofgrd(igridf)
-
-            IF (myid == iprocc) THEN
-                nsend = nsend + 1
-
-                CALL get_mgdims(kk, jj, ii, igridc)
-                CALL get_mgdims(kkf, jjf, iif, igridf)
-                messagelength = kkf*jjf*iif/8
-
-                IF (sendcounter + messagelength > SIZE(sendbuf)) THEN
-                    CALL errr(__FILE__, __LINE__)
+            IF (messagelength > 0) THEN
+                IF (i == isend) THEN
+                    CALL post_send(iprocnbr, messagelength, sendcounter)
+                ELSE IF (sendconns(1, i + 1) /= iprocnbr) THEN
+                    CALL post_send(iprocnbr, messagelength, sendcounter)
                 END IF
-
-                CALL get_ip3(ip3, igridc)
-                CALL pack_send(&
-                    sendbuf(sendcounter+1:sendcounter+messagelength), &
-                    kk, jj, ii, fc(ip3), igridc, igridf)
-
-                CALL MPI_Isend(sendbuf(sendcounter+1), messagelength, &
-                    mglet_mpi_real, iprocf, igridf, MPI_COMM_WORLD, &
-                    sendreqs(nsend))
-
-                sendcounter = sendcounter + messagelength
             END IF
         END DO
     END SUBROUTINE send_all
 
 
-    SUBROUTINE pack_send(buf, kk, jj, ii, fc, igridc, igridf)
+    SUBROUTINE post_send(iprocnbr, messagelength, sendcounter)
         ! Subroutine arguments
-        REAL(realk), INTENT(inout) :: buf(:)
-        INTEGER(intk), INTENT(in) :: kk, jj, ii
-        REAL(realk), INTENT(in) :: fc(kk, jj, ii)
-        INTEGER(intk), INTENT(in) :: igridc
-        INTEGER(intk), INTENT(in) :: igridf
+        INTEGER(int32), INTENT(in) :: iprocnbr
+        INTEGER(int32), INTENT(inout) :: messagelength
+        INTEGER(int32), INTENT(inout) :: sendcounter
 
         ! Local variables
-        INTEGER(intk) :: i, j, k
+        ! none...
+
+        nsend = nsend + 1
+        CALL MPI_Isend(sendbuf(sendcounter + 1), messagelength, &
+            mglet_mpi_real, iprocnbr, 1, MPI_COMM_WORLD, sendreqs(nsend))
+
+        sendcounter = sendcounter + messagelength
+        messagelength = 0
+    END SUBROUTINE post_send
+
+
+    SUBROUTINE write_buffer(sendid, messagelength, sendcounter, fc)
+        ! Subroutine arguments
+        INTEGER(int32), INTENT(in) :: sendid
+        INTEGER(int32), INTENT(inout) :: messagelength
+        INTEGER(int32), INTENT(in) :: sendcounter
+        TYPE(field_t), INTENT(in) :: fc
+
+        ! Local variables
+        REAL(realk), POINTER, CONTIGUOUS :: fcptr(:, :, :)
         INTEGER(intk) :: kkf, jjf, iif
-        INTEGER(intk) :: counter
         INTEGER(intk) :: ista, jsta, ksta, isto, jsto, ksto
+        INTEGER(intk) :: igridc, igridf
+        INTEGER(int32) :: thismessagelength, offset, counter
+
+        igridf = sendconns(3, sendid)
+        igridc = sendconns(4, sendid)
 
         ! Compute start- and end-positions in coarse grid
         ista = iposition(igridf) - 1
@@ -194,100 +189,122 @@ CONTAINS
         jsto = jsta + (jjf - 4)/2 + 1
         ksto = ksta + (kkf - 4)/2 + 1
 
-        ! Pack buffer
+        thismessagelength = (isto-ista+1)*(jsto-jsta+1)*(ksto-ksta+1)
+
+        IF (sendcounter + messagelength + thismessagelength > idim_mg_bufs) THEN
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        offset = sendcounter + messagelength + 1
+        CALL fc%get_ptr(fcptr, igridc)
+        CALL pack_single(sendbuf(offset:offset+thismessagelength-1), fcptr, &
+            ista, isto, jsta, jsto, ksta, ksto, counter)
+
+        IF (counter /= thismessagelength) THEN
+            WRITE(*, *) "counter:", counter, "expected:", thismessagelength
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        messagelength = messagelength + thismessagelength
+    END SUBROUTINE write_buffer
+
+
+    SUBROUTINE pack_single(buf, fcptr, ista, isto, jsta, jsto, ksta, ksto, &
+            counter)
+        ! Subroutine arguments
+        REAL(realk), INTENT(inout), CONTIGUOUS :: buf(:)
+        REAL(realk), INTENT(in), CONTIGUOUS :: fcptr(:, :, :)
+        INTEGER(intk), INTENT(in) :: ista, isto, jsta, jsto, ksta, ksto
+        INTEGER(int32), INTENT(out) :: counter
+
+        ! Local variables
+        INTEGER(intk) :: i, j, k
+
         counter = 0
         DO i = ista, isto
             DO j = jsta, jsto
                 DO k = ksta, ksto
                     counter = counter + 1
-                    buf(counter) = fc(k, j, i)
+                    buf(counter) = fcptr(k, j, i)
                 END DO
             END DO
         END DO
-
-        ! Sanity checks
-        IF (counter /= kkf*jjf*iif/8) THEN
-            WRITE(*, *) "counter = ", counter
-            WRITE(*, *) "kkf = ", kkf
-            WRITE(*, *) "jjf = ", jjf
-            WRITE(*, *) "iif = ", iif
-            WRITE(*, *) "ksta = ", ksta
-            WRITE(*, *) "jsta = ", jsta
-            WRITE(*, *) "ista = ", ista
-            WRITE(*, *) "ksto = ", ksto
-            WRITE(*, *) "jsto = ", jsto
-            WRITE(*, *) "isto = ", isto
-            CALL errr(__FILE__, __LINE__)
-        END IF
-        IF (counter /= SIZE(buf)) THEN
-            CALL errr(__FILE__, __LINE__)
-        END IF
-    END SUBROUTINE pack_send
+    END SUBROUTINE pack_single
 
 
-    ! Finish prolongation
-    !
-    ! Wait for communication to finish and clean up
-    SUBROUTINE ctof_end(ff)
+    SUBROUTINE process_bufs(ff)
         ! Subroutine arguments
-        REAL(realk), INTENT(inout) :: ff(:)
+        TYPE(field_t), INTENT(inout) :: ff
 
         ! Local variables
-        INTEGER(int32) :: idx
+        TYPE(MPI_Status) :: recvstatus
+        INTEGER(intk) :: i
+        INTEGER(int32) :: idx, recvmessagelen, unpacklen
 
-        CALL start_timer(232)
+        DO WHILE (.TRUE.)
+            IF (nrecv == 0) EXIT
+            CALL MPI_Waitany(nrecv, recvreqs, idx, recvstatus)
 
-        IF (.NOT. in_progress) THEN
-            CALL errr(__FILE__, __LINE__)
-        END IF
+            IF (idx /= MPI_UNDEFINED) THEN
+                CALL MPI_Get_count(recvstatus, mglet_mpi_real, recvmessagelen)
 
-        IF (nrecv > 0) THEN
-            DO WHILE (.TRUE.)
-                CALL MPI_Waitany(nrecv, recvreqs, idx, MPI_STATUS_IGNORE)
+                unpacklen = 0
+                DO i = 1, irecv
+                    IF (recvidxlist(1, i) == recvlist(idx) &
+                            .AND. recvidxlist(2, i) > 0) THEN
+                        CALL read_buffer(i, ff)
+                        unpacklen = unpacklen + recvidxlist(2, i)
+                    END IF
+                END DO
 
-                IF (idx /= MPI_UNDEFINED) THEN
-                    CALL start_timer(235)
-                    CALL prolong_finish(ff, recvgrids(idx), recvpos(idx))
-                    CALL stop_timer(235)
-                ELSE
-                    EXIT
+                IF (recvmessagelen /= unpacklen) THEN
+                    CALL errr(__FILE__, __LINE__)
                 END IF
-            END DO
-        END IF
+            ELSE
+                EXIT
+            END IF
+        END DO
 
         CALL MPI_Waitall(nsend, sendreqs, MPI_STATUSES_IGNORE)
-
-        in_progress = .FALSE.
-
-        CALL stop_timer(232)
-    END SUBROUTINE ctof_end
+    END SUBROUTINE process_bufs
 
 
-    ! Finish prolongation, i.e. distribute the data on the grid
-    SUBROUTINE prolong_finish(ff, igridf, pos)
+    SUBROUTINE read_buffer(recvid, ff)
         ! Subroutine arguments
-        REAL(realk), INTENT(inout), TARGET :: ff(:)
-        INTEGER(intk), INTENT(in) :: igridf
-        INTEGER(intk), INTENT(in) :: pos
+        INTEGER(intk), INTENT(in) :: recvid
+        TYPE(field_t), INTENT(inout) :: ff
 
         ! Local variables
-        INTEGER(intk) :: ip3
-        INTEGER(intk) :: k, j, i, kc, jc, ic
-        INTEGER(intk) :: kk, jj, ii, kkc, jjc, iic
-        REAL(realk), POINTER :: fc(:, :, :)
-        REAL(realk), POINTER :: fff(:, :, :)
+        REAL(realk), POINTER, CONTIGUOUS :: ffptr(:, :, :)
+        INTEGER(intk) :: igridf, kk, jj, ii, offset, thismessagelength
 
-        CALL get_ip3(ip3, igridf)
+        igridf = recvconns(3, recvid)
+        offset = recvidxlist(3, recvid) + 1
+
+        CALL ff%get_ptr(ffptr, igridf)
         CALL get_mgdims(kk, jj, ii, igridf)
-        fff(1:kk, 1:jj, 1:ii) => ff(ip3:ip3 + kk*jj*ii - 1)
+        thismessagelength = kk*jj*ii/8
 
-        ! We map the recvbuf to a 3-D field to make lookup easier
-        ! (remember that only 2..kkc-1 are send - so kkc here is not
-        ! really the same as kk for the coarse grid)
+        CALL unpack_single(recvbuf(offset:offset+thismessagelength-1), &
+            ffptr, kk, jj, ii)
+
+        IF (thismessagelength /= recvidxlist(2, recvid)) THEN
+            CALL errr(__FILE__, __LINE__)
+        END IF
+    END SUBROUTINE read_buffer
+
+
+    SUBROUTINE unpack_single(buf, ffptr, kk, jj, ii)
+        ! Subroutine arguments
+        REAL(realk), INTENT(in), CONTIGUOUS :: buf(:)
+        REAL(realk), INTENT(inout), CONTIGUOUS :: ffptr(:, :, :)
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+
+        ! Local variables
+        INTEGER(intk) :: kkc, jjc, k, j, i, kc, jc, ic, idx
+
         kkc = kk/2
         jjc = jj/2
-        iic = ii/2
-        fc(1:kkc, 1:jjc, 1:iic) => recvbuf(pos:pos + kkc*jjc*iic - 1)
 
         DO i = 1, ii
             DO j = 1, jj
@@ -295,61 +312,111 @@ CONTAINS
                     ic = (i-1)/2 + 1
                     jc = (j-1)/2 + 1
                     kc = (k-1)/2 + 1
-                    fff(k, j, i) = fc(kc, jc, ic)
+                    idx = kc + (jc-1)*kkc + (ic-1)*kkc*jjc
+                    ffptr(k, j, i) = buf(idx)
                 END DO
             END DO
         END DO
-    END SUBROUTINE prolong_finish
+    END SUBROUTINE unpack_single
 
 
     ! Initialize arrays and data types
     SUBROUTINE init_ctof()
         ! Local variables
-        INTEGER :: igrid, iprocc, ipar
+        INTEGER :: i, igrid, iprocc, ipar, maxconns
+        INTEGER(int32), ALLOCATABLE :: sendcounts(:), sdispls(:)
+        INTEGER(int32), ALLOCATABLE :: recvcounts(:), rdispls(:)
+        INTEGER(intk), PARAMETER :: ncols = 4
 
         CALL set_timer(230, "CTOF")
-        CALL set_timer(231, "CTOF_BEGIN")
-        CALL set_timer(232, "CTOF_END")
-        CALL set_timer(235, "CTOF_PROLONG_FINISH")
 
-        IF (.NOT. isinit) THEN
-            ALLOCATE(sendreqs(nmygrids*maxchilds))
-            ALLOCATE(recvreqs(nmygrids))
-            ALLOCATE(recvgrids(nmygrids))
-            ALLOCATE(recvpos(nmygrids))
-        END IF
+        IF (is_init) CALL errr(__FILE__, __LINE__)
+
+        ! Fine grids only need information from one coarse grid
+        maxconns = nmygrids
+        ALLOCATE(recvconns(ncols, maxconns))
+
+        ALLOCATE(recvcounts(0:numprocs-1), source=0_intk)
+        ALLOCATE(rdispls(0:numprocs-1), source=0_intk)
+        ALLOCATE(sendcounts(0:numprocs-1), source=0_intk)
+        ALLOCATE(sdispls(0:numprocs-1), source=0_intk)
 
         nrecv = 0
-        nsend = 0
-
-        DO igrid = 1, ngrid
+        DO i = 1, nmygrids
+            igrid = mygrids(i)
             ipar = iparent(igrid)
-            IF (ipar /= 0) THEN
-                iprocc = idprocofgrd(ipar)
-                IF (myid == iprocc) THEN
-                    nsend = nsend + 1
-                    IF (nsend > nmygrids*maxchilds) THEN
-                        CALL errr(__FILE__, __LINE__)
-                    END IF
-                END IF
+            IF (ipar == 0) CYCLE
+
+            iprocc = idprocofgrd(ipar)
+
+            nrecv = nrecv + 1
+            IF (nrecv > maxconns) THEN
+                CALL errr(__FILE__, __LINE__)
             END IF
+
+            recvconns(1, nrecv) = myid
+            recvconns(2, nrecv) = iprocc
+            recvconns(3, nrecv) = igrid
+            recvconns(4, nrecv) = ipar
+
+            recvcounts(iprocc) = recvcounts(iprocc) + ncols
+        END DO
+        irecv = nrecv
+
+        ! Sort recvconns by process ID (col 2)
+        CALL sort_conns(recvconns(:, 1:nrecv), 2)
+
+        ! Calculate rdispl offset
+        DO i = 1, numprocs-1
+            rdispls(i) = rdispls(i-1) + recvcounts(i-1)
         END DO
 
-        isinit = .TRUE.
-        in_progress = .FALSE.
+        ! First exchange NUMBER OF ELEMENTS TO SEND, to be able to
+        ! calculate sdispls array
+        CALL MPI_Alltoall(recvcounts, 1, MPI_INTEGER, sendcounts, 1, &
+            MPI_INTEGER, MPI_COMM_WORLD)
+
+        ! Calculate sdispl offset
+        DO i = 1, numprocs-1
+            sdispls(i) = sdispls(i-1) + sendcounts(i-1)
+        END DO
+
+        isend = (sdispls(numprocs-1) + sendcounts(numprocs-1))/ncols
+        ALLOCATE(sendconns(ncols, isend))
+        sendconns = 0
+
+        ! Exchange connection information
+        CALL MPI_Alltoallv(recvconns, recvcounts, rdispls, MPI_INTEGER, &
+            sendconns, sendcounts, sdispls, MPI_INTEGER, MPI_COMM_WORLD)
+
+        DEALLOCATE(sdispls)
+        DEALLOCATE(sendcounts)
+        DEALLOCATE(rdispls)
+        DEALLOCATE(recvcounts)
+
+        ALLOCATE(sendreqs(numprocs))
+        ALLOCATE(recvreqs(numprocs))
+        ALLOCATE(recvlist(irecv))
+        ALLOCATE(recvidxlist(3, irecv))
+
+        is_init = .TRUE.
+        nrecv = 0
+        nsend = 0
     END SUBROUTINE init_ctof
 
 
     SUBROUTINE finish_ctof()
-        IF (isInit .NEQV. .TRUE.) THEN
-            RETURN
-        END IF
+        IF (.NOT. is_init) RETURN
 
-        isInit = .FALSE.
+        is_init = .FALSE.
+        isend = 0
+        irecv = 0
 
+        DEALLOCATE(sendconns)
+        DEALLOCATE(recvconns)
         DEALLOCATE(sendreqs)
         DEALLOCATE(recvreqs)
-        DEALLOCATE(recvgrids)
-        DEALLOCATE(recvpos)
+        DEALLOCATE(recvlist)
+        DEALLOCATE(recvidxlist)
     END SUBROUTINE finish_ctof
 END MODULE ctof_mod

--- a/src/scalar/blockbt_mod.F90
+++ b/src/scalar/blockbt_mod.F90
@@ -49,7 +49,7 @@ CONTAINS
         ! allows a scalar flux
         DO ilevel = minlevel, maxlevel
             hilf_f%arr = -1.0
-            CALL ctof(ilevel, hilf_f%arr, bt_f%arr)
+            CALL ctof(ilevel, hilf_f, bt_f)
 
             DO i = 1, nmygridslvl(ilevel)
                 igrid = mygridslvl(i, ilevel)


### PR DESCRIPTION
- Batches MPI calls between processes instead of calling one `MPI_Isend` and `MPI_Irecv` per grid that needs to exchange data
- Mostly inspired by the existing `ftoc` implementation, though the initialization is reversed to first compute recv information and then distribute this to calculate the send information (necessary since we do not keep track of each grid's children)
- Removes the rather fine grained timers 231 (`CTOF_BEGIN`), 232 (`CTOF_END`) and 235 (`CTOF_PROLONG_FINISH`)
    - Timer 230 (`CTOF`) remains and wraps a full `ctof` call