### PR TITLE
Spark llvm testing -- for documentation mainly

### DIFF
--- a/src/flow/sip_hyperplane_mod.F90
+++ b/src/flow/sip_hyperplane_mod.F90
@@ -469,13 +469,14 @@ CONTAINS
         iacc = -1
 
         ! Iterating over the hyperplanes H(k, j, i) = m
+        !$omp parallel private(m, lm, lp, ip, iacc, idx, idx_km, idx_jm, idx_im)
         DO m = n3dmin, n3dmax
 
             lm = INT(mip(m), intk)
             lp = INT(mip(m+1), intk) - lm
 
             ! > Parallel operations on the hyperplane (k, j, i) = m
-            !$omp parallel do private(ip, iacc, idx, idx_km, idx_jm, idx_im)
+            !$omp do
             DO ip = 1, lp
 
                 ! Computing the contiguous access index
@@ -499,8 +500,13 @@ CONTAINS
                 !     - ls(k, j, i)*res(k, j-1, i) - lb(k, j, i)*res(k-1, j, i)
 
             END DO
-            !$omp end parallel do
+            !$omp end do
+
+            ! > Implicit barrier at !$omp end do ignored...
+            !$omp barrier
+
         END DO
+        !$omp end parallel
 
     END SUBROUTINE sipiter1
 
@@ -526,13 +532,15 @@ CONTAINS
         iacc = -1
 
         ! Iterating (REVERSE) over the hyperplanes H(k, j, i) = m
+
+        !$omp parallel private(m, lm, lp, ip, iacc, idx, idx_kp, idx_jp, idx_ip)
         DO m = n3dmax, n3dmin, -1
 
             lm = INT(mip(m), intk)
             lp = INT(mip(m+1), intk) - lm
 
             ! > Parallel operations on the hyperplane (k, j, i) = m
-            !$omp parallel do private(ip, iacc, idx, idx_kp, idx_jp, idx_ip)
+            !$omp do
             DO ip = 1, lp
 
                 ! Computing the contiguous access index
@@ -553,10 +561,15 @@ CONTAINS
                 !     - ue(k, j, i)*res(k, j, i+1) - ut(k, j, i)*res(k+1, j, i)
 
             END DO
-            !$omp end parallel do
+            !$omp end do
+
+            ! > Implicit barrier at !$omp end do ignored...
+            !$omp barrier
+
         END DO
 
-        !$omp parallel do collapse(3) private(i, j, k, idx)
+
+        !$omp do collapse(3) private(i, j, k, idx)
         DO i = 3, ii-2
             DO j = 3, jj-2
                 DO k = 3, kk-2
@@ -565,6 +578,8 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
+        !$omp end parallel
+
     END SUBROUTINE sipiter2
 END MODULE sip_hyperplane_mod

--- a/src/flow/sip_hyperplane_mod.F90
+++ b/src/flow/sip_hyperplane_mod.F90
@@ -476,7 +476,7 @@ CONTAINS
             lp = INT(mip(m+1), intk) - lm
 
             ! > Parallel operations on the hyperplane (k, j, i) = m
-            !$omp do
+            !$omp loop bind(parallel)
             DO ip = 1, lp
 
                 ! Computing the contiguous access index
@@ -500,7 +500,7 @@ CONTAINS
                 !     - ls(k, j, i)*res(k, j-1, i) - lb(k, j, i)*res(k-1, j, i)
 
             END DO
-            !$omp end do
+            !$omp end loop
 
             ! > Implicit barrier at !$omp end do ignored...
             !$omp barrier
@@ -532,7 +532,6 @@ CONTAINS
         iacc = -1
 
         ! Iterating (REVERSE) over the hyperplanes H(k, j, i) = m
-
         !$omp parallel private(m, lm, lp, ip, iacc, idx, idx_kp, idx_jp, idx_ip)
         DO m = n3dmax, n3dmin, -1
 
@@ -540,7 +539,7 @@ CONTAINS
             lp = INT(mip(m+1), intk) - lm
 
             ! > Parallel operations on the hyperplane (k, j, i) = m
-            !$omp do
+            !$omp loop bind(parallel)
             DO ip = 1, lp
 
                 ! Computing the contiguous access index
@@ -561,7 +560,7 @@ CONTAINS
                 !     - ue(k, j, i)*res(k, j, i+1) - ut(k, j, i)*res(k+1, j, i)
 
             END DO
-            !$omp end do
+            !$omp end loop
 
             ! > Implicit barrier at !$omp end do ignored...
             !$omp barrier
@@ -569,7 +568,7 @@ CONTAINS
         END DO
 
 
-        !$omp do collapse(3) private(i, j, k, idx)
+        !$omp loop bind(parallel) collapse(3) private(i, j, k, idx)
         DO i = 3, ii-2
             DO j = 3, jj-2
                 DO k = 3, kk-2
@@ -578,7 +577,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end do
+        !$omp end loop
         !$omp end parallel
 
     END SUBROUTINE sipiter2


### PR DESCRIPTION
Dear @jfuchs-kmt and @hakostra 

LLVM on NVIDIA (version documented below) seems to be catching up with the AMD flang compiler. The SIP routines, however, require a slightly different treatment in order to be executed correctly. The implementation also works with the AMD compiler, where is appears to yield slightly worse performance (~5% in SIP). 

In general, the performance on Spark still remains below expectation. Most worryingly, the execution gets slower over the iterations, which may hint at some leak or pollution of the mapping table -- not visible via export LIBOMPTARGET_INFO=-1, however.

Compiler used and installed:

flang version 23.0.0git (https://github.com/llvm/llvm-project.git ef3ac7a77a06442ab2ac57f5417cfa9ded7a3b46)
Target: aarch64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/llvm/llvm-project/install_latest/bin

Best regards,

Simon