### PR TITLE
Remove restrict_t as Preparation for FTOC offloading

### DIFF
--- a/src/ib/CMakeLists.txt
+++ b/src/ib/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(ib STATIC
     parent/parent_core_mod.F90
     par_ftoc_mod.F90
     punktekoordinaten_mod.F90
+    restrict_mod.F90
     stencils_mod.F90
     topol_mod.F90
 )

--- a/src/ib/ftoc_mod.F90
+++ b/src/ib/ftoc_mod.F90
@@ -1,7 +1,8 @@
 MODULE ftoc_mod
+    USE MPI_f08
     USE core_mod
     USE ibcore_mod, ONLY: ib
-    USE MPI_f08
+    USE restrict_mod, ONLY: restrict, message_length, start_and_stop
 
     IMPLICIT NONE (type, external)
     PRIVATE
@@ -156,37 +157,38 @@ CONTAINS
         TYPE(field_t), INTENT(in), OPTIONAL :: v1, v2, v3, s1, s2, s3
 
         ! Local variables
-        INTEGER(int32) :: n
+        INTEGER(int32) :: messagelength
 
         ncells = 0
 
         IF (flag == '*') THEN
             IF (PRESENT(v1)) THEN
-                n = ib%restrict_op%message_length('U', igrid)
-                ncells = ncells + n
+                CALL message_length(messagelength, 'U', igrid)
+                ncells = ncells + messagelength
             END IF
             IF (PRESENT(v2)) THEN
-                n = ib%restrict_op%message_length('V', igrid)
-                ncells = ncells + n
+                CALL message_length(messagelength, 'V', igrid)
+                ncells = ncells + messagelength
             END IF
             IF (PRESENT(v3)) THEN
-                n = ib%restrict_op%message_length('W', igrid)
-                ncells = ncells + n
+                CALL message_length(messagelength, 'W', igrid)
+                ncells = ncells + messagelength
             END IF
             IF (PRESENT(s1)) THEN
-                n = ib%restrict_op%message_length('P', igrid)
-                ncells = ncells + n
+                CALL message_length(messagelength, 'P', igrid)
+                ncells = ncells + messagelength
             END IF
             IF (PRESENT(s2)) THEN
-                n = ib%restrict_op%message_length('P', igrid)
-                ncells = ncells + n
+                CALL message_length(messagelength, 'P', igrid)
+                ncells = ncells + messagelength
             END IF
             IF (PRESENT(s3)) THEN
-                n = ib%restrict_op%message_length('P', igrid)
-                ncells = ncells + n
+                CALL message_length(messagelength, 'P', igrid)
+                ncells = ncells + messagelength
             END IF
         ELSE
-            ncells = ib%restrict_op%message_length(flag, igrid)
+            CALL message_length(messagelength, flag, igrid)
+            ncells = ncells + messagelength
         END IF
     END SUBROUTINE count_ncells
 
@@ -258,8 +260,7 @@ CONTAINS
         ! Local variables
         INTEGER(intk) :: kk, jj, ii
         INTEGER(intk) :: igrid
-        INTEGER(int32) :: thismessagelength, offset, ncells
-        REAL(realk), POINTER, CONTIGUOUS :: field(:, :, :)
+        INTEGER(int32) :: thismessagelength, offset
         CHARACTER(len=1) :: flag_u
 
         igrid = sendconns(3, sendid)
@@ -283,57 +284,28 @@ CONTAINS
             ELSE
                 flag_u = flag
             END IF
-            ncells = ib%restrict_op%message_length(flag_u, igrid)
-            CALL v1%get_ptr(field, igrid)
-            CALL ib%restrict_op%restrict(kk, jj, ii, field, &
-                sendbuf(offset:offset+ncells-1), &
-                flag_u, igrid)
-            offset = offset + ncells
+
+            CALL restrict(ib, flag_u, v1, igrid, offset)
         END IF
 
         IF (PRESENT(v2)) THEN
-            ncells = ib%restrict_op%message_length('V', igrid)
-            CALL v2%get_ptr(field, igrid)
-            CALL ib%restrict_op%restrict(kk, jj, ii, field, &
-                sendbuf(offset:offset+ncells-1), &
-                'V', igrid)
-            offset = offset + ncells
+            CALL restrict(ib, 'V', v2, igrid, offset)
         END IF
 
         IF (PRESENT(v3)) THEN
-            ncells = ib%restrict_op%message_length('W', igrid)
-            CALL v3%get_ptr(field, igrid)
-            CALL ib%restrict_op%restrict(kk, jj, ii, field, &
-                sendbuf(offset:offset+ncells-1), &
-                'W', igrid)
-            offset = offset + ncells
+            CALL restrict(ib, 'W', v3, igrid, offset)
         END IF
 
         IF (PRESENT(s1)) THEN
-            ncells = ib%restrict_op%message_length('P', igrid)
-            CALL s1%get_ptr(field, igrid)
-            CALL ib%restrict_op%restrict(kk, jj, ii, field, &
-                sendbuf(offset:offset+ncells-1), &
-                'P', igrid)
-            offset = offset + ncells
+            CALL restrict(ib, 'P', s1, igrid, offset)
         END IF
 
         IF (PRESENT(s2)) THEN
-            ncells = ib%restrict_op%message_length('P', igrid)
-            CALL s2%get_ptr(field, igrid)
-            CALL ib%restrict_op%restrict(kk, jj, ii, field, &
-                sendbuf(offset:offset+ncells-1), &
-                'P', igrid)
-            offset = offset + ncells
+            CALL restrict(ib, 'P', s2, igrid, offset)
         END IF
 
         IF (PRESENT(s3)) THEN
-            ncells = ib%restrict_op%message_length('P', igrid)
-            CALL s3%get_ptr(field, igrid)
-            CALL ib%restrict_op%restrict(kk, jj, ii, field, &
-                sendbuf(offset:offset+ncells-1), &
-                'P', igrid)
-            offset = offset + ncells
+            CALL restrict(ib, 'P', s3, igrid, offset)
         END IF
 
         IF (offset /= sendcounter + messagelength + thismessagelength + 1) THEN
@@ -401,7 +373,7 @@ CONTAINS
         ! Grid dimensions and pointers
         INTEGER(intk) :: kk, jj, ii
         INTEGER(intk) :: igrid, igridc
-        INTEGER(int32) :: offset, ncells
+        INTEGER(int32) :: offset, messagelength
         REAL(realk), POINTER, CONTIGUOUS :: field(:, :, :)
         CHARACTER(len=1) :: flag_u
 
@@ -417,57 +389,57 @@ CONTAINS
             ELSE
                 flag_u = flag
             END IF
-            ncells = ib%restrict_op%message_length(flag_u, igrid)
+            CALL message_length(messagelength, flag_u, igrid)
             CALL v1%get_ptr(field, igridc)
 
             IF (flag_u == 'N') THEN
                 CALL restrict_recieve_open_n(kk, jj, ii, field, &
-                    recvbuf(offset:offset+ncells-1), igrid, flag_u)
+                    recvbuf(offset:offset+messagelength-1), igrid, flag_u)
             ELSE
                 CALL restrict_recieve_open(kk, jj, ii, field, &
-                    recvbuf(offset:offset+ncells-1), igrid, flag_u)
+                    recvbuf(offset:offset+messagelength-1), igrid, flag_u)
             END IF
-            offset = offset + ncells
+            offset = offset + messagelength
         END IF
 
         IF (PRESENT(v2)) THEN
-            ncells = ib%restrict_op%message_length('V', igrid)
+            CALL message_length(messagelength, 'V', igrid)
             CALL v2%get_ptr(field, igridc)
             CALL restrict_recieve_open(kk, jj, ii, field, &
-                recvbuf(offset:offset+ncells-1), igrid, 'V')
-            offset = offset + ncells
+                recvbuf(offset:offset+messagelength-1), igrid, 'V')
+            offset = offset + messagelength
         END IF
 
         IF (PRESENT(v3)) THEN
-            ncells = ib%restrict_op%message_length('W', igrid)
+            CALL message_length(messagelength, 'W', igrid)
             CALL v3%get_ptr(field, igridc)
             CALL restrict_recieve_open(kk, jj, ii, field, &
-                recvbuf(offset:offset+ncells-1), igrid, 'W')
-            offset = offset + ncells
+                recvbuf(offset:offset+messagelength-1), igrid, 'W')
+            offset = offset + messagelength
         END IF
 
         IF (PRESENT(s1)) THEN
-            ncells = ib%restrict_op%message_length('P', igrid)
+            CALL message_length(messagelength, 'P', igrid)
             CALL s1%get_ptr(field, igridc)
             CALL restrict_recieve_open(kk, jj, ii, field, &
-                recvbuf(offset:offset+ncells-1), igrid, 'P')
-            offset = offset + ncells
+                recvbuf(offset:offset+messagelength-1), igrid, 'P')
+            offset = offset + messagelength
         END IF
 
         IF (PRESENT(s2)) THEN
-            ncells = ib%restrict_op%message_length('P', igrid)
+            CALL message_length(messagelength, 'P', igrid)
             CALL s2%get_ptr(field, igridc)
             CALL restrict_recieve_open(kk, jj, ii, field, &
-                recvbuf(offset:offset+ncells-1), igrid, 'P')
-            offset = offset + ncells
+                recvbuf(offset:offset+messagelength-1), igrid, 'P')
+            offset = offset + messagelength
         END IF
 
         IF (PRESENT(s3)) THEN
-            ncells = ib%restrict_op%message_length('P', igrid)
+            CALL message_length(messagelength, 'P', igrid)
             CALL s3%get_ptr(field, igridc)
             CALL restrict_recieve_open(kk, jj, ii, field, &
-                recvbuf(offset:offset+ncells-1), igrid, 'P')
-            offset = offset + ncells
+                recvbuf(offset:offset+messagelength-1), igrid, 'P')
+            offset = offset + messagelength
         END IF
 
         IF (offset - recvidxlist(3, recvid) - 1 /= recvidxlist(2, recvid)) THEN
@@ -591,7 +563,7 @@ CONTAINS
         INTEGER(intk) :: ipos, jpos, kpos
         INTEGER(intk) :: i, j, k, ic, jc, kc, ic0, jc0, kc0, icount
 
-        CALL ib%restrict_op%start_and_stop(istart, istop, jstart, jstop, &
+        CALL start_and_stop(istart, istop, jstart, jstop, &
             kstart, kstop, flag, igridf)
 
         ic0 = 0
@@ -639,7 +611,7 @@ CONTAINS
         INTEGER(intk) :: ipos, jpos, kpos
         INTEGER(intk) :: i, j, k, ic, jc, kc, icount
 
-        CALL ib%restrict_op%start_and_stop(istart, istop, jstart, jstop, &
+        CALL start_and_stop(istart, istop, jstart, jstop, &
             kstart, kstop, flag, igridf)
 
         ipos = iposition(igridf)

--- a/src/ib/gc_mod.F90
+++ b/src/ib/gc_mod.F90
@@ -4,7 +4,6 @@ MODULE gc_mod
     USE ibconst_mod, ONLY: maccur
     USE noib_mod, ONLY: noib_t
     USE bubvbw_mod, ONLY: bubvbw
-    USE gc_restrict_mod, ONLY: gc_restrict_t
     USE gc_blockbp_mod, ONLY: gc_blockbp_t
     USE gc_stencils_mod, ONLY: gc_stencils_t
 
@@ -51,7 +50,6 @@ CONTAINS
         END IF
 
         ALLOCATE(gc_t :: ib)
-        ALLOCATE(gc_restrict_t :: ib%restrict_op)
 
         ib%type = "GHOSTCELL"
 
@@ -106,9 +104,7 @@ CONTAINS
     SUBROUTINE destructor(this)
         TYPE(gc_t), INTENT(inout) :: this
 
-        IF (ALLOCATED(this%restrict_op)) THEN
-            DEALLOCATE(this%restrict_op)
-        END IF
+        ! Nothing to do here
     END SUBROUTINE destructor
 
 

--- a/src/ib/gc_restrict_mod.F90
+++ b/src/ib/gc_restrict_mod.F90
@@ -1,92 +1,31 @@
 MODULE gc_restrict_mod
-    USE core_mod, ONLY: realk, intk, get_fieldptr, errr
-    USE noib_restrict_mod, ONLY: noib_restrict_t
+    USE core_mod
 
     IMPLICIT NONE(type, external)
     PRIVATE
 
-    TYPE, EXTENDS(noib_restrict_t) :: gc_restrict_t
-    CONTAINS
-        PROCEDURE :: restrict
-        PROCEDURE :: restrict_p
-        PROCEDURE :: restrict_r
-        PROCEDURE :: restrict_n
-        PROCEDURE :: restrict_e
-        PROCEDURE :: restrict_f
-        PROCEDURE :: restrict_i
-    END TYPE gc_restrict_t
-
-    PUBLIC :: gc_restrict_t
-
+    PUBLIC :: restrict_gc_p_t, restrict_gc_r, restrict_gc_n, restrict_gc_e, &
+        restrict_gc_f, restrict_gc_i
 CONTAINS
-    SUBROUTINE restrict(this, kk, jj, ii, ff, sendbuf, ctyp, igrid)
+    SUBROUTINE restrict_gc_p_t(kk, jj, ii, ff, ddx, ddy, ddz, b, &
+            messagelength, sbuf, istart, istop, jstart, jstop, kstart, kstop)
+        !$omp declare target
         ! Subroutine arguments
-        CLASS(gc_restrict_t), INTENT(inout) :: this
-        INTEGER(intk), INTENT(IN) :: kk, jj, ii
-        REAL(realk), INTENT(IN) :: ff(kk, jj, ii)
-        REAL(realk), CONTIGUOUS, INTENT(INOUT) :: sendbuf(:)
-        CHARACTER(len=1), INTENT(in) :: ctyp
-        INTEGER(intk), INTENT(in) :: igrid
-
-        SELECT CASE (ctyp)
-        CASE ("U")
-            CALL this%restrict_u(kk, jj, ii, ff, sendbuf, ctyp, igrid)
-        CASE ("V")
-            CALL this%restrict_v(kk, jj, ii, ff, sendbuf, ctyp, igrid)
-        CASE ("W")
-            CALL this%restrict_w(kk, jj, ii, ff, sendbuf, ctyp, igrid)
-        CASE ("P", "T")
-            CALL this%restrict_p(kk, jj, ii, ff, sendbuf, ctyp, igrid)
-        CASE ("R")
-            CALL this%restrict_r(kk, jj, ii, ff, sendbuf, ctyp, igrid)
-        CASE ("S")
-            CALL this%restrict_s(kk, jj, ii, ff, sendbuf, ctyp, igrid)
-        CASE ("N")
-            CALL this%restrict_n(kk, jj, ii, ff, sendbuf, ctyp, igrid)
-        CASE ("E")
-            CALL this%restrict_e(kk, jj, ii, ff, sendbuf, ctyp, igrid)
-        CASE ("F")
-            CALL this%restrict_f(kk, jj, ii, ff, sendbuf, ctyp, igrid)
-        CASE ("I")
-            CALL this%restrict_i(kk, jj, ii, ff, sendbuf, ctyp, igrid)
-        CASE DEFAULT
-            CALL errr(__FILE__, __LINE__)
-        END SELECT
-    END SUBROUTINE restrict
-
-
-    SUBROUTINE restrict_p(this, kk, jj, ii, ff, sendbuf, ctyp, igrid)
-        ! Subroutine arguments
-        CLASS(gc_restrict_t), INTENT(inout) :: this
-        INTEGER(intk), INTENT(IN) :: kk, jj, ii
-        REAL(realk), INTENT(IN) :: ff(kk, jj, ii)
-        REAL(realk), CONTIGUOUS, INTENT(INOUT) :: sendbuf(:)
-        CHARACTER(len=1), INTENT(in) :: ctyp
-        INTEGER(intk), INTENT(in) :: igrid
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(in) :: ff(kk, jj, ii)
+        REAL(realk), INTENT(in) :: ddx(ii), ddy(jj), ddz(kk)
+        REAL(realk), INTENT(in) :: b(kk, jj, ii)
+        INTEGER(int32), INTENT(in) :: messagelength
+        REAL(realk), INTENT(inout) :: sbuf(messagelength)
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
         INTEGER(intk) :: i, j, k, icount
         INTEGER(intk) :: nk, ink
-        INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
 
         REAL(realk) :: vol1(kk), vol2(kk), vol3(kk), vol4(kk)
         REAL(realk) :: pv1(kk), pv2(kk), pv3(kk), pv4(kk)
         REAL(realk) :: sum_pv, sum_v
-
-        REAL(realk), POINTER, CONTIGUOUS :: ddx(:), ddy(:), ddz(:), bp(:, :, :)
-
-        CALL this%start_and_stop(istart, istop, jstart, jstop, &
-            kstart, kstop, ctyp, igrid)
-
-        CALL get_fieldptr(ddx, "DDX", igrid)
-        CALL get_fieldptr(ddy, "DDY", igrid)
-        CALL get_fieldptr(ddz, "DDZ", igrid)
-
-        IF (ctyp == 'T') THEN
-            CALL get_fieldptr(bp, "BT", igrid)
-        ELSE
-            CALL get_fieldptr(bp, "BP", igrid)
-        END IF
 
         ! Number of k iterations
         ! (not to be confused with kk - these are not the same!!!)
@@ -97,16 +36,16 @@ CONTAINS
             DO j = jstart, jstop, 2
                 ! Vomume
                 DO k = kstart, kstop+1
-                    vol1(k) = bp(k, j, i)*ddz(k)*ddy(j)*ddx(i)
+                    vol1(k) = b(k, j, i)*ddz(k)*ddy(j)*ddx(i)
                 END DO
                 DO k = kstart, kstop+1
-                    vol2(k) = bp(k, j, i+1)*ddz(k)*ddy(j)*ddx(i+1)
+                    vol2(k) = b(k, j, i+1)*ddz(k)*ddy(j)*ddx(i+1)
                 END DO
                 DO k = kstart, kstop+1
-                    vol3(k) = bp(k, j+1, i)*ddz(k)*ddy(j+1)*ddx(i)
+                    vol3(k) = b(k, j+1, i)*ddz(k)*ddy(j+1)*ddx(i)
                 END DO
                 DO k = kstart, kstop+1
-                    vol4(k) = bp(k, j+1, i+1)*ddz(k)*ddy(j+1)*ddx(i+1)
+                    vol4(k) = b(k, j+1, i+1)*ddz(k)*ddy(j+1)*ddx(i+1)
                 END DO
 
                 ! Pressure times volume
@@ -134,9 +73,9 @@ CONTAINS
                         + vol1(k+1) + vol2(k+1) + vol3(k+1) + vol4(k+1)
 
                     IF (sum_v > 0.0) THEN
-                        sendbuf(icount + ink) = sum_pv/sum_v
+                        sbuf(icount + ink) = sum_pv/sum_v
                     ELSE
-                        sendbuf(icount + ink) = 0.0
+                        sbuf(icount + ink) = 0.0
                     END IF
                 END DO
 
@@ -145,58 +84,50 @@ CONTAINS
 
                 ! Legacy code - keep for reference
                 ! DO k = kstart, kstop, 2
-                !     sum_pv = ff(k, j, i)*bp(k, j, i)*ddz(k)*ddy(j)*ddx(i) &
-                !         + ff(k, j, i+1)*bp(k, j, i+1)*ddz(k)*ddy(j)*ddx(i+1) &
-                !         + ff(k, j+1, i)*bp(k, j+1, i)*ddz(k)*ddy(j+1)*ddx(i) &
-                !         + ff(k, j+1, i+1)*bp(k, j+1, i+1)*ddz(k)*ddy(j+1)*ddx(i+1) &
-                !         + ff(k+1, j, i)*bp(k+1, j, i)*ddz(k+1)*ddy(j)*ddx(i) &
-                !         + ff(k+1, j, i+1)*bp(k+1, j, i+1)*ddz(k+1)*ddy(j)*ddx(i+1) &
-                !         + ff(k+1, j+1, i)*bp(k+1, j+1, i)*ddz(k+1)*ddy(j+1)*ddx(i) &
-                !         + ff(k+1, j+1, i+1)*bp(k+1, j+1, i+1)*ddz(k+1)*ddy(j+1)*ddx(i+1)
+                !     sum_pv = ff(k, j, i)*b(k, j, i)*ddz(k)*ddy(j)*ddx(i) &
+                !         + ff(k, j, i+1)*b(k, j, i+1)*ddz(k)*ddy(j)*ddx(i+1) &
+                !         + ff(k, j+1, i)*b(k, j+1, i)*ddz(k)*ddy(j+1)*ddx(i) &
+                !         + ff(k, j+1, i+1)*b(k, j+1, i+1)*ddz(k)*ddy(j+1)*ddx(i+1) &
+                !         + ff(k+1, j, i)*b(k+1, j, i)*ddz(k+1)*ddy(j)*ddx(i) &
+                !         + ff(k+1, j, i+1)*b(k+1, j, i+1)*ddz(k+1)*ddy(j)*ddx(i+1) &
+                !         + ff(k+1, j+1, i)*b(k+1, j+1, i)*ddz(k+1)*ddy(j+1)*ddx(i) &
+                !         + ff(k+1, j+1, i+1)*b(k+1, j+1, i+1)*ddz(k+1)*ddy(j+1)*ddx(i+1)
 
-                !     sum_v = bp(k, j, i)*ddz(k)*ddy(j)*ddx(i) &
-                !         + bp(k, j, i+1)*ddz(k)*ddy(j)*ddx(i+1) &
-                !         + bp(k, j+1, i)*ddz(k)*ddy(j+1)*ddx(i) &
-                !         + bp(k, j+1, i+1)*ddz(k)*ddy(j+1)*ddx(i+1) &
-                !         + bp(k+1, j, i)*ddz(k+1)*ddy(j)*ddx(i) &
-                !         + bp(k+1, j, i+1)*ddz(k+1)*ddy(j)*ddx(i+1) &
-                !         + bp(k+1, j+1, i)*ddz(k+1)*ddy(j+1)*ddx(i) &
-                !         + bp(k+1, j+1, i+1)*ddz(k+1)*ddy(j+1)*ddx(i+1)
+                !     sum_v = b(k, j, i)*ddz(k)*ddy(j)*ddx(i) &
+                !         + b(k, j, i+1)*ddz(k)*ddy(j)*ddx(i+1) &
+                !         + b(k, j+1, i)*ddz(k)*ddy(j+1)*ddx(i) &
+                !         + b(k, j+1, i+1)*ddz(k)*ddy(j+1)*ddx(i+1) &
+                !         + b(k+1, j, i)*ddz(k+1)*ddy(j)*ddx(i) &
+                !         + b(k+1, j, i+1)*ddz(k+1)*ddy(j)*ddx(i+1) &
+                !         + b(k+1, j+1, i)*ddz(k+1)*ddy(j+1)*ddx(i) &
+                !         + b(k+1, j+1, i+1)*ddz(k+1)*ddy(j+1)*ddx(i+1)
 
                 !     icount = icount + 1
                 !     sendbuf(icount) = divide0(sum_pv, sum_v)
                 ! END DO
             END DO
         END DO
-    END SUBROUTINE restrict_p
+    END SUBROUTINE restrict_gc_p_t
 
 
-    SUBROUTINE restrict_r(this, kk, jj, ii, ff, sendbuf, ctyp, igrid)
+    SUBROUTINE restrict_gc_r(kk, jj, ii, ff, ddx, ddy, ddz, bp, &
+            messagelength, sbuf, istart, istop, jstart, jstop, kstart, kstop)
+        !$omp declare target
         ! Subroutine arguments
-        CLASS(gc_restrict_t), INTENT(inout) :: this
-        INTEGER(intk), INTENT(IN) :: kk, jj, ii
-        REAL(realk), INTENT(IN) :: ff(kk, jj, ii)
-        REAL(realk), CONTIGUOUS, INTENT(INOUT) :: sendbuf(:)
-        CHARACTER(len=1), INTENT(in) :: ctyp
-        INTEGER(intk), INTENT(in) :: igrid
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(in) :: ff(kk, jj, ii)
+        REAL(realk), INTENT(in) :: ddx(ii), ddy(jj), ddz(kk)
+        REAL(realk), INTENT(in) :: bp(kk, jj, ii)
+        INTEGER(int32), INTENT(in) :: messagelength
+        REAL(realk), INTENT(inout) :: sbuf(messagelength)
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
         INTEGER(intk) :: i, j, k, icount
         INTEGER(intk) :: nk, ink
-        INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
 
         REAL(realk) :: pv1(kk), pv2(kk), pv3(kk), pv4(kk)
         REAL(realk) :: sum_pv, sum_v
-
-        REAL(realk), POINTER, CONTIGUOUS :: ddx(:), ddy(:), ddz(:), bp(:, :, :)
-
-        CALL this%start_and_stop(istart, istop, jstart, jstop, &
-            kstart, kstop, ctyp, igrid)
-
-        CALL get_fieldptr(ddx, "DDX", igrid)
-        CALL get_fieldptr(ddy, "DDY", igrid)
-        CALL get_fieldptr(ddz, "DDZ", igrid)
-        CALL get_fieldptr(bp, "BP", igrid)
 
         ! Number of k iterations
         ! (not to be confused with kk - these are not the same!!!)
@@ -231,7 +162,7 @@ CONTAINS
                     sum_v = (ddx(i) + ddx(i+1))*(ddy(j) + ddy(j+1)) &
                         *(ddz(k) + ddz(k+1))
 
-                    sendbuf(icount + ink) = sum_pv/sum_v
+                    sbuf(icount + ink) = sum_pv/sum_v
                 END DO
 
                 ! Increment counter
@@ -256,52 +187,46 @@ CONTAINS
                 ! END DO
             END DO
         END DO
-    END SUBROUTINE restrict_r
+    END SUBROUTINE restrict_gc_r
 
 
-    SUBROUTINE restrict_n(this, kk, jj, ii, ff, sendbuf, ctyp, igrid)
+    SUBROUTINE restrict_gc_n(kk, jj, ii, ff, messagelength, sbuf, &
+            istart, istop, jstart, jstop, kstart, kstop)
+        !$omp declare target
         ! Subroutine arguments
-        CLASS(gc_restrict_t), INTENT(inout) :: this
-        INTEGER(intk), INTENT(IN) :: kk, jj, ii
-        REAL(realk), INTENT(IN) :: ff(kk, jj, ii)
-        REAL(realk), CONTIGUOUS, INTENT(INOUT) :: sendbuf(:)
-        CHARACTER(len=1), INTENT(in) :: ctyp
-        INTEGER(intk), INTENT(in) :: igrid
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(in) :: ff(kk, jj, ii)
+        INTEGER(int32), INTENT(in) :: messagelength
+        REAL(realk), INTENT(inout) :: sbuf(messagelength)
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
         INTEGER(intk) :: i, j, k, icount
-        INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
-
-        CALL this%start_and_stop(istart, istop, jstart, jstop, &
-            kstart, kstop, ctyp, igrid)
 
         icount = 0
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
                     icount = icount + 1
-                    sendbuf(icount) = ff(k, j, i)
+                    sbuf(icount) = ff(k, j, i)
                 END DO
             END DO
         END DO
-    END SUBROUTINE restrict_n
+    END SUBROUTINE restrict_gc_n
 
 
-    SUBROUTINE restrict_e(this, kk, jj, ii, ff, sendbuf, ctyp, igrid)
+    SUBROUTINE restrict_gc_e(kk, jj, ii, ff, messagelength, sbuf, &
+            istart, istop, jstart, jstop, kstart, kstop)
+        !$omp declare target
         ! Subroutine arguments
-        CLASS(gc_restrict_t), INTENT(inout) :: this
-        INTEGER(intk), INTENT(IN) :: kk, jj, ii
-        REAL(realk), INTENT(IN) :: ff(kk, jj, ii)
-        REAL(realk), CONTIGUOUS, INTENT(INOUT) :: sendbuf(:)
-        CHARACTER(len=1), INTENT(in) :: ctyp
-        INTEGER(intk), INTENT(in) :: igrid
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(in) :: ff(kk, jj, ii)
+        INTEGER(int32), INTENT(in) :: messagelength
+        REAL(realk), INTENT(inout) :: sbuf(messagelength)
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
         INTEGER(intk) :: i, j, k, icount
-        INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
-
-        CALL this%start_and_stop(istart, istop, jstart, jstop, &
-            kstart, kstop, ctyp, igrid)
 
         icount = 0
         DO i = istart, istop, 2
@@ -310,7 +235,7 @@ CONTAINS
                     icount = icount + 1
                     ! TODO: Check purpose of MIN(1.0, ...) MAX(...) is never
                     ! greater than 1 ???
-                    sendbuf(icount) = MIN(1.0_realk, MAX(ff(k, j, i), &
+                    sbuf(icount) = MIN(1.0_realk, MAX(ff(k, j, i), &
                         ff(k, j, i+1), &
                         ff(k, j+1, i), &
                         ff(k, j+1, i+1), &
@@ -321,31 +246,28 @@ CONTAINS
                 END DO
             END DO
         END DO
-    END SUBROUTINE restrict_e
+    END SUBROUTINE restrict_gc_e
 
 
-    SUBROUTINE restrict_f(this, kk, jj, ii, ff, sendbuf, ctyp, igrid)
+    SUBROUTINE restrict_gc_f(kk, jj, ii, ff, messagelength, sbuf, &
+            istart, istop, jstart, jstop, kstart, kstop)
+        !$omp declare target
         ! Subroutine arguments
-        CLASS(gc_restrict_t), INTENT(inout) :: this
-        INTEGER(intk), INTENT(IN) :: kk, jj, ii
-        REAL(realk), INTENT(IN) :: ff(kk, jj, ii)
-        REAL(realk), CONTIGUOUS, INTENT(INOUT) :: sendbuf(:)
-        CHARACTER(len=1), INTENT(in) :: ctyp
-        INTEGER(intk), INTENT(in) :: igrid
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(in) :: ff(kk, jj, ii)
+        INTEGER(int32), INTENT(in) :: messagelength
+        REAL(realk), INTENT(inout) :: sbuf(messagelength)
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
         INTEGER(intk) :: i, j, k, icount
-        INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
-
-        CALL this%start_and_stop(istart, istop, jstart, jstop, &
-            kstart, kstop, ctyp, igrid)
 
         icount = 0
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
                     icount = icount + 1
-                    sendbuf(icount) = MIN(2.0_realk, MAX(ff(k, j, i), &
+                    sbuf(icount) = MIN(2.0_realk, MAX(ff(k, j, i), &
                         ff(k, j, i+1), &
                         ff(k, j+1, i), &
                         ff(k, j+1, i+1), &
@@ -356,31 +278,28 @@ CONTAINS
                 END DO
             END DO
         END DO
-    END SUBROUTINE restrict_f
+    END SUBROUTINE restrict_gc_f
 
 
-    SUBROUTINE restrict_i(this, kk, jj, ii, ff, sendbuf, ctyp, igrid)
+    SUBROUTINE restrict_gc_i(kk, jj, ii, ff, messagelength, sbuf, &
+            istart, istop, jstart, jstop, kstart, kstop)
+        !$omp declare target
         ! Subroutine arguments
-        CLASS(gc_restrict_t), INTENT(inout) :: this
-        INTEGER(intk), INTENT(IN) :: kk, jj, ii
-        REAL(realk), INTENT(IN) :: ff(kk, jj, ii)
-        REAL(realk), CONTIGUOUS, INTENT(INOUT) :: sendbuf(:)
-        CHARACTER(len=1), INTENT(in) :: ctyp
-        INTEGER(intk), INTENT(in) :: igrid
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(in) :: ff(kk, jj, ii)
+        INTEGER(int32), INTENT(in) :: messagelength
+        REAL(realk), INTENT(inout) :: sbuf(messagelength)
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
         INTEGER(intk) :: i, j, k, icount
-        INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
-
-        CALL this%start_and_stop(istart, istop, jstart, jstop, &
-            kstart, kstop, ctyp, igrid)
 
         icount = 0
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
                     icount = icount + 1
-                    sendbuf(icount) = MAX(ff(k, j, i), &
+                    sbuf(icount) = MAX(ff(k, j, i), &
                         ff(k, j, i+1), &
                         ff(k, j+1, i), &
                         ff(k, j+1, i+1), &
@@ -403,5 +322,5 @@ CONTAINS
                 END DO
             END DO
         END DO
-    END SUBROUTINE restrict_i
+    END SUBROUTINE restrict_gc_i
 END MODULE gc_restrict_mod

--- a/src/ib/ibmodel_mod.F90
+++ b/src/ib/ibmodel_mod.F90
@@ -4,16 +4,8 @@ MODULE ibmodel_mod
     IMPLICIT NONE(type, external)
     PRIVATE
 
-    TYPE, ABSTRACT :: restrict_t
-    CONTAINS
-        PROCEDURE :: message_length
-        PROCEDURE(start_and_stop_i), NOPASS, DEFERRED :: start_and_stop
-        PROCEDURE(restrict_i), DEFERRED :: restrict
-    END TYPE restrict_t
-
     TYPE, ABSTRACT :: ibmodel_t
         CHARACTER(len=16) :: type
-        CLASS(restrict_t), ALLOCATABLE :: restrict_op
     CONTAINS
         PROCEDURE(blockbp_i), DEFERRED :: blockbp
         PROCEDURE(read_stencils_i), DEFERRED :: read_stencils
@@ -29,16 +21,6 @@ MODULE ibmodel_mod
             CHARACTER(len=1), INTENT(in) :: ctyp
             INTEGER(intk), INTENT(in) :: igrid
         END SUBROUTINE start_and_stop_i
-
-        SUBROUTINE restrict_i(this, kk, jj, ii, ff, sendbuf, ctyp, igrid)
-            IMPORT :: restrict_t, intk, realk
-            CLASS(restrict_t), INTENT(inout) :: this
-            INTEGER(intk), INTENT(IN) :: kk, jj, ii
-            REAL(realk), INTENT(IN) :: ff(kk, jj, ii)
-            REAL(realk), CONTIGUOUS, INTENT(INOUT) :: sendbuf(:)
-            CHARACTER(len=1), INTENT(in) :: ctyp
-            INTEGER(intk), INTENT(IN) :: igrid
-        END SUBROUTINE restrict_i
 
         SUBROUTINE blockbp_i(this, stop_now)
             IMPORT :: ibmodel_t
@@ -66,23 +48,5 @@ MODULE ibmodel_mod
         END SUBROUTINE divcal_i
     END INTERFACE
 
-    PUBLIC :: ibmodel_t, restrict_t
-
-CONTAINS
-    INTEGER(intk) FUNCTION message_length(this, ctyp, igrid)
-        ! Subroutine arguments
-        CLASS(restrict_t), INTENT(inout) :: this
-        CHARACTER(len=1), INTENT(in) :: ctyp
-        INTEGER(intk), INTENT(IN) :: igrid
-
-        ! Local variables
-        INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
-
-        CALL this%start_and_stop(istart, istop, jstart, jstop, &
-            kstart, kstop, ctyp, igrid)
-
-        message_length = ((istop-istart)/2+1) &
-            *((jstop-jstart)/2+1) &
-            *((kstop-kstart)/2+1)
-    END FUNCTION message_length
+    PUBLIC :: ibmodel_t
 END MODULE ibmodel_mod

--- a/src/ib/noib_mod.F90
+++ b/src/ib/noib_mod.F90
@@ -2,7 +2,6 @@ MODULE noib_mod
     USE core_mod
     USE ibmodel_mod, ONLY: ibmodel_t
     USE fieldhelper_mod, ONLY: map_arr_to_device
-    USE noib_restrict_mod, ONLY: noib_restrict_t
 
     IMPLICIT NONE(type, external)
     PRIVATE
@@ -34,7 +33,6 @@ CONTAINS
         END IF
 
         ALLOCATE(noib_t :: ib)
-        ALLOCATE(noib_restrict_t :: ib%restrict_op)
 
         ib%type = "NONE"
 
@@ -56,9 +54,7 @@ CONTAINS
     SUBROUTINE destructor(this)
         TYPE(noib_t), INTENT(inout) :: this
 
-        IF (ALLOCATED(this%restrict_op)) THEN
-            DEALLOCATE(this%restrict_op)
-        END IF
+        ! Nothing to do
     END SUBROUTINE destructor
 
 

--- a/src/ib/noib_restrict_mod.F90
+++ b/src/ib/noib_restrict_mod.F90
@@ -1,155 +1,25 @@
 MODULE noib_restrict_mod
-    USE core_mod, ONLY: realk, intk, errr, get_fieldptr
-    USE ibmodel_mod, ONLY: restrict_t
+    USE core_mod
 
     IMPLICIT NONE(type, external)
     PRIVATE
 
-    TYPE, EXTENDS(restrict_t) :: noib_restrict_t
-    CONTAINS
-        PROCEDURE, NOPASS :: start_and_stop
-        PROCEDURE :: restrict
-        PROCEDURE :: restrict_u
-        PROCEDURE :: restrict_v
-        PROCEDURE :: restrict_w
-        PROCEDURE :: restrict_s
-    END TYPE noib_restrict_t
-
-    PUBLIC :: noib_restrict_t
-
+    PUBLIC :: restrict_noib_u, restrict_noib_v, restrict_noib_w, restrict_noib_s
 CONTAINS
-    SUBROUTINE restrict(this, kk, jj, ii, ff, sendbuf, ctyp, igrid)
+    SUBROUTINE restrict_noib_u(kk, jj, ii, ff, ddx, ddy, ddz, messagelength, &
+            sbuf, istart, istop, jstart, jstop, kstart, kstop)
+        !$omp declare target
         ! Subroutine arguments
-        CLASS(noib_restrict_t), INTENT(inout) :: this
-        INTEGER(intk), INTENT(IN) :: kk, jj, ii
-        REAL(realk), INTENT(IN) :: ff(kk, jj, ii)
-        REAL(realk), CONTIGUOUS, INTENT(INOUT) :: sendbuf(:)
-        CHARACTER(len=1), INTENT(in) :: ctyp
-        INTEGER(intk), INTENT(in) :: igrid
-
-        SELECT CASE (ctyp)
-        CASE ("U")
-            CALL this%restrict_u(kk, jj, ii, ff, sendbuf, ctyp, igrid)
-        CASE ("V")
-            CALL this%restrict_v(kk, jj, ii, ff, sendbuf, ctyp, igrid)
-        CASE ("W")
-            CALL this%restrict_w(kk, jj, ii, ff, sendbuf, ctyp, igrid)
-        CASE ("P", "R", "S", "T")
-            CALL this%restrict_s(kk, jj, ii, ff, sendbuf, ctyp, igrid)
-        CASE DEFAULT
-            CALL errr(__FILE__, __LINE__)
-        END SELECT
-    END SUBROUTINE restrict
-
-
-    SUBROUTINE start_and_stop(ista, isto, jsta, jsto, &
-            ksta, ksto, ctyp, igrid)
-        USE core_mod, ONLY: get_mgdims
-
-        ! Subroutine arguments
-        INTEGER(intk), INTENT(out) :: ista, isto, jsta, jsto, ksta, ksto
-        CHARACTER(len=1), INTENT(in) :: ctyp
-        INTEGER(intk), INTENT(in) :: igrid
-
-        ! Local variables
-        INTEGER(intk) :: ii, jj, kk
-        INTEGER(intk) :: istart, iend, jstart, jend, kstart, kend
-
-        ! Loop ranges are DO i = istart, ii-iend
-        ! returned as DO i = ista, isto, 2
-        SELECT CASE (ctyp)
-        CASE ("U")
-            istart = 2
-            iend = 2
-            jstart = 3
-            jend = 3
-            kstart = 3
-            kend = 3
-        CASE ("V")
-            istart = 3
-            iend = 3
-            jstart = 2
-            jend = 2
-            kstart = 3
-            kend = 3
-        CASE ("W")
-            istart = 3
-            iend = 3
-            jstart = 3
-            jend = 3
-            kstart = 2
-            kend = 2
-        CASE ("E", "F", "P", "R", "S", 'I', 'T')
-            istart = 3
-            iend = 3
-            jstart = 3
-            jend = 3
-            kstart = 3
-            kend = 3
-        CASE ("N")
-            istart = 2
-            iend = 2
-            jstart = 2
-            jend = 2
-            kstart = 2
-            kend = 2
-        CASE DEFAULT
-            CALL errr(__FILE__, __LINE__)
-        END SELECT
-
-        CALL get_mgdims(kk, jj, ii, igrid)
-
-        ista = istart
-        isto = ii - iend
-        jsta = jstart
-        jsto = jj - jend
-        ksta = kstart
-        ksto = kk - kend
-
-        ! Since the loop has strides of 2, do a sanity check that
-        ! the upper index is correct. The stop-index MUST be the actual
-        ! index of the last iteration for the message size to be computed
-        ! correctly
-        !
-        ! E.g. The loop:
-        !   DO i = 3, kk-3, 2
-        ! with kk = 28 will iterate like:
-        !   i = 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25
-        ! with 12 iterations.
-        !
-        ! If the loop had been:
-        !   DO i = 3, kk-2, 2
-        ! the iterations would have been the same (the last one being i = 25)
-        ! but the message size would be wrong.
-        !
-        ! Therefore require that MOD(isto-ista, 2) == 0
-        IF (MOD(isto-ista, 2) > 0) CALL errr(__FILE__, __LINE__)
-        IF (MOD(jsto-jsta, 2) > 0) CALL errr(__FILE__, __LINE__)
-        IF (MOD(ksto-ksta, 2) > 0) CALL errr(__FILE__, __LINE__)
-    END SUBROUTINE start_and_stop
-
-
-    SUBROUTINE restrict_u(this, kk, jj, ii, ff, sendbuf, ctyp, igrid)
-        ! Subroutine arguments
-        CLASS(noib_restrict_t), INTENT(inout) :: this
-        INTEGER(intk), INTENT(IN) :: kk, jj, ii
-        REAL(realk), INTENT(IN) :: ff(kk, jj, ii)
-        REAL(realk), CONTIGUOUS, INTENT(INOUT) :: sendbuf(:)
-        CHARACTER(len=1), INTENT(in) :: ctyp
-        INTEGER(intk), INTENT(in) :: igrid
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(in) :: ff(kk, jj, ii)
+        REAL(realk), INTENT(in) :: ddx(ii), ddy(jj), ddz(kk)
+        INTEGER(int32), INTENT(in) :: messagelength
+        REAL(realk), DIMENSION(messagelength), INTENT(inout) :: sbuf
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
         INTEGER(intk) :: i, j, k, icount
-        INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
         REAL(realk) :: sum_ua, sum_a
-        REAL(realk), POINTER, CONTIGUOUS :: ddx(:), ddy(:), ddz(:)
-
-        CALL this%start_and_stop(istart, istop, jstart, jstop, &
-            kstart, kstop, ctyp, igrid)
-
-        CALL get_fieldptr(ddx, "DDX", igrid)
-        CALL get_fieldptr(ddy, "DDY", igrid)
-        CALL get_fieldptr(ddz, "DDZ", igrid)
 
         icount = 0
         DO i = istart, istop, 2
@@ -163,34 +33,27 @@ CONTAINS
                     sum_a = (ddy(j) + ddy(j+1))*(ddz(k) + ddz(k+1))
 
                     icount = icount + 1
-                    sendbuf(icount) = sum_ua/sum_a
+                    sbuf(icount) = sum_ua/sum_a
                 END DO
             END DO
         END DO
-    END SUBROUTINE restrict_u
+    END SUBROUTINE restrict_noib_u
 
 
-    SUBROUTINE restrict_v(this, kk, jj, ii, ff, sendbuf, ctyp, igrid)
+    SUBROUTINE restrict_noib_v(kk, jj, ii, ff, ddx, ddy, ddz, messagelength, &
+            sbuf, istart, istop, jstart, jstop, kstart, kstop)
+        !$omp declare target
         ! Subroutine arguments
-        CLASS(noib_restrict_t), INTENT(inout) :: this
-        INTEGER(intk), INTENT(IN) :: kk, jj, ii
-        REAL(realk), INTENT(IN) :: ff(kk, jj, ii)
-        REAL(realk), CONTIGUOUS, INTENT(INOUT) :: sendbuf(:)
-        CHARACTER(len=1), INTENT(in) :: ctyp
-        INTEGER(intk), INTENT(in) :: igrid
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(in) :: ff(kk, jj, ii)
+        REAL(realk), INTENT(in) :: ddx(ii), ddy(jj), ddz(kk)
+        INTEGER(int32), INTENT(in) :: messagelength
+        REAL(realk), INTENT(inout) :: sbuf(messagelength)
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
         INTEGER(intk) :: i, j, k, icount
-        INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
         REAL(realk) :: sum_va, sum_a
-        REAL(realk), POINTER, CONTIGUOUS :: ddx(:), ddy(:), ddz(:)
-
-        CALL this%start_and_stop(istart, istop, jstart, jstop, &
-            kstart, kstop, ctyp, igrid)
-
-        CALL get_fieldptr(ddx, "DDX", igrid)
-        CALL get_fieldptr(ddy, "DDY", igrid)
-        CALL get_fieldptr(ddz, "DDZ", igrid)
 
         icount = 0
         DO i = istart, istop, 2
@@ -204,34 +67,27 @@ CONTAINS
                     sum_a = (ddx(i) + ddx(i+1))*(ddz(k) + ddz(k+1))
 
                     icount = icount + 1
-                    sendbuf(icount) = sum_va/sum_a
+                    sbuf(icount) = sum_va/sum_a
                 END DO
             END DO
         END DO
-    END SUBROUTINE restrict_v
+    END SUBROUTINE restrict_noib_v
 
 
-    SUBROUTINE restrict_w(this, kk, jj, ii, ff, sendbuf, ctyp, igrid)
+    SUBROUTINE restrict_noib_w(kk, jj, ii, ff, ddx, ddy, ddz, messagelength, &
+            sbuf, istart, istop, jstart, jstop, kstart, kstop)
+        !$omp declare target
         ! Subroutine arguments
-        CLASS(noib_restrict_t), INTENT(inout) :: this
-        INTEGER(intk), INTENT(IN) :: kk, jj, ii
-        REAL(realk), INTENT(IN) :: ff(kk, jj, ii)
-        REAL(realk), CONTIGUOUS, INTENT(INOUT) :: sendbuf(:)
-        CHARACTER(len=1), INTENT(in) :: ctyp
-        INTEGER(intk), INTENT(in) :: igrid
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(in) :: ff(kk, jj, ii)
+        REAL(realk), INTENT(in) :: ddx(ii), ddy(jj), ddz(kk)
+        INTEGER(int32), INTENT(in) :: messagelength
+        REAL(realk), INTENT(inout) :: sbuf(messagelength)
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
         INTEGER(intk) :: i, j, k, icount
-        INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
         REAL(realk) :: sum_wa, sum_a
-        REAL(realk), POINTER, CONTIGUOUS :: ddx(:), ddy(:), ddz(:)
-
-        CALL this%start_and_stop(istart, istop, jstart, jstop, &
-            kstart, kstop, ctyp, igrid)
-
-        CALL get_fieldptr(ddx, "DDX", igrid)
-        CALL get_fieldptr(ddy, "DDY", igrid)
-        CALL get_fieldptr(ddz, "DDZ", igrid)
 
         icount = 0
         DO i = istart, istop, 2
@@ -245,34 +101,27 @@ CONTAINS
                     sum_a = (ddx(i) + ddx(i+1))*(ddy(j) + ddy(j+1))
 
                     icount = icount + 1
-                    sendbuf(icount) = sum_wa/sum_a
+                    sbuf(icount) = sum_wa/sum_a
                 END DO
             END DO
         END DO
-    END SUBROUTINE restrict_w
+    END SUBROUTINE restrict_noib_w
 
 
-    SUBROUTINE restrict_s(this, kk, jj, ii, ff, sendbuf, ctyp, igrid)
+    SUBROUTINE restrict_noib_s(kk, jj, ii, ff, ddx, ddy, ddz, messagelength, &
+            sbuf, istart, istop, jstart, jstop, kstart, kstop)
+        !$omp declare target
         ! Subroutine arguments
-        CLASS(noib_restrict_t), INTENT(inout) :: this
-        INTEGER(intk), INTENT(IN) :: kk, jj, ii
-        REAL(realk), INTENT(IN) :: ff(kk, jj, ii)
-        REAL(realk), CONTIGUOUS, INTENT(INOUT) :: sendbuf(:)
-        CHARACTER(len=1), INTENT(in) :: ctyp
-        INTEGER(intk), INTENT(in) :: igrid
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(in) :: ff(kk, jj, ii)
+        REAL(realk), INTENT(in) :: ddx(ii), ddy(jj), ddz(kk)
+        INTEGER(int32), INTENT(in) :: messagelength
+        REAL(realk), INTENT(inout) :: sbuf(messagelength)
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
         INTEGER(intk) :: i, j, k, icount
-        INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
         REAL(realk) :: sum_pv, sum_v
-        REAL(realk), POINTER, CONTIGUOUS :: ddx(:), ddy(:), ddz(:)
-
-        CALL this%start_and_stop(istart, istop, jstart, jstop, &
-            kstart, kstop, ctyp, igrid)
-
-        CALL get_fieldptr(ddx, "DDX", igrid)
-        CALL get_fieldptr(ddy, "DDY", igrid)
-        CALL get_fieldptr(ddz, "DDZ", igrid)
 
         icount = 0
         DO i = istart, istop, 2
@@ -291,9 +140,9 @@ CONTAINS
                         *(ddz(k) + ddz(k+1))
 
                     icount = icount + 1
-                    sendbuf(icount) = sum_pv/sum_v
+                    sbuf(icount) = sum_pv/sum_v
                 END DO
             END DO
         END DO
-    END SUBROUTINE restrict_s
+    END SUBROUTINE restrict_noib_s
 END MODULE noib_restrict_mod

--- a/src/ib/restrict_mod.F90
+++ b/src/ib/restrict_mod.F90
@@ -1,0 +1,309 @@
+MODULE restrict_mod
+    USE core_mod
+    USE ibmodel_mod, ONLY: ibmodel_t
+    USE noib_restrict_mod
+    USE gc_restrict_mod
+
+    IMPLICIT NONE (type, external)
+    PRIVATE
+
+    INTERFACE message_length
+        MODULE PROCEDURE :: message_length_A
+        MODULE PROCEDURE :: message_length_B
+    END INTERFACE message_length
+
+    PUBLIC :: restrict, message_length, start_and_stop
+CONTAINS
+    SUBROUTINE restrict(ib, ctyp, field, igrid, offset)
+        ! Subroutine arguments
+        CLASS(ibmodel_t), INTENT(in) :: ib
+        CHARACTER(len=1), INTENT(in) :: ctyp
+        TYPE(field_t), INTENT(in) :: field
+        INTEGER(intk), INTENT(in) :: igrid
+        INTEGER(int32), INTENT(inout) :: offset
+
+        SELECT CASE (ib%type)
+        CASE ("GHOSTCELL")
+            CALL restrict_gc(ctyp, field, igrid, offset)
+        CASE ("NONE")
+            CALL restrict_noib(ctyp, field, igrid, offset)
+        CASE DEFAULT
+            CALL errr(__FILE__, __LINE__)
+        END SELECT
+    END SUBROUTINE restrict
+
+
+    SUBROUTINE restrict_noib(ctyp, f_t, igrid, offset)
+        ! Subroutine arguments
+        CHARACTER(len=1), INTENT(in) :: ctyp
+        TYPE(field_t), INTENT(in) :: f_t
+        INTEGER(intk), INTENT(in) :: igrid
+        INTEGER(int32), INTENT(inout) :: offset
+
+        ! Local variables
+        TYPE(field_t), POINTER :: ddx_f, ddy_f, ddz_f
+        REAL(realk), POINTER, CONTIGUOUS, DIMENSION(:, :, :) :: f
+        REAL(realk), POINTER, CONTIGUOUS, DIMENSION(:) :: ddx, ddy, ddz
+
+        INTEGER(intk) :: kk, jj, ii
+        INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
+        INTEGER(int32) :: messagelength, targetidx
+
+        CALL get_mgdims(kk, jj, ii, igrid)
+        CALL start_and_stop(istart, istop, jstart, jstop, kstart, kstop, ctyp, &
+            igrid)
+        CALL message_length(messagelength, istart, istop, jstart, jstop, &
+            kstart, kstop)
+        targetidx = offset + messagelength - 1
+
+        CALL get_field(ddx_f, "DDX")
+        CALL get_field(ddy_f, "DDY")
+        CALL get_field(ddz_f, "DDZ")
+
+        CALL ddx_f%get_ptr(ddx, igrid)
+        CALL ddy_f%get_ptr(ddy, igrid)
+        CALL ddz_f%get_ptr(ddz, igrid)
+
+        CALL f_t%get_ptr(f, igrid)
+
+        SELECT CASE (ctyp)
+        CASE ("U")
+            CALL restrict_noib_u(kk, jj, ii, f, ddx, ddy, ddz, &
+                messagelength, sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ("V")
+            CALL restrict_noib_v(kk, jj, ii, f, ddx, ddy, ddz, &
+                messagelength, sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ("W")
+            CALL restrict_noib_w(kk, jj, ii, f, ddx, ddy, ddz, &
+                messagelength, sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ("P", "R", "S", "T")
+            CALL restrict_noib_s(kk, jj, ii, f, ddx, ddy, ddz, &
+                messagelength, sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE DEFAULT
+            CALL errr(__FILE__, __LINE__)
+        END SELECT
+
+        offset = offset + messagelength
+    END SUBROUTINE restrict_noib
+
+
+    SUBROUTINE restrict_gc(ctyp, f_t, igrid, offset)
+        ! Subroutine arguments
+        CHARACTER(len=1), INTENT(in) :: ctyp
+        TYPE(field_t), INTENT(in) :: f_t
+        INTEGER(intk), INTENT(in) :: igrid
+        INTEGER(int32), INTENT(inout) :: offset
+
+        ! Local variables
+        TYPE(field_t), POINTER :: ddx_f, ddy_f, ddz_f, b_f
+        REAL(realk), POINTER, CONTIGUOUS, DIMENSION(:, :, :) :: f, b
+        REAL(realk), POINTER, CONTIGUOUS, DIMENSION(:) :: ddx, ddy, ddz
+
+        INTEGER(intk) :: kk, jj, ii
+        INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
+        INTEGER(int32) :: messagelength, targetidx
+
+        CALL get_mgdims(kk, jj, ii, igrid)
+        CALL start_and_stop(istart, istop, jstart, jstop, kstart, kstop, ctyp, &
+            igrid)
+        CALL message_length(messagelength, istart, istop, jstart, jstop, &
+            kstart, kstop)
+        targetidx = offset + messagelength - 1
+
+        CALL get_field(ddx_f, "DDX")
+        CALL get_field(ddy_f, "DDY")
+        CALL get_field(ddz_f, "DDZ")
+
+        CALL ddx_f%get_ptr(ddx, igrid)
+        CALL ddy_f%get_ptr(ddy, igrid)
+        CALL ddz_f%get_ptr(ddz, igrid)
+
+        CALL f_t%get_ptr(f, igrid)
+
+        SELECT CASE (ctyp)
+        CASE ("U")
+            CALL restrict_noib_u(kk, jj, ii, f, ddx, ddy, ddz, &
+                messagelength, sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ("V")
+            CALL restrict_noib_v(kk, jj, ii, f, ddx, ddy, ddz, &
+                messagelength, sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ("W")
+            CALL restrict_noib_w(kk, jj, ii, f, ddx, ddy, ddz, &
+                messagelength, sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ("P")
+            CALL get_field(b_f, "BP")
+            CALL b_f%get_ptr(b, igrid)
+            CALL restrict_gc_p_t(kk, jj, ii, f, ddx, ddy, ddz, b, &
+                messagelength, sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ("T")
+            CALL get_field(b_f, "BT")
+            CALL b_f%get_ptr(b, igrid)
+            CALL restrict_gc_p_t(kk, jj, ii, f, ddx, ddy, ddz, b, &
+                messagelength, sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ("R")
+            CALL get_field(b_f, "BP")
+            CALL b_f%get_ptr(b, igrid)
+            CALL restrict_gc_r(kk, jj, ii, f, ddx, ddy, ddz, b, &
+                messagelength, sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ("S")
+            CALL restrict_noib_s(kk, jj, ii, f, ddx, ddy, ddz, &
+                messagelength, sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ("N")
+            CALL restrict_gc_n(kk, jj, ii, f, messagelength, &
+                sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ("E")
+            CALL restrict_gc_e(kk, jj, ii, f, messagelength, &
+                sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ("F")
+            CALL restrict_gc_f(kk, jj, ii, f, messagelength, &
+                sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ("I")
+            CALL restrict_gc_i(kk, jj, ii, f, messagelength, &
+                sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE DEFAULT
+            CALL errr(__FILE__, __LINE__)
+        END SELECT
+
+        offset = offset + messagelength
+    END SUBROUTINE restrict_gc
+
+
+    SUBROUTINE message_length_A(messagelength, ctyp, igrid)
+        ! Subroutine arguments
+        INTEGER(int32), INTENT(out) :: messagelength
+        CHARACTER(len=1), INTENT(in) :: ctyp
+        INTEGER(intk), INTENT(in) :: igrid
+
+        ! Local variables
+        INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
+
+        CALL start_and_stop(istart, istop, jstart, jstop, kstart, kstop, ctyp, &
+            igrid)
+        CALL message_length_impl(messagelength, istart, istop, jstart, jstop, &
+            kstart, kstop)
+    END SUBROUTINE message_length_A
+
+
+    SUBROUTINE message_length_B(messagelength, istart, istop, jstart, &
+            jstop, kstart, kstop)
+        ! Subroutine arguments
+        INTEGER(int32), INTENT(out) :: messagelength
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
+
+        CALL message_length_impl(messagelength, istart, istop, jstart, jstop, &
+            kstart, kstop)
+    END SUBROUTINE message_length_B
+
+
+    SUBROUTINE message_length_impl(messagelength, istart, istop, jstart, &
+            jstop, kstart, kstop)
+        ! Function arguments
+        INTEGER(int32), INTENT(out) :: messagelength
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
+
+        messagelength = INT(((istop-istart)/2+1) &
+            *((jstop-jstart)/2+1) &
+            *((kstop-kstart)/2+1), kind=int32)
+    END SUBROUTINE message_length_impl
+
+
+    SUBROUTINE start_and_stop(ista, isto, jsta, jsto, &
+            ksta, ksto, ctyp, igrid)
+        USE core_mod, ONLY: get_mgdims
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(out) :: ista, isto, jsta, jsto, ksta, ksto
+        CHARACTER(len=1), INTENT(in) :: ctyp
+        INTEGER(intk), INTENT(in) :: igrid
+
+        ! Local variables
+        INTEGER(intk) :: ii, jj, kk
+        INTEGER(intk) :: istart, iend, jstart, jend, kstart, kend
+
+        ! Loop ranges are DO i = istart, ii-iend
+        ! returned as DO i = ista, isto, 2
+        SELECT CASE (ctyp)
+        CASE ("U")
+            istart = 2
+            iend = 2
+            jstart = 3
+            jend = 3
+            kstart = 3
+            kend = 3
+        CASE ("V")
+            istart = 3
+            iend = 3
+            jstart = 2
+            jend = 2
+            kstart = 3
+            kend = 3
+        CASE ("W")
+            istart = 3
+            iend = 3
+            jstart = 3
+            jend = 3
+            kstart = 2
+            kend = 2
+        CASE ("E", "F", "P", "R", "S", 'I', 'T')
+            istart = 3
+            iend = 3
+            jstart = 3
+            jend = 3
+            kstart = 3
+            kend = 3
+        CASE ("N")
+            istart = 2
+            iend = 2
+            jstart = 2
+            jend = 2
+            kstart = 2
+            kend = 2
+        CASE DEFAULT
+            CALL errr(__FILE__, __LINE__)
+        END SELECT
+
+        CALL get_mgdims(kk, jj, ii, igrid)
+
+        ista = istart
+        isto = ii - iend
+        jsta = jstart
+        jsto = jj - jend
+        ksta = kstart
+        ksto = kk - kend
+
+        ! Since the loop has strides of 2, do a sanity check that
+        ! the upper index is correct. The stop-index MUST be the actual
+        ! index of the last iteration for the message size to be computed
+        ! correctly
+        !
+        ! E.g. The loop:
+        !   DO i = 3, kk-3, 2
+        ! with kk = 28 will iterate like:
+        !   i = 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25
+        ! with 12 iterations.
+        !
+        ! If the loop had been:
+        !   DO i = 3, kk-2, 2
+        ! the iterations would have been the same (the last one being i = 25)
+        ! but the message size would be wrong.
+        !
+        ! Therefore require that MOD(isto-ista, 2) == 0
+        IF (MOD(isto-ista, 2) > 0) CALL errr(__FILE__, __LINE__)
+        IF (MOD(jsto-jsta, 2) > 0) CALL errr(__FILE__, __LINE__)
+        IF (MOD(ksto-ksta, 2) > 0) CALL errr(__FILE__, __LINE__)
+    END SUBROUTINE start_and_stop
+END MODULE restrict_mod


### PR DESCRIPTION
- Completely removes `restrict_t`
- `ftoc` now has no calls to polymorphic `ib` object procedures
- All restrict operations are independent of `ctyp`. This means that when calling them in kernels, they do not need to call `start_and_stop`. Thus, the indices `istart`, `istop` etc. should be part of the sendtasks for offloading
- The new top-level `restrict` subroutine is intended for CPU only. When offloading, separate kernels should be created for `noib_t` and `gc_t`. The GPU kernels will need a different interface since they take in precomputed indices instead of calculating them on the fly.
- I did not refactor `restrict_recieve_open` and `restrict_recieve_open_n` as this is part of the next step for the offloaded `ftoc2` module