### PR TITLE
Remove _MGLET_OFFLOAD_PERFORMANCE_

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,6 @@ set(MGLET_Fortran_FLAGS_DEBUG "" CACHE STRING "MGLET Fortran flags (debug)")
 if(MGLET_OFFLOAD)
     set(MGLET_OFFLOAD_COMPILE_FLAGS "" CACHE STRING "MGLET Offload compile flags")
     set(MGLET_OFFLOAD_ARCH_FLAGS "" CACHE STRING "MGLET Offload architecture flags")
-    add_compile_definitions("$<$<NOT:$<CONFIG:Debug>>:_MGLET_OFFLOAD_PERFORMANCE_=1>")
 endif()
 
 add_compile_options("$<$<COMPILE_LANGUAGE:C>:${MGLET_C_FLAGS}>"

--- a/src/core/grids_mod.F90
+++ b/src/core/grids_mod.F90
@@ -481,7 +481,7 @@ CONTAINS
 
         imygrid = globalgrids(igrid)
 
-#ifndef _MGLET_OFFLOAD_PERFORMANCE_
+#ifdef _MGLET_DEBUG_
         IF (imygrid == -1_intk) CALL errr(__FILE__, __LINE__)
 #endif
     END SUBROUTINE get_imygrid


### PR DESCRIPTION
Leftover from when field helpers had get_grid subroutines. This is now unused and can be removed.