### PR TITLE
Remove Zeroing of Fields in Fieldpool

### DIFF
--- a/src/core/connect/conn2_mod.F90
+++ b/src/core/connect/conn2_mod.F90
@@ -82,7 +82,7 @@ CONTAINS
 
         IF (.NOT. is_init) CALL errr(__FILE__, __LINE__)
 
-        CALL push_field(dummy, "CONN2_DUMMY", zero=.FALSE.)
+        CALL push_field(dummy, "CONN2_DUMMY")
 
         f1 => dummy
         f2 => dummy

--- a/src/core/fieldpool_mod.F90
+++ b/src/core/fieldpool_mod.F90
@@ -72,22 +72,19 @@ CONTAINS
     END SUBROUTINE finish_fieldpool
 
 
-    SUBROUTINE push_realfield(field, name, istag, jstag, kstag, units, zero)
+    ! Returns a pointer to a field with allocated arr and buffers that have
+    ! unspecified values.
+    ! The arr member is NOT zeroed by default and the buffers member is NOT
+    ! guaranteed to be set to nan if _MGLET_DEBUG_ is set.
+    SUBROUTINE push_realfield(field, name, istag, jstag, kstag, units)
         ! Subroutine arguments
         TYPE(field_t), INTENT(out), POINTER :: field
         CHARACTER(len=*), INTENT(in) :: name
         INTEGER(intk), INTENT(in), OPTIONAL :: istag, jstag, kstag
         INTEGER(intk), INTENT(in), OPTIONAL :: units(7)
-        LOGICAL, INTENT(in), OPTIONAL :: zero
 
         ! Local variables
-        LOGICAL :: zero2, did_init
-
-        IF (PRESENT(zero)) THEN
-            zero2 = zero
-        ELSE
-            zero2 = .TRUE.
-        END IF
+        ! none...
 
         IF (stackptr_real > max_realfields) THEN
             WRITE(*, *) "Exceeded maximum number of realfields in fieldpool."
@@ -98,50 +95,32 @@ CONTAINS
 
         field => realfields(stackptr_real)
 
-        did_init = .FALSE.
         IF (.NOT. field%is_init) THEN
             CALL field%init(name=name, istag=istag, jstag=jstag, kstag=kstag, &
-                units=units, zero=zero2)
+                units=units, zero=.FALSE.)
             CALL field%init_buffers()
-            !$omp target enter data map(to: realfields(stackptr_real)%arr)
-            !$omp target enter data map(to: realfields(stackptr_real)%buffers)
-            did_init = .TRUE.
+            !$omp target enter data map(alloc: realfields(stackptr_real)%arr, &
+            !$omp& realfields(stackptr_real)%buffers)
         ELSE
             CALL set_field_properties(field, name, istag, jstag, kstag, units)
-        END IF
-
-        IF (zero2 .AND. .NOT. did_init) THEN
-            ! TODO(offload): Once larger portions of the code are ported,
-            ! remove the device=.FALSE. setter and preprocessor ifdef.
-            ! Currently, we can not generalize whether all fields in the
-            ! fieldpool are only required on the device and are thus required
-            ! to set both host and device buffers to zero.
-#ifdef _MGLET_OFFLOAD_
-            CALL set_field_arr(field, 0.0_realk, device=.TRUE.)
-#endif
-            CALL set_field_arr(field, 0.0_realk, device=.FALSE.)
         END IF
 
         stackptr_real = stackptr_real+1
     END SUBROUTINE push_realfield
 
 
-    SUBROUTINE push_intfield(field, name, istag, jstag, kstag, units, zero)
+    ! Returns a pointer to a field with allocated arr that has unspecified
+    ! values.
+    ! The arr member is NOT zeroed by default
+    SUBROUTINE push_intfield(field, name, istag, jstag, kstag, units)
         ! Subroutine arguments
         TYPE(intfield_t), INTENT(out), POINTER :: field
         CHARACTER(len=*), INTENT(in) :: name
         INTEGER(intk), INTENT(in), OPTIONAL :: istag, jstag, kstag
         INTEGER(intk), INTENT(in), OPTIONAL :: units(7)
-        LOGICAL, INTENT(in), OPTIONAL :: zero
 
         ! Local variables
-        LOGICAL :: zero2, did_init
-
-        IF (PRESENT(zero)) THEN
-            zero2 = zero
-        ELSE
-            zero2 = .TRUE.
-        END IF
+        ! none...
 
         IF (stackptr_int > max_intfields) THEN
             WRITE(*, *) "Exceeded maximum number of intfields in fieldpool."
@@ -152,26 +131,12 @@ CONTAINS
 
         field => intfields(stackptr_int)
 
-        did_init = .FALSE.
         IF (.NOT. field%is_init) THEN
             CALL field%init(name=name, istag=istag, jstag=jstag, kstag=kstag, &
-                units=units, zero=zero2)
-                !$omp target enter data map(to: intfields(stackptr_int)%arr)
-                did_init = .TRUE.
+                units=units, zero=.FALSE.)
+                !$omp target enter data map(alloc: intfields(stackptr_int)%arr)
         ELSE
             CALL set_field_properties(field, name, istag, jstag, kstag, units)
-        END IF
-
-        IF (zero2 .AND. .NOT. did_init) THEN
-            ! TODO(offload): Once larger portions of the code are ported,
-            ! remove the device=.FALSE. setter and preprocessor ifdef.
-            ! Currently, we can not generalize whether all fields in the
-            ! fieldpool are only required on the device and are thus required
-            ! to set both host and device buffers to zero.
-#ifdef _MGLET_OFFLOAD_
-            CALL set_field_arr(field, 0_ifk, device=.TRUE.)
-#endif
-            CALL set_field_arr(field, 0_ifk, device=.FALSE.)
         END IF
 
         stackptr_int = stackptr_int+1

--- a/src/flow/flowstat_mod.F90
+++ b/src/flow/flowstat_mod.F90
@@ -592,6 +592,7 @@ CONTAINS
             units=units)
         CALL push_field(ux_f, name_ux, istag=istag, jstag=jstag, &
             kstag=kstag, units=units_ux)
+        CALL set_field_arr(ux_f, 0.0_realk)
 
         CALL differentiate(ux_f, u_f, ivar)
 
@@ -687,6 +688,7 @@ CONTAINS
             units=units)
         CALL push_field(ux_f, name_ux, istag=istag, jstag=jstag, &
             kstag=kstag, units=units_ux)
+        CALL set_field_arr(ux_f, 0.0_realk)
         CALL differentiate(ux_f, u_f, ivar)
 
         field%arr = ux_f%arr**2
@@ -815,6 +817,8 @@ CONTAINS
             kstag=kstag, units=units_ux)
         CALL push_field(vx_f, name_vx, istag=istag, jstag=jstag, &
             kstag=kstag, units=units_ux)
+        CALL set_field_arr(ux_f, 0.0_realk)
+        CALL set_field_arr(vx_f, 0.0_realk)
 
         CALL differentiate(ux_f, u_f, ivar1)
         CALL differentiate(vx_f, v_f, ivar2)
@@ -887,6 +891,9 @@ CONTAINS
             kstag=kstag, units=units_ux)
         CALL push_field(temp_f, 'tmp', istag=istag, jstag=jstag, &
             kstag=kstag, units=units_ux)
+        CALL set_field_arr(uy_f, 0.0_realk)
+        CALL set_field_arr(vx_f, 0.0_realk)
+        CALL set_field_arr(temp_f, 0.0_realk)
 
         CALL differentiate(uy_f, u_f, ivar1)
         CALL differentiate(vx_f, v_f, ivar2)

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -185,11 +185,15 @@ CONTAINS
             CALL get_field(bp, "BP")
         END IF
 
-        ! All of these fields are initialized to zero automatically
         CALL push_field(dp, "DP")
         CALL push_field(hilf, "HILF")
         CALL push_field(rhs, "RHS")
         CALL push_field(res, "RES")
+        CALL set_field_arr(dp, 0.0_realk, device=.TRUE.)
+        CALL set_field_arr(hilf, 0.0_realk, device=.TRUE.)
+        CALL set_field_arr(rhs, 0.0_realk)
+        CALL set_field_arr(res, 0.0_realk, device=.TRUE.)
+
 
         ! laplace(dp) = prefak * div(u) is the underlying equation
         prefak = rho/dt

--- a/src/flow/timeintegration_mod.F90
+++ b/src/flow/timeintegration_mod.F90
@@ -58,6 +58,9 @@ CONTAINS
         CALL push_field(uo, "UO")
         CALL push_field(vo, "VO")
         CALL push_field(wo, "WO")
+        CALL set_field_arr(uo, 0.0_realk)
+        CALL set_field_arr(vo, 0.0_realk)
+        CALL set_field_arr(wo, 0.0_realk)
 
         ! Transporting velocities for the convective terms
         ! Only CC use a different transporting velocity

--- a/src/ib/gc_blockbp_mod.F90
+++ b/src/ib/gc_blockbp_mod.F90
@@ -79,13 +79,20 @@ CONTAINS
         CALL push_field(au, "AU", istag=1)
         CALL push_field(av, "AV", jstag=1)
         CALL push_field(aw, "AW", kstag=1)
+        CALL set_field_arr(au, 0.0_realk)
+        CALL set_field_arr(av, 0.0_realk)
+        CALL set_field_arr(aw, 0.0_realk)
 
         CALL push_field(kanteu, "KANTEU", jstag=1, kstag=1)
         CALL push_field(kantev, "KANTEV", istag=1, kstag=1)
         CALL push_field(kantew, "KANTEW", istag=1, jstag=1)
+        CALL set_field_arr(kanteu, 0.0_realk)
+        CALL set_field_arr(kantev, 0.0_realk)
+        CALL set_field_arr(kantew, 0.0_realk)
 
         ! Important with proper staggering for parent to work
         CALL push_field(knoten, "KNOTEN", istag=1, jstag=1, kstag=1)
+        CALL set_field_arr(knoten, 0.0_realk)
 
         IF (myid == 0) THEN
             WRITE (*, '("BLOCKING: ", A40, ", WTIME:", F16.3)') &
@@ -316,6 +323,7 @@ CONTAINS
         TYPE(field_t), POINTER :: bodyid_3d_f
 
         CALL push_field(bodyid_3d_f, "BODYID")
+        CALL set_field_arr(bodyid_3d_f, 0.0_realk)
 
         ! Copy from list to 3D field
         DO ilevel = minlevel, maxlevel

--- a/src/ib/ib_mod.F90
+++ b/src/ib/ib_mod.F90
@@ -87,6 +87,8 @@ CONTAINS
         finecell%arr = 1.0
 
         CALL push_field(hilf, "HILF")
+        CALL set_field_arr(hilf, 0.0_realk)
+
         DO ilevel = maxlevel, minlevel, -1
             CALL ftoc(ilevel, hilf, finecell, 'P')
         END DO

--- a/src/ib/parent/parent2_mod.F90
+++ b/src/ib/parent/parent2_mod.F90
@@ -79,7 +79,7 @@ CONTAINS
             IF (normal2) idx_normal = 1
         END IF
 
-        CALL push_field(dummy, "PARENT2_DUMMY", zero=.FALSE.)
+        CALL push_field(dummy, "PARENT2_DUMMY")
 
         f1 => dummy
         f2 => dummy

--- a/src/scalar/blockbt_mod.F90
+++ b/src/scalar/blockbt_mod.F90
@@ -30,6 +30,7 @@ CONTAINS
 
         CALL get_field(bp_f, "BP")
         CALL push_field(hilf_f, "HILF")
+        CALL set_field_arr(hilf_f, 0.0_realk)
 
         ! Checking if any neighboring cell (shared face) has bp=1
         ! [only those cells can have a flux stencil associated with them]

--- a/src/scalar/scastat_mod.F90
+++ b/src/scalar/scastat_mod.F90
@@ -125,6 +125,7 @@ CONTAINS
             units=units_txtx)
         CALL push_field(tx_f, 'tmp', istag=istag, jstag=jstag, kstag=kstag, &
             units=units_tx)
+        CALL set_field_arr(tx_f, 0.0_realk)
 
         ! central difference on scalar (= no staggering)
         CALL differentiate(tx_f, t_f, ivar)

--- a/src/scalar/timeintegrate_scalar_mod.F90
+++ b/src/scalar/timeintegrate_scalar_mod.F90
@@ -38,6 +38,10 @@ CONTAINS
         CALL push_field(qtu, "QTU", istag=1)
         CALL push_field(qtv, "QTV", jstag=1)
         CALL push_field(qtw, "QTW", kstag=1)
+        CALL set_field_arr(qtt, 0.0_realk)
+        CALL set_field_arr(qtu, 0.0_realk)
+        CALL set_field_arr(qtv, 0.0_realk)
+        CALL set_field_arr(qtw, 0.0_realk)
 
         CALL stop_timer(401)
 


### PR DESCRIPTION
The new interface for fieldpool `push_field` is clearer when reading code in solvers. Fieldpool is only responsible for getting a pointer to an allocated field. Zeroing is the responsibility of the algorithm.