### PR TITLE
Smaller corrections to mapping behaviour

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -225,6 +225,18 @@
             }
         },
         {
+            "name": "llvm-offload-example",
+            "displayName": "LLVM compilers (clang, clang++, flang) (offload)",
+            "description": "Offload configuration using the LLVM compilers (clang, clang++, flang)",
+            "inherits": "llvm-release",
+            "cacheVariables": {
+                "MGLET_OFFLOAD": "ON",
+                "MGLET_OFFLOAD_COMPILE_FLAGS": "-fopenmp-version=52",
+                "MGLET_OFFLOAD_ARCH_FLAGS": "--offload-arch=sm_121",
+                "MGLET_Fortran_FLAGS_RELEASE": ""
+            }
+        },
+        {
             "name": "amd",
             "hidden": true,
             "displayName": "AMD compilers (amdclang, amdclang++, amdflang)",

--- a/src/core/connect/conn2_mod.F90
+++ b/src/core/connect/conn2_mod.F90
@@ -482,6 +482,9 @@ CONTAINS
         CALL vdummy%init("DUMMY", jstag=1)
         CALL wdummy%init("DUMMY", kstag=1)
 
+        !$omp target enter data map(to: &
+        !$omp&  udummy%arr, vdummy%arr, wdummy%arr, pdummy%arr)
+
         ! START -- This section defines the recored variants of conn2 ---
 
         DO ilevel = minlevel, maxlevel
@@ -494,6 +497,9 @@ CONTAINS
         CALL conn2(layers=1, s1=pdummy)
 
         ! END -- This section defines the recored variants of conn2 ---
+
+        !$omp target exit data map(delete: &
+        !$omp&  udummy%arr, vdummy%arr, wdummy%arr, pdummy%arr)
 
         CALL pdummy%finish()
         CALL udummy%finish()

--- a/src/core/fields_mod.F90
+++ b/src/core/fields_mod.F90
@@ -64,8 +64,10 @@ CONTAINS
         DO i = 1, nfields
             CALL is_field_mapped(mapped, fields(i))
             IF (mapped) THEN
-                !$omp target exit data map(delete: fields(i)%arr, &
-                !$omp& fields(i)%buffers)
+                !$omp target exit data map(delete: fields(i)%arr)
+                IF (ALLOCATED(fields(i)%buffers)) THEN
+                    !$omp target exit data map(delete: fields(i)%buffers)
+                END IF
             END IF
             CALL fields(i)%finish()
         END DO
@@ -218,9 +220,12 @@ CONTAINS
         ELSE
             map_device = .TRUE.
         END IF
+
         IF (map_device) THEN
-            !$omp target enter data map(to: fields(nfields)%arr, &
-            !$omp& fields(nfields)%buffers)
+            !$omp target enter data map(to: fields(nfields)%arr)
+            IF (ALLOCATED(fields(nfields)%buffers)) THEN
+                !$omp target enter data map(to: fields(nfields)%buffers)
+            END IF
         END IF
     END SUBROUTINE set_field
 

--- a/src/ib/ctof/ctof2_mod.F90
+++ b/src/ib/ctof/ctof2_mod.F90
@@ -904,6 +904,8 @@ CONTAINS
 
         CALL dummy%init("DUMMY")
 
+        !$omp target enter data map(to: dummy%arr)
+
         is_recording = .TRUE.
 
         ! Recording operations for all levels
@@ -912,6 +914,8 @@ CONTAINS
         END DO
 
         is_recording = .FALSE.
+
+        !$omp target exit data map(delete: dummy%arr)
 
         CALL dummy%finish()
     END SUBROUTINE run_recording_pass

--- a/src/ib/parent/parent2_mod.F90
+++ b/src/ib/parent/parent2_mod.F90
@@ -1543,6 +1543,10 @@ CONTAINS
         CALL wdummy%init_buffers()
         CALL pdummy%init_buffers()
 
+        !$omp target enter data map(to: &
+        !$omp&  udummy%arr, vdummy%arr, wdummy%arr, pdummy%arr, &
+        !$omp&  udummy%buffers, vdummy%buffers, wdummy%buffers, pdummy%buffers)
+
         ! START -- This section defines the record variants of parent2 ---
 
         DO ilevel = minlevel, maxlevel
@@ -1554,6 +1558,10 @@ CONTAINS
         CALL parent2(minlevel, v1=udummy, v2=vdummy, v3=wdummy, s1=pdummy)
 
         ! END -- This section defines the record variants of parent2 ---
+
+        !$omp target exit data map(delete: &
+        !$omp&  udummy%arr, vdummy%arr, wdummy%arr, pdummy%arr, &
+        !$omp&  udummy%buffers, vdummy%buffers, wdummy%buffers, pdummy%buffers)
 
         CALL udummy%finish()
         CALL vdummy%finish()


### PR DESCRIPTION
Smaller corrections to mapping behaviour.

While the amdflang let those small errors slip, LLVM threw errors.