### PR TITLE
Offload mgpcorr

### DIFF
--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -312,14 +312,12 @@ CONTAINS
             CALL bound_pressure(ilevel, dp, bp)
         END DO
 
-        ! TODO(offload): Remove once surrounding subroutines are offloaded
-        CALL map_arr_from_device(dp, message="from:dp%arr")
+        CALL map_arr_to_device(u, v, w, p, message="to:u|v|w|p%arr")
 
         ! Pressure correction: P = P + dtrk/rho*DP
         ! Velocity fields are modified and become solenoidal based on DP
-        CALL mgpcorr(u, v, w, p, dp, dt/rho, bp)
+        CALL mgpcorr(u, v, w, p, dp, dt/rho)
 
-        CALL map_arr_to_device(u, v, w, p, message="to:u|v|w|p%arr")
         DO ilevel = maxlevel, minlevel, -1
             CALL ftoc(ilevel, u, v, w, p, device=.TRUE.)
         END DO
@@ -732,50 +730,59 @@ CONTAINS
     END SUBROUTINE rescal_grid
 
 
-    SUBROUTINE mgpcorr(u, v, w, p, dp, rfak, bp_f)
+    SUBROUTINE mgpcorr(u_f, v_f, w_f, p_f, dp_f, rfak)
         ! Subroutine arguments
-        TYPE(field_t), INTENT(inout) :: u, v, w, p
-        TYPE(field_t), INTENT(in) :: dp
+        TYPE(field_t), INTENT(inout) :: u_f, v_f, w_f, p_f
+        TYPE(field_t), INTENT(in) :: dp_f
         REAL(realk), INTENT(in) :: rfak
-        TYPE(field_t), INTENT(in), OPTIONAL :: bp_f
 
         ! Local variables
-        INTEGER(intk) :: i, igrid, ip3
+        TYPE(field_t), POINTER :: rdx_f, rdy_f, rdz_f, bp_f
+        INTEGER(intk) :: i, igrid, ip3, ip1x, ip1y, ip1z
         INTEGER(intk) :: kk, jj, ii
-
-        TYPE(field_t), POINTER :: rdx_f
-        TYPE(field_t), POINTER :: rdy_f
-        TYPE(field_t), POINTER :: rdz_f
-
-        REAL(realk), POINTER, CONTIGUOUS :: rdx(:), rdy(:), rdz(:), bp(:, :, :)
-
-        NULLIFY(bp)
 
         CALL get_field(rdx_f, "RDX")
         CALL get_field(rdy_f, "RDY")
         CALL get_field(rdz_f, "RDZ")
+        CALL get_field(bp_f, "BP")
 
+        ASSOCIATE(u => u_f%arr, v => v_f%arr, w => w_f%arr, &
+            p => p_f%arr, dp => dp_f%arr, &
+            rdx => rdx_f%arr, rdy => rdy_f%arr, rdz => rdz_f%arr, &
+            bp => bp_f%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("mgpcorr")
+#endif
+
+        !$omp target teams distribute private(i, igrid, kk, jj, ii, ip3, ip1x, &
+        !$omp& ip1y, ip1z)
         DO i = 1, nmygrids
             igrid = mygrids(i)
             CALL get_mgdims(kk, jj, ii, igrid)
             CALL get_ip3(ip3, igrid)
+            CALL get_ip1x(ip1x, igrid)
+            CALL get_ip1y(ip1y, igrid)
+            CALL get_ip1z(ip1z, igrid)
 
-            CALL rdx_f%get_ptr(rdx, igrid)
-            CALL rdy_f%get_ptr(rdy, igrid)
-            CALL rdz_f%get_ptr(rdz, igrid)
-
-            IF (PRESENT(bp_f)) THEN
-                CALL bp_f%get_ptr(bp, igrid)
-            END IF
-
-            CALL mgpcorr_grid(kk, jj, ii, u%arr(ip3), v%arr(ip3), w%arr(ip3), &
-                p%arr(ip3), dp%arr(ip3), rdx, rdy, rdz, rfak, bp)
+            !$omp parallel
+            CALL mgpcorr_grid(kk, jj, ii, u(ip3), v(ip3), w(ip3), &
+                p(ip3), dp(ip3), bp(ip3), rdx(ip1x), rdy(ip1y), rdz(ip1z), rfak)
+            !$omp end parallel
         END DO
+        !$omp end target teams distribute
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+
+        END ASSOCIATE
     END SUBROUTINE mgpcorr
 
 
-    PURE SUBROUTINE mgpcorr_grid(kk, jj, ii, u, v, w, p, dp, rdx, rdy, rdz, &
-            rfak, bp)
+    PURE SUBROUTINE mgpcorr_grid(kk, jj, ii, u, v, w, p, dp, bp, rdx, rdy, &
+            rdz, rfak)
+        !$omp declare target
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: kk, jj, ii
         REAL(realk), INTENT(inout) :: u(kk, jj, ii)
@@ -783,89 +790,60 @@ CONTAINS
         REAL(realk), INTENT(inout) :: w(kk, jj, ii)
         REAL(realk), INTENT(inout) :: p(kk, jj, ii)
         REAL(realk), INTENT(in) :: dp(kk, jj, ii)
+        REAL(realk), INTENT(in) :: bp(kk, jj, ii)
         REAL(realk), INTENT(in) :: rdx(ii)
         REAL(realk), INTENT(in) :: rdy(jj)
         REAL(realk), INTENT(in) :: rdz(kk)
         REAL(realk), INTENT(in) :: rfak
-        REAL(realk), INTENT(in), OPTIONAL :: bp(kk, jj, ii)
 
         ! Local variables
         INTEGER(intk) :: k, j, i
 
-        IF (PRESENT(bp)) THEN
-            DO i = 2, ii-1
-                DO j = 2, jj-1
-                    DO k = 2, kk-1
-                        p(k, j, i) = p(k, j, i) + dp(k, j, i)*bp(k, j, i)
-                    END DO
+        !$omp do collapse(3)
+        DO i = 2, ii-1
+            DO j = 2, jj-1
+                DO k = 2, kk-1
+                    p(k, j, i) = p(k, j, i) + dp(k, j, i)*bp(k, j, i)
                 END DO
             END DO
+        END DO
+        !$omp end do
 
-            DO i = 2, ii-2
-                DO j = 3, jj-2
-                    DO k = 3, kk-2
-                        u(k, j, i) = u(k, j, i) &
-                            + (dp(k, j, i) - dp(k, j, i+1)) &
-                            *bp(k, j, i)*bp(k, j, i+1)*rdx(i)*rfak
-                    END DO
+        !$omp do collapse(3)
+        DO i = 2, ii-2
+            DO j = 3, jj-2
+                DO k = 3, kk-2
+                    u(k, j, i) = u(k, j, i) &
+                        + (dp(k, j, i) - dp(k, j, i+1)) &
+                        *bp(k, j, i)*bp(k, j, i+1)*rdx(i)*rfak
                 END DO
             END DO
+        END DO
+        !$omp end do
 
-            DO i = 3, ii-2
-                DO j = 2, jj - 2
-                    DO k = 3, kk-2
-                        v(k, j, i) = v(k, j, i) &
-                            + (dp(k, j, i) - dp(k, j+1, i)) &
-                            *bp(k, j, i)*bp(k, j+1, i)*rdy(j)*rfak
-                    END DO
+        !$omp do collapse(3)
+        DO i = 3, ii-2
+            DO j = 2, jj - 2
+                DO k = 3, kk-2
+                    v(k, j, i) = v(k, j, i) &
+                        + (dp(k, j, i) - dp(k, j+1, i)) &
+                        *bp(k, j, i)*bp(k, j+1, i)*rdy(j)*rfak
                 END DO
             END DO
+        END DO
+        !$omp end do
 
-            DO i = 3, ii-2
-                DO j = 3, jj-2
-                    DO k = 2, kk-2
-                        w(k, j, i) = w(k, j, i) &
-                            + (dp(k, j, i) - dp(k+1, j, i)) &
-                            *bp(k, j, i)*bp(k+1, j, i)*rdz(k)*rfak
-                    END DO
+        !$omp do collapse(3)
+        DO i = 3, ii-2
+            DO j = 3, jj-2
+                DO k = 2, kk-2
+                    w(k, j, i) = w(k, j, i) &
+                        + (dp(k, j, i) - dp(k+1, j, i)) &
+                        *bp(k, j, i)*bp(k+1, j, i)*rdz(k)*rfak
                 END DO
             END DO
-        ELSE
-            DO i = 2, ii-1
-                DO j = 2, jj-1
-                    DO k = 2, kk-1
-                        p(k, j, i) = p(k, j, i) + dp(k, j, i)
-                    END DO
-                END DO
-            END DO
-
-            DO i = 2, ii-2
-                DO j = 3, jj-2
-                    DO k = 3, kk-2
-                        u(k, j, i) = u(k, j, i) &
-                            + (dp(k, j, i) - dp(k, j, i+1))*rdx(i)*rfak
-                    END DO
-                END DO
-            END DO
-
-            DO i = 3, ii-2
-                DO j = 2, jj - 2
-                    DO k = 3, kk-2
-                        v(k, j, i) = v(k, j, i) &
-                            + (dp(k, j, i) - dp(k, j+1, i))*rdy(j)*rfak
-                    END DO
-                END DO
-            END DO
-
-            DO i = 3, ii-2
-                DO j = 3, jj-2
-                    DO k = 2, kk-2
-                        w(k, j, i) = w(k, j, i) &
-                            + (dp(k, j, i) - dp(k+1, j, i))*rdz(k)*rfak
-                    END DO
-                END DO
-            END DO
-        END IF
+        END DO
+        !$omp end do
     END SUBROUTINE mgpcorr_grid
 
 

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -194,9 +194,10 @@ CONTAINS
         ! laplace(dp) = prefak * div(u) is the underlying equation
         prefak = rho/dt
         CALL ib%divcal(rhs, u, v, w, prefak)
+        CALL map_arr_to_device(rhs, message="to:rhs%arr")
 
         DO ilevel = maxlevel, minlevel, -1
-            CALL ftoc(ilevel, rhs, rhs, 'R')
+            CALL ftoc(ilevel, rhs, rhs, 'R', .TRUE.)
         END DO
 
         ! For debug logging
@@ -211,9 +212,6 @@ CONTAINS
             CALL print_plog(ittot, irk, 0)
         END IF
 
-        ! TODO(offload): Remove once surrounding subroutines are offloaded
-        CALL map_arr_to_device(rhs, message="to:rhs%arr")
-
         ipc = 0
         outer: DO ipcount = 1, nouter
             ! Inner pressure iterations
@@ -225,9 +223,6 @@ CONTAINS
                 CALL mgpoisit(ilevel, hilf, rhs, res, bp)
             END DO
             CALL stop_timer(322)
-
-            ! TODO(offload): Remove once surrounding subroutines offloaded
-            CALL map_arr_from_device(hilf, message="from:hilf%arr")
 
             ! --- intermediate state ---
             ! every grid level has an inner solution
@@ -241,11 +236,8 @@ CONTAINS
             ! vom feinsten zum groebsten (fine to coarse)
             ! hilf = 0.0
             DO ilevel = maxlevel, minlevel, -1
-                CALL ftoc(ilevel, hilf, hilf, 'P')
+                CALL ftoc(ilevel, hilf, hilf, 'P', device=.TRUE.)
             END DO
-
-            ! TODO(offload): Remove once surrounding subroutines are offloaded
-            CALL map_arr_to_device(hilf, message="to:hilf%arr")
 
             ! --- intermediate state ---
             ! every grid level has the best solution
@@ -261,15 +253,10 @@ CONTAINS
             CALL laplacephi(res, hilf)
             ! rhs <- rhs + res
             CALL rescal(rhs, res)
-            ! TODO(offload): Remove once surrounding subroutines are offloaded
-            CALL map_arr_from_device(rhs, message="from:rhs%arr")
 
             DO ilevel = maxlevel, minlevel+1, -1
-                CALL ftoc(ilevel, rhs, rhs, 'R')
+                CALL ftoc(ilevel, rhs, rhs, 'R', device=.TRUE.)
             END DO
-
-            ! TODO(offload): Remove once surrounding subroutines are offloaded
-            CALL map_arr_to_device(rhs, message="to:rhs%arr")
 
             ! Max of RHS scaled according to levels
             CALL maxabscal(maxrhs, maxrhslvl, rhs)
@@ -331,9 +318,12 @@ CONTAINS
         ! Pressure correction: P = P + dtrk/rho*DP
         ! Velocity fields are modified and become solenoidal based on DP
         CALL mgpcorr(u, v, w, p, dp, dt/rho, bp)
+
+        CALL map_arr_to_device(u, v, w, p, message="to:u|v|w|p%arr")
         DO ilevel = maxlevel, minlevel, -1
-            CALL ftoc(ilevel, u, v, w, p)
+            CALL ftoc(ilevel, u, v, w, p, device=.TRUE.)
         END DO
+        CALL map_arr_from_device(u, v, w, p, message="from:u|v|w|p%arr")
 
         ! All levels (coarse to fine)
         ! Propagation of the solution to neighbours and childs

--- a/src/ib/CMakeLists.txt
+++ b/src/ib/CMakeLists.txt
@@ -21,7 +21,10 @@ add_library(ib STATIC
     flzelle_mod.F90
     freekante_mod.F90
     freepressure_mod.F90
-    ftoc_mod.F90
+    ftoc/ftoc_mod.F90
+    ftoc/ftoc1_mod.F90
+    ftoc/ftoc2_mod.F90
+    ftoc/ftoc_core_mod.F90
     gc_blockbpfeld_mod.F90
     gc_blockbp_mod.F90
     gc_blockface_mod.F90

--- a/src/ib/ftoc/ftoc1_mod.F90
+++ b/src/ib/ftoc/ftoc1_mod.F90
@@ -1,18 +1,12 @@
-MODULE ftoc_mod
+MODULE ftoc1_mod
     USE MPI_f08
     USE core_mod
+    USE ftoc_core_mod
     USE ibcore_mod, ONLY: ib
     USE restrict_mod, ONLY: restrict, message_length, start_and_stop
 
     IMPLICIT NONE (type, external)
     PRIVATE
-
-    ! The information in the first dimension is sorted as follows:
-    !   Field 1: Rank of sending process
-    !   Field 2: Rank of receiving process
-    !   Field 3: ID of sending grid (fine grid)
-    !   Field 4: ID of receiving grid (coarse grid)
-    INTEGER(intk), ALLOCATABLE :: sendconns(:, :), recvconns(:, :)
 
     ! Lists that hold the send and receive request arrays
     TYPE(MPI_Request), ALLOCATABLE :: sendreqs(:), recvreqs(:)
@@ -22,22 +16,17 @@ MODULE ftoc_mod
     INTEGER(int32), ALLOCATABLE :: recvlist(:)
     INTEGER(intk), ALLOCATABLE :: recvidxlist(:, :)
 
-    ! Number of send and receive connections
-    INTEGER(intk) :: isend = 0, irecv = 0
-
     ! Variable to indicate if the required data structures have been created
     LOGICAL :: is_init = .FALSE.
 
-    INTERFACE ftoc
-        MODULE PROCEDURE :: ftoc_one, ftoc_multiple
-    END INTERFACE ftoc
+    INTERFACE ftoc1
+        MODULE PROCEDURE :: ftoc1_one, ftoc1_multiple
+    END INTERFACE ftoc1
 
     ! contained functions
-    PUBLIC :: ftoc, init_ftoc, finish_ftoc
-
-
+    PUBLIC :: ftoc1, init_ftoc1, finish_ftoc1
 CONTAINS
-    SUBROUTINE ftoc_one(ilevel, ff, fc, flag)
+    SUBROUTINE ftoc1_one(ilevel, ff, fc, flag)
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: ilevel
         TYPE(field_t), INTENT(in) :: ff
@@ -47,8 +36,6 @@ CONTAINS
         ! Local variables
         ! none...
 
-        CALL start_timer(220)
-
         IF (.NOT. is_init) CALL errr(__FILE__, __LINE__)
 
         CALL recv_all(ilevel, flag, fc)
@@ -57,20 +44,16 @@ CONTAINS
 
         nrecv = 0
         nsend = 0
-
-        CALL stop_timer(220)
-    END SUBROUTINE ftoc_one
+    END SUBROUTINE ftoc1_one
 
 
-    SUBROUTINE ftoc_multiple(ilevel, v1, v2, v3, s1, s2, s3)
+    SUBROUTINE ftoc1_multiple(ilevel, v1, v2, v3, s1, s2, s3)
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: ilevel
         TYPE(field_t), INTENT(inout), OPTIONAL :: v1, v2, v3, s1, s2, s3
 
         ! Local variables
         CHARACTER(len=*), PARAMETER :: flag = '*'
-
-        CALL start_timer(220)
 
         IF (.NOT. is_init) CALL errr(__FILE__, __LINE__)
 
@@ -80,9 +63,7 @@ CONTAINS
 
         nrecv = 0
         nsend = 0
-
-        CALL stop_timer(220)
-    END SUBROUTINE ftoc_multiple
+    END SUBROUTINE ftoc1_multiple
 
 
     SUBROUTINE recv_all(ilevel, flag, v1, v2, v3, s1, s2, s3)
@@ -147,50 +128,6 @@ CONTAINS
         recvcounter = recvcounter + messagelength
         messagelength = 0
     END SUBROUTINE post_recv
-
-
-    SUBROUTINE count_ncells(ncells, flag, igrid, v1, v2, v3, s1, s2, s3)
-        ! Subroutine arguments
-        INTEGER(int32), INTENT(out) :: ncells
-        CHARACTER(len=1), INTENT(in) :: flag
-        INTEGER(intk), INTENT(in) :: igrid
-        TYPE(field_t), INTENT(in), OPTIONAL :: v1, v2, v3, s1, s2, s3
-
-        ! Local variables
-        INTEGER(int32) :: messagelength
-
-        ncells = 0
-
-        IF (flag == '*') THEN
-            IF (PRESENT(v1)) THEN
-                CALL message_length(messagelength, 'U', igrid)
-                ncells = ncells + messagelength
-            END IF
-            IF (PRESENT(v2)) THEN
-                CALL message_length(messagelength, 'V', igrid)
-                ncells = ncells + messagelength
-            END IF
-            IF (PRESENT(v3)) THEN
-                CALL message_length(messagelength, 'W', igrid)
-                ncells = ncells + messagelength
-            END IF
-            IF (PRESENT(s1)) THEN
-                CALL message_length(messagelength, 'P', igrid)
-                ncells = ncells + messagelength
-            END IF
-            IF (PRESENT(s2)) THEN
-                CALL message_length(messagelength, 'P', igrid)
-                ncells = ncells + messagelength
-            END IF
-            IF (PRESENT(s3)) THEN
-                CALL message_length(messagelength, 'P', igrid)
-                ncells = ncells + messagelength
-            END IF
-        ELSE
-            CALL message_length(messagelength, flag, igrid)
-            ncells = ncells + messagelength
-        END IF
-    END SUBROUTINE count_ncells
 
 
     ! Perform all send calls
@@ -448,106 +385,47 @@ CONTAINS
     END SUBROUTINE read_buffer
 
 
-    SUBROUTINE init_ftoc()
-        ! Local variables
-        INTEGER(intk) :: i, igrid, iprocc, ipar, maxconns
-        INTEGER(int32), ALLOCATABLE :: sendcounts(:), sdispls(:)
-        INTEGER(int32), ALLOCATABLE :: recvcounts(:), rdispls(:)
-        INTEGER(intk), PARAMETER :: ncols = 4
+    SUBROUTINE init_ftoc1()
+        ! Subroutine arguments
+        ! none...
 
-        CALL set_timer(220, "FTOC")
+        ! Local variables
+        ! none...
 
         IF (is_init) CALL errr(__FILE__, __LINE__)
 
-        maxconns = nmygrids*8
-        ALLOCATE(sendconns(ncols, maxconns))
+        ! Check if ctof_core_mod provides necessary infrastructure
+        IF (.NOT. is_ftoc_core_init) CALL errr(__FILE__, __LINE__)
 
-        ALLOCATE(sendcounts(0:numprocs-1), SOURCE=0)
-        ALLOCATE(sdispls(0:numprocs-1), SOURCE=0)
-        ALLOCATE(recvcounts(0:numprocs-1), SOURCE=0)
-        ALLOCATE(rdispls(0:numprocs-1), SOURCE=0)
-
-        nsend = 0
-        DO i = 1, nmygrids
-            igrid = mygrids(i)
-            ipar = iparent(igrid)
-            IF (ipar == 0) CYCLE
-
-            iprocc = idprocofgrd(ipar)
-
-            nsend = nsend + 1
-            IF (nsend > maxconns) THEN
-                CALL errr(__FILE__, __LINE__)
-            END IF
-
-            sendconns(1, nsend) = myid
-            sendconns(2, nsend) = iprocc
-            sendconns(3, nsend) = igrid
-            sendconns(4, nsend) = ipar
-
-            sendcounts(iprocc) = sendcounts(iprocc) + ncols
-        END DO
-        isend = nsend
-
-        ! Sort sendconns by process ID (col 2)
-        CALL sort_conns(sendconns(:, 1:nsend), 2)
-
-        ! Calculate sdispl offset
-        DO i = 1, numprocs-1
-            sdispls(i) = sdispls(i-1) + sendcounts(i-1)
-        END DO
-
-        ! First exchange NUMBER OF ELEMENTS TO RECEIVE, to be able to
-        ! calculate rdispls array
-        CALL MPI_Alltoall(sendcounts, 1, MPI_INTEGER, recvcounts, 1, &
-            MPI_INTEGER, MPI_COMM_WORLD)
-
-        ! Calculate rdispl offset
-        DO i = 1, numprocs-1
-            rdispls(i) = rdispls(i-1) + recvcounts(i-1)
-        END DO
-
-        irecv = (rdispls(numprocs-1) + recvcounts(numprocs-1))/ncols
-        ALLOCATE(recvconns(ncols, irecv))
-        recvconns = 0
-
-        ! Exchange connection information
-        CALL MPI_Alltoallv(sendconns, sendcounts, sdispls, MPI_INTEGER, &
-            recvconns, recvcounts, rdispls, MPI_INTEGER, &
-            MPI_COMM_WORLD)
-
-        DEALLOCATE(rdispls)
-        DEALLOCATE(recvcounts)
-        DEALLOCATE(sdispls)
-        DEALLOCATE(sendcounts)
-
-        ALLOCATE(sendreqs(numprocs))
-        ALLOCATE(recvreqs(numprocs))
-        ALLOCATE(recvlist(irecv))
-        ALLOCATE(recvidxlist(3, irecv))
-
-        is_init = .TRUE.
+        ALLOCATE(recvidxlist(3, irecv), source=0_intk)
+        ALLOCATE(recvlist(irecv), source=0_int32)
+        ALLOCATE(sendreqs(numprocs), source=MPI_REQUEST_NULL)
+        ALLOCATE(recvreqs(numprocs), source=MPI_REQUEST_NULL)
         nsend = 0
         nrecv = 0
-    END SUBROUTINE init_ftoc
+
+        is_init = .TRUE.
+    END SUBROUTINE init_ftoc1
 
 
-    SUBROUTINE finish_ftoc()
-        ! Function to deallocate arrays.
-        ! After successful execution, the module varaible "is_init" is set
-        ! to false.
-        IF (.NOT. is_init) RETURN
+    SUBROUTINE finish_ftoc1()
+        ! Subroutine arguments
+        ! none...
 
-        is_init = .FALSE.
-        isend = 0
-        irecv = 0
-        DEALLOCATE(sendconns)
-        DEALLOCATE(recvconns)
-        DEALLOCATE(sendreqs)
+        ! Local variables
+        ! none...
+
+        IF (.NOT. is_init) CALL errr(__FILE__, __LINE__)
+
         DEALLOCATE(recvreqs)
+        DEALLOCATE(sendreqs)
         DEALLOCATE(recvlist)
         DEALLOCATE(recvidxlist)
-    END SUBROUTINE finish_ftoc
+        nsend = 0
+        nrecv = 0
+
+        is_init = .FALSE.
+    END SUBROUTINE finish_ftoc1
 
 
     SUBROUTINE restrict_recieve_open(kk, jj, ii, fc, buffer, igridf, flag)
@@ -638,5 +516,4 @@ CONTAINS
             END DO
         END DO
     END SUBROUTINE restrict_recieve_open_n
-
-END MODULE ftoc_mod
+END MODULE ftoc1_mod

--- a/src/ib/ftoc/ftoc2_mod.F90
+++ b/src/ib/ftoc/ftoc2_mod.F90
@@ -5,7 +5,7 @@ MODULE ftoc2_mod
     USE ibcore_mod, ONLY: ib
     USE gc_restrict_mod
     USE noib_restrict_mod
-    USE restrict_mod, ONLY: message_length, start_and_stop
+    USE restrict_mod
 
     ! FTOC2 uses the sendbuf from commbuf_mod simultaneously while packing for
     ! MPI sends and for self communication. Since the self communication must
@@ -656,9 +656,9 @@ CONTAINS
         ! Local variables
         INTEGER(intk) :: itask, kkf, jjf, iif, kkc, jjc, iic
         INTEGER(intk) :: ip3f, ip3c, ipx, ipy, ipz
-        INTEGER(intk) :: fieldid, tasksize, igridf, igridc, &
-            istart, istop, jstart, jstop, kstart, kstop, ipos, jpos, kpos, &
-            scratchidx
+        INTEGER(intk) :: fieldid, igridf, igridc, istart, istop, jstart, &
+            jstop, kstart, kstop, ipos, jpos, kpos
+        INTEGER(int32) :: tasksize, scratchidx
         CHARACTER(len=1) :: flag
 
         ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
@@ -676,8 +676,8 @@ CONTAINS
         DO itask = 1, netasks
             fieldid = etasks(1, itask)
             flag = ACHAR(etasks(2, itask))
-            tasksize = etasks(3, itask)
-            scratchidx = etasks(4, itask)
+            tasksize = INT(etasks(3, itask), kind=int32)
+            scratchidx = INT(etasks(4, itask), kind=int32)
             igridf = etasks(5, itask)
             igridc = etasks(6, itask)
             istart = etasks(7, itask)
@@ -700,54 +700,54 @@ CONTAINS
 
             SELECT CASE(fieldid)
             CASE (1)
-                CALL restrict_sendtask_noib(flag, kkf, jjf, iif, &
+                CALL restrict_noib_flag(flag, kkf, jjf, iif, &
                     a1(ip3f), ddx(ipx), ddy(ipy), ddz(ipz), &
-                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a1(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
                     tasksize, istart, istop, jstart, jstop, kstart, kstop, &
                     ipos, jpos, kpos)
             CASE (2)
-                CALL restrict_sendtask_noib(flag, kkf, jjf, iif, &
+                CALL restrict_noib_flag(flag, kkf, jjf, iif, &
                     a2(ip3f), ddx(ipx), ddy(ipy), ddz(ipz), &
-                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a2(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
                     tasksize, istart, istop, jstart, jstop, kstart, kstop, &
                     ipos, jpos, kpos)
             CASE (3)
-                CALL restrict_sendtask_noib(flag, kkf, jjf, iif, &
+                CALL restrict_noib_flag(flag, kkf, jjf, iif, &
                     a3(ip3f), ddx(ipx), ddy(ipy), ddz(ipz), &
-                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a3(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
                     tasksize, istart, istop, jstart, jstop, kstart, kstop, &
                     ipos, jpos, kpos)
             CASE (4)
-                CALL restrict_sendtask_noib(flag, kkf, jjf, iif, &
+                CALL restrict_noib_flag(flag, kkf, jjf, iif, &
                     a4(ip3f), ddx(ipx), ddy(ipy), ddz(ipz), &
-                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a4(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
                     tasksize, istart, istop, jstart, jstop, kstart, kstop, &
                     ipos, jpos, kpos)
             CASE (5)
-                CALL restrict_sendtask_noib(flag, kkf, jjf, iif, &
+                CALL restrict_noib_flag(flag, kkf, jjf, iif, &
                     a5(ip3f), ddx(ipx), ddy(ipy), ddz(ipz), &
-                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a5(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
                     tasksize, istart, istop, jstart, jstop, kstart, kstop, &
                     ipos, jpos, kpos)
             CASE (6)
-                CALL restrict_sendtask_noib(flag, kkf, jjf, iif, &
+                CALL restrict_noib_flag(flag, kkf, jjf, iif, &
                     a6(ip3f), ddx(ipx), ddy(ipy), ddz(ipz), &
-                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a6(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
@@ -779,9 +779,9 @@ CONTAINS
         ! Local variables
         INTEGER(intk) :: itask, kkf, jjf, iif, kkc, jjc, iic
         INTEGER(intk) :: ip3f, ip3c, ipx, ipy, ipz
-        INTEGER(intk) :: fieldid, tasksize, igridf, igridc, &
-            istart, istop, jstart, jstop, kstart, kstop, ipos, jpos, kpos, &
-            scratchidx
+        INTEGER(intk) :: fieldid, igridf, igridc, istart, istop, jstart, &
+            jstop, kstart, kstop, ipos, jpos, kpos
+        INTEGER(int32) :: tasksize, scratchidx
         CHARACTER(len=1) :: flag
 
         ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
@@ -800,8 +800,8 @@ CONTAINS
         DO itask = 1, netasks
             fieldid = etasks(1, itask)
             flag = ACHAR(etasks(2, itask))
-            tasksize = etasks(3, itask)
-            scratchidx = etasks(4, itask)
+            tasksize = INT(etasks(3, itask), kind=int32)
+            scratchidx = INT(etasks(4, itask), kind=int32)
             igridf = etasks(5, itask)
             igridc = etasks(6, itask)
             istart = etasks(7, itask)
@@ -824,54 +824,54 @@ CONTAINS
 
             SELECT CASE(fieldid)
             CASE (1)
-                CALL restrict_sendtask_gc(flag, kkf, jjf, iif, a1(ip3f), &
+                CALL restrict_gc_flag(flag, kkf, jjf, iif, a1(ip3f), &
                     ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
-                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a1(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
                     tasksize, istart, istop, jstart, jstop, kstart, kstop, &
                     ipos, jpos, kpos)
             CASE (2)
-                CALL restrict_sendtask_gc(flag, kkf, jjf, iif, a2(ip3f), &
+                CALL restrict_gc_flag(flag, kkf, jjf, iif, a2(ip3f), &
                     ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
-                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a2(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
                     tasksize, istart, istop, jstart, jstop, kstart, kstop, &
                     ipos, jpos, kpos)
             CASE (3)
-                CALL restrict_sendtask_gc(flag, kkf, jjf, iif, a3(ip3f), &
+                CALL restrict_gc_flag(flag, kkf, jjf, iif, a3(ip3f), &
                     ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
-                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a3(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
                     tasksize, istart, istop, jstart, jstop, kstart, kstop, &
                     ipos, jpos, kpos)
             CASE (4)
-                CALL restrict_sendtask_gc(flag, kkf, jjf, iif, a4(ip3f), &
+                CALL restrict_gc_flag(flag, kkf, jjf, iif, a4(ip3f), &
                     ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
-                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a4(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
                     tasksize, istart, istop, jstart, jstop, kstart, kstop, &
                     ipos, jpos, kpos)
             CASE (5)
-                CALL restrict_sendtask_gc(flag, kkf, jjf, iif, a5(ip3f), &
+                CALL restrict_gc_flag(flag, kkf, jjf, iif, a5(ip3f), &
                     ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
-                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a5(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
                     tasksize, istart, istop, jstart, jstop, kstart, kstop, &
                     ipos, jpos, kpos)
             CASE (6)
-                CALL restrict_sendtask_gc(flag, kkf, jjf, iif, a6(ip3f), &
+                CALL restrict_gc_flag(flag, kkf, jjf, iif, a6(ip3f), &
                     ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
-                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a6(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
@@ -1095,8 +1095,9 @@ CONTAINS
 
         ! Local variables
         INTEGER(intk) :: itask, kk, jj, ii, ip3, ipx, ipy, ipz
-        INTEGER(intk) :: fieldid, icount, tasksize, igrid, &
-            istart, istop, jstart, jstop, kstart, kstop
+        INTEGER(intk) :: fieldid, igrid, istart, istop, jstart, jstop, kstart, &
+            kstop
+        INTEGER(int32) :: icount, tasksize
         CHARACTER(len=1) :: flag
 
         ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
@@ -1113,8 +1114,8 @@ CONTAINS
         DO itask = 1, nstasks
             fieldid = stasks(1, itask)
             flag = ACHAR(stasks(2, itask))
-            icount = stasks(3, itask)
-            tasksize = stasks(4, itask)
+            icount = INT(stasks(3, itask), kind=int32)
+            tasksize = INT(stasks(4, itask), kind=int32)
             igrid = stasks(5, itask)
             istart = stasks(6, itask)
             istop = stasks(7, itask)
@@ -1131,28 +1132,28 @@ CONTAINS
 
             SELECT CASE(fieldid)
             CASE (1)
-                CALL restrict_sendtask_noib(flag, kk, jj, ii, a1(ip3), &
-                    ddx(ipx), ddy(ipy), ddz(ipz), tasksize, icount, &
+                CALL restrict_noib_flag(flag, kk, jj, ii, a1(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), icount, tasksize, &
                     istart, istop, jstart, jstop, kstart, kstop)
             CASE (2)
-                CALL restrict_sendtask_noib(flag, kk, jj, ii, a2(ip3), &
-                    ddx(ipx), ddy(ipy), ddz(ipz), tasksize, icount, &
+                CALL restrict_noib_flag(flag, kk, jj, ii, a2(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), icount, tasksize, &
                     istart, istop, jstart, jstop, kstart, kstop)
             CASE (3)
-                CALL restrict_sendtask_noib(flag, kk, jj, ii, a3(ip3), &
-                    ddx(ipx), ddy(ipy), ddz(ipz), tasksize, icount, &
+                CALL restrict_noib_flag(flag, kk, jj, ii, a3(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), icount, tasksize, &
                     istart, istop, jstart, jstop, kstart, kstop)
             CASE (4)
-                CALL restrict_sendtask_noib(flag, kk, jj, ii, a4(ip3), &
-                    ddx(ipx), ddy(ipy), ddz(ipz), tasksize, icount, &
+                CALL restrict_noib_flag(flag, kk, jj, ii, a4(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), icount, tasksize, &
                     istart, istop, jstart, jstop, kstart, kstop)
             CASE (5)
-                CALL restrict_sendtask_noib(flag, kk, jj, ii, a5(ip3), &
-                    ddx(ipx), ddy(ipy), ddz(ipz), tasksize, icount, &
+                CALL restrict_noib_flag(flag, kk, jj, ii, a5(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), icount, tasksize, &
                     istart, istop, jstart, jstop, kstart, kstop)
             CASE (6)
-                CALL restrict_sendtask_noib(flag, kk, jj, ii, a6(ip3), &
-                    ddx(ipx), ddy(ipy), ddz(ipz), tasksize, icount, &
+                CALL restrict_noib_flag(flag, kk, jj, ii, a6(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), icount, tasksize, &
                     istart, istop, jstart, jstop, kstart, kstop)
 #ifdef _MGLET_DEBUG_
             CASE DEFAULT
@@ -1179,8 +1180,9 @@ CONTAINS
 
         ! Local variables
         INTEGER(intk) :: itask, kk, jj, ii, ip3, ipx, ipy, ipz
-        INTEGER(intk) :: fieldid, icount, tasksize, igrid, &
-            istart, istop, jstart, jstop, kstart, kstop
+        INTEGER(intk) :: fieldid, igrid, istart, istop, jstart, jstop, kstart, &
+            kstop
+        INTEGER(int32) :: icount, tasksize
         CHARACTER(len=1) :: flag
 
         ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
@@ -1198,8 +1200,8 @@ CONTAINS
         DO itask = 1, nstasks
             fieldid = stasks(1, itask)
             flag = ACHAR(stasks(2, itask))
-            icount = stasks(3, itask)
-            tasksize = stasks(4, itask)
+            icount = INT(stasks(3, itask), kind=int32)
+            tasksize = INT(stasks(4, itask), kind=int32)
             igrid = stasks(5, itask)
             istart = stasks(6, itask)
             istop = stasks(7, itask)
@@ -1216,29 +1218,29 @@ CONTAINS
 
             SELECT CASE(fieldid)
             CASE (1)
-                CALL restrict_sendtask_gc(flag, kk, jj, ii, a1(ip3), &
-                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), tasksize, &
-                    icount, istart, istop, jstart, jstop, kstart, kstop)
+                CALL restrict_gc_flag(flag, kk, jj, ii, a1(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), icount, &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop)
             CASE (2)
-                CALL restrict_sendtask_gc(flag, kk, jj, ii, a2(ip3), &
-                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), tasksize, &
-                    icount, istart, istop, jstart, jstop, kstart, kstop)
+                CALL restrict_gc_flag(flag, kk, jj, ii, a2(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), icount, &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop)
             CASE (3)
-                CALL restrict_sendtask_gc(flag, kk, jj, ii, a3(ip3), &
-                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), tasksize, &
-                    icount, istart, istop, jstart, jstop, kstart, kstop)
+                CALL restrict_gc_flag(flag, kk, jj, ii, a3(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), icount, &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop)
             CASE (4)
-                CALL restrict_sendtask_gc(flag, kk, jj, ii, a4(ip3), &
-                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), tasksize, &
-                    icount, istart, istop, jstart, jstop, kstart, kstop)
+                CALL restrict_gc_flag(flag, kk, jj, ii, a4(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), icount, &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop)
             CASE (5)
-                CALL restrict_sendtask_gc(flag, kk, jj, ii, a5(ip3), &
-                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), tasksize, &
-                    icount, istart, istop, jstart, jstop, kstart, kstop)
+                CALL restrict_gc_flag(flag, kk, jj, ii, a5(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), icount, &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop)
             CASE (6)
-                CALL restrict_sendtask_gc(flag, kk, jj, ii, a6(ip3), &
-                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), tasksize, &
-                    icount, istart, istop, jstart, jstop, kstart, kstop)
+                CALL restrict_gc_flag(flag, kk, jj, ii, a6(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), icount, &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop)
 #ifdef _MGLET_DEBUG_
             CASE DEFAULT
                 CALL errr(__FILE__, __LINE__)
@@ -1253,121 +1255,6 @@ CONTAINS
 
         END ASSOCIATE
     END SUBROUTINE process_sendtasks_gc
-
-
-    SUBROUTINE restrict_sendtask_noib(flag, kk, jj, ii, ff, ddx, ddy, &
-            ddz, tasksize, icount, istart, istop, jstart, jstop, kstart, kstop)
-        !$omp declare target
-        ! Subroutine arguments
-        CHARACTER(len=1), INTENT(in) :: flag
-        INTEGER(intk), INTENT(in) :: kk, jj, ii
-        REAL(realk), INTENT(in) :: ff(kk, jj, ii)
-        REAL(realk), INTENT(in) :: ddx(ii), ddy(jj), ddz(kk)
-        INTEGER(intk), INTENT(in) :: tasksize, icount
-        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
-
-        ! Local variables
-        INTEGER(int32) :: targetidx, messagelength
-
-        messagelength = INT(tasksize, kind=int32)
-        targetidx = icount + tasksize - 1
-
-        SELECT CASE (flag)
-        CASE ('U')
-            CALL restrict_noib_u(kk, jj, ii, ff, ddx, ddy, ddz, &
-                messagelength, sendbuf(icount:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE ('V')
-            CALL restrict_noib_v(kk, jj, ii, ff, ddx, ddy, ddz, &
-                messagelength, sendbuf(icount:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE ('W')
-            CALL restrict_noib_w(kk, jj, ii, ff, ddx, ddy, ddz, &
-                messagelength, sendbuf(icount:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE ('P', 'R', 'S', 'T')
-            CALL restrict_noib_s(kk, jj, ii, ff, ddx, ddy, ddz, &
-                messagelength, sendbuf(icount:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-#ifdef _MGLET_DEBUG_
-        CASE DEFAULT
-            CALL errr(__FILE__, __LINE__)
-#endif
-        END SELECT
-    END SUBROUTINE restrict_sendtask_noib
-
-
-    SUBROUTINE restrict_sendtask_gc(flag, kk, jj, ii, ff, ddx, ddy, &
-            ddz, bp, bt, tasksize, icount, istart, istop, jstart, jstop, &
-            kstart, kstop)
-        !$omp declare target
-        ! Subroutine arguments
-        CHARACTER(len=1), INTENT(in) :: flag
-        INTEGER(intk), INTENT(in) :: kk, jj, ii
-        REAL(realk), INTENT(in) :: ff(kk, jj, ii)
-        REAL(realk), INTENT(in) :: ddx(ii), ddy(jj), ddz(kk)
-        REAL(realk), INTENT(in) :: bp(kk, jj, ii), bt(kk, jj, ii)
-        INTEGER(intk), INTENT(in) :: tasksize, icount
-        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
-
-        ! Local variables
-        INTEGER(int32) :: messagelength
-        INTEGER(intk) :: targetidx
-
-        messagelength = INT(tasksize, kind=int32)
-        targetidx = icount + tasksize - 1
-
-        SELECT CASE (flag)
-            CASE ('U')
-                CALL restrict_noib_u(kk, jj, ii, ff, ddx, ddy, ddz, &
-                    messagelength, sendbuf(icount:targetidx), &
-                    istart, istop, jstart, jstop, kstart, kstop)
-            CASE ('V')
-                CALL restrict_noib_v(kk, jj, ii, ff, ddx, ddy, ddz, &
-                    messagelength, sendbuf(icount:targetidx), &
-                    istart, istop, jstart, jstop, kstart, kstop)
-            CASE ('W')
-                CALL restrict_noib_w(kk, jj, ii, ff, ddx, ddy, ddz, &
-                    messagelength, sendbuf(icount:targetidx), &
-                    istart, istop, jstart, jstop, kstart, kstop)
-            CASE ('P')
-                CALL restrict_gc_p_t(kk, jj, ii, ff, ddx, ddy, ddz, bp, &
-                    messagelength, sendbuf(icount:targetidx), &
-                    istart, istop, jstart, jstop, kstart, kstop)
-            CASE ('T')
-                CALL restrict_gc_p_t(kk, jj, ii, ff, ddx, ddy, ddz, bt, &
-                    messagelength, sendbuf(icount:targetidx), &
-                    istart, istop, jstart, jstop, kstart, kstop)
-            CASE ('R')
-                CALL restrict_gc_r(kk, jj, ii, ff, ddx, ddy, ddz, bp, &
-                    messagelength, sendbuf(icount:targetidx), &
-                    istart, istop, jstart, jstop, kstart, kstop)
-            CASE ('S')
-                CALL restrict_noib_s(kk, jj, ii, ff, ddx, ddy, ddz, &
-                    messagelength, sendbuf(icount:targetidx), &
-                    istart, istop, jstart, jstop, kstart, kstop)
-            CASE ('N')
-                CALL restrict_gc_n(kk, jj, ii, ff, messagelength, &
-                    sendbuf(icount:targetidx), &
-                    istart, istop, jstart, jstop, kstart, kstop)
-            CASE ('E')
-                CALL restrict_gc_e(kk, jj, ii, ff, messagelength, &
-                    sendbuf(icount:targetidx), &
-                    istart, istop, jstart, jstop, kstart, kstop)
-            CASE ('F')
-                CALL restrict_gc_f(kk, jj, ii, ff, messagelength, &
-                    sendbuf(icount:targetidx), &
-                    istart, istop, jstart, jstop, kstart, kstop)
-            CASE ('I')
-                CALL restrict_gc_i(kk, jj, ii, ff, messagelength, &
-                    sendbuf(icount:targetidx), &
-                    istart, istop, jstart, jstop, kstart, kstop)
-#ifdef _MGLET_DEBUG_
-            CASE DEFAULT
-                CALL errr(__FILE__, __LINE__)
-#endif
-            END SELECT
-    END SUBROUTINE restrict_sendtask_gc
 
 
     SUBROUTINE process_mpirecv(nmpirtasks, mpirtasks)

--- a/src/ib/ftoc/ftoc2_mod.F90
+++ b/src/ib/ftoc/ftoc2_mod.F90
@@ -3,18 +3,61 @@ MODULE ftoc2_mod
     USE core_mod
     USE ftoc_core_mod
     USE ibcore_mod, ONLY: ib
-    USE restrict_mod, ONLY: restrict, message_length, start_and_stop
+    USE gc_restrict_mod
+    USE noib_restrict_mod
+    USE restrict_mod, ONLY: message_length, start_and_stop
+
+    ! FTOC2 uses the sendbuf from commbuf_mod simultaneously while packing for
+    ! MPI sends and for self communication. Since the self communication must
+    ! never overlap with packing, and to avoid allocating a temporary buffer
+    ! for self communication, packing and self communication use different
+    ! parts of the same sendbuf. Due to the nature of fine to coarse, where
+    ! the restricted grid (1/8 of the fine grid) is sent to the coarser grid,
+    ! the size should not be exceeded at any point.
+    ! The sendbuf is used as following:
+    ! Packing: start to max size for worst-case ftoc2 call
+    ! Self communication: max size for worst-case ftoc2 call to end
 
     IMPLICIT NONE (type, external)
     PRIVATE
 
     ! Lists that hold the send and receive request arrays
     TYPE(MPI_Request), ALLOCATABLE :: sendreqs(:), recvreqs(:)
-
-    ! Lists that hold the messages that are ACTUALLY sendt and received
-    INTEGER(intk) :: nsend, nrecv
     INTEGER(int32), ALLOCATABLE :: recvlist(:)
     INTEGER(intk), ALLOCATABLE :: recvidxlist(:, :)
+    INTEGER(intk) :: nsend, nrecv
+
+    ! Task extents
+    INTEGER(intk), PARAMETER :: sendtasksize = 11
+    INTEGER(intk), PARAMETER :: recvtasksize = 15
+    INTEGER(intk), PARAMETER :: selftasksize = 15
+    INTEGER(intk), PARAMETER :: mpitasksize = 3
+    INTEGER(intk) :: maxsendtasks, maxrecvtasks
+    INTEGER(intk) :: maxselftasks
+    INTEGER(intk) :: maxmpisendtasks, maxmpirecvtasks
+
+    ! Pointers to fields passed to ftoc2, point to dummy field if not present
+    TYPE(field_t), POINTER :: f1 => NULL(), f2 => NULL(), f3 => NULL(), &
+        f4 => NULL(), f5 => NULL(), f6 => NULL()
+
+    ! Workpackages containing individual tasks for packing / unpacking
+    INTEGER(intk), ALLOCATABLE :: sendtasks(:, :), recvtasks(:, :)
+    INTEGER(intk), ALLOCATABLE :: selftasks(:, :)
+    INTEGER(intk), ALLOCATABLE :: mpisendtasks(:, :), mpirecvtasks(:, :)
+    !$omp declare target(sendtasks, recvtasks, selftasks)
+
+    TYPE :: work_t
+        LOGICAL :: is_init = .FALSE.
+        INTEGER(intk), ALLOCATABLE :: sendtasks(:, :)
+        INTEGER(intk), ALLOCATABLE :: recvtasks(:, :)
+        INTEGER(intk), ALLOCATABLE :: selftasks(:, :)
+        INTEGER(intk), ALLOCATABLE :: mpisendtasks(:, :)
+        INTEGER(intk), ALLOCATABLE :: mpirecvtasks(:, :)
+    END TYPE work_t
+
+    ! Array to store instructions for different argument combinations
+    TYPE(work_t), ALLOCATABLE, TARGET :: workrecords(:, :, :)
+    LOGICAL :: is_recording = .FALSE.
 
     ! Variable to indicate if the required data structures have been created
     LOGICAL :: is_init = .FALSE.
@@ -29,17 +72,27 @@ CONTAINS
     SUBROUTINE ftoc2_one(ilevel, ff, fc, flag)
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: ilevel
-        TYPE(field_t), INTENT(in) :: ff
-        TYPE(field_t), INTENT(inout) :: fc
+        TYPE(field_t), TARGET, INTENT(in) :: ff
+        TYPE(field_t), TARGET, INTENT(inout) :: fc
         CHARACTER(len=1), INTENT(in) :: flag
 
         ! Local variables
         ! none...
 
-
         IF (.NOT. is_init) CALL errr(__FILE__, __LINE__)
 
-        ! TODO(offload): implement
+        IF (TRIM(ff%name) /= TRIM(fc%name)) THEN
+            WRITE(*, *) "ftoc2_one only supports equal ff and fc fields."
+            WRITE(*, *) "Fine to coarse from a fine field to a different coarse"
+            WRITE(*, *) "field is not supported on the device. Use a temporary"
+            WRITE(*, *) "field instead and copy result over."
+            WRITE(*, *) "ff: ", TRIM(ff%name)
+            WRITE(*, *) "fc: ", TRIM(fc%name)
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        ! ff and fc are the same field
+        CALL ftoc2_impl(ilevel, v1=fc, flag=flag)
 
         nrecv = 0
         nsend = 0
@@ -49,18 +102,1772 @@ CONTAINS
     SUBROUTINE ftoc2_multiple(ilevel, v1, v2, v3, s1, s2, s3)
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: ilevel
-        TYPE(field_t), INTENT(inout), OPTIONAL :: v1, v2, v3, s1, s2, s3
+        TYPE(field_t), TARGET, INTENT(inout), OPTIONAL :: v1, v2, v3, s1, s2, s3
 
         ! Local variables
-        CHARACTER(len=*), PARAMETER :: flag = '*'
+        ! none...
 
         IF (.NOT. is_init) CALL errr(__FILE__, __LINE__)
 
-        ! TODO(offload): implement
+        CALL ftoc2_impl(ilevel, v1, v2, v3, s1, s2, s3, flag='*')
 
         nrecv = 0
         nsend = 0
     END SUBROUTINE ftoc2_multiple
+
+
+    SUBROUTINE ftoc2_impl(ilevel, v1, v2, v3, s1, s2, s3, flag)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: ilevel
+        TYPE(field_t), TARGET, OPTIONAL, INTENT(inout) :: v1, v2, v3, s1, s2, s3
+        CHARACTER(len=1), INTENT(in) :: flag
+
+        ! Local variables
+        TYPE(field_t), POINTER :: dummy
+        INTEGER(intk) :: nvars, idx_args, idx_flag
+
+        CALL push_field(dummy, "FTOC2_DUMMY", zero=.FALSE.)
+
+        f1 => dummy
+        f2 => dummy
+        f3 => dummy
+        f4 => dummy
+        f5 => dummy
+        f6 => dummy
+
+        nvars = 0
+        idx_args = 0
+        IF (PRESENT(v1)) THEN
+            nvars = nvars + 1
+            f1 => v1
+            idx_args = idx_args + 1 * 2**(0)
+        END IF
+        IF (PRESENT(v2)) THEN
+            nvars = nvars + 1
+            f2 => v2
+            idx_args = idx_args + 1 * 2**(1)
+        END IF
+        IF (PRESENT(v3)) THEN
+            nvars = nvars + 1
+            f3 => v3
+            idx_args = idx_args + 1 * 2**(2)
+        END IF
+        IF (PRESENT(s1)) THEN
+            nvars = nvars + 1
+            f4 => s1
+            idx_args = idx_args + 1 * 2**(3)
+        END IF
+        IF (PRESENT(s2)) THEN
+            nvars = nvars + 1
+            f5 => s2
+            idx_args = idx_args + 1 * 2**(4)
+        END IF
+        IF (PRESENT(s3)) THEN
+            nvars = nvars + 1
+            f6 => s3
+            idx_args = idx_args + 1 * 2**(5)
+        END IF
+
+        IF (idx_args == 0) THEN
+            WRITE(*, *) "No fields present."
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        idx_flag = IACHAR(flag)
+
+        ASSOCIATE(wptr => workrecords(ilevel, idx_args, idx_flag))
+
+        IF (is_recording) THEN
+            ! During the recording phase, the workpackage is not yet initialized
+            ! and needs to be created. Tasks arrays are offloaded for later
+            ! efficient task execution on device
+            CALL recording_pass(wptr, ilevel, flag, nvars, &
+                v1, v2, v3, s1, s2, s3)
+        ELSE
+            IF (wptr%is_init) THEN
+                CALL recorded_ftoc2(wptr)
+            ELSE
+                CALL jit_ftoc2(ilevel, flag, v1, v2, v3, s1, s2, s3)
+            END IF
+        END IF
+
+        END ASSOCIATE
+
+        f1 => NULL()
+        f2 => NULL()
+        f3 => NULL()
+        f4 => NULL()
+        f5 => NULL()
+        f6 => NULL()
+
+        CALL pop_field(dummy)
+    END SUBROUTINE ftoc2_impl
+
+
+    SUBROUTINE jit_ftoc2(ilevel, flag, v1, v2, v3, s1, s2, s3)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: ilevel
+        CHARACTER(len=1), INTENT(in) :: flag
+        TYPE(field_t), OPTIONAL, INTENT(inout) :: v1, v2, v3, s1, s2, s3
+
+        ! Local variables
+        INTEGER(intk) :: nsendtasks, nrecvtasks
+        INTEGER(intk) :: nselftasks
+        INTEGER(intk) :: nmpisendtasks
+
+        ! Manufacturing the workpackage just in-time and execute
+        CALL prepare_tasks_all(sendtasks, nsendtasks, selftasks, nselftasks, &
+            mpisendtasks, nmpisendtasks, ilevel, flag, v1, v2, v3, s1, s2, s3)
+
+        !$omp target update to( &
+        !$omp& sendtasks(1:sendtasksize, 1:nsendtasks+1), &
+        !$omp& selftasks(1:selftasksize, 1:nselftasks+1)) nowait
+
+        CALL recv_mpi_all(ilevel, flag, v1, v2, v3, s1, s2, s3)
+
+        !$omp taskwait
+
+        CALL process_sendtasks(nsendtasks, sendtasks)
+        CALL process_mpisend(nmpisendtasks, mpisendtasks)
+        CALL process_selftasks(nselftasks, selftasks)
+
+        CALL prepare_recvtasks_all(recvtasks, nrecvtasks, flag, v1, v2, v3, &
+            s1, s2, s3)
+
+        !$omp target update to(recvtasks(1:recvtasksize, 1:nrecvtasks+1))
+
+        CALL process_recvtasks(nrecvtasks, recvtasks)
+    END SUBROUTINE jit_ftoc2
+
+
+    SUBROUTINE recorded_ftoc2(wptr)
+        ! Subroutine arguments
+        TYPE(work_t), INTENT(inout) :: wptr
+
+        ! Local variables
+        INTEGER(intk) :: nsendtasks, nrecvtasks
+        INTEGER(intk) :: nselftasks
+        INTEGER(intk) :: nmpisendtasks, nmpirecvtasks
+
+        ! Using the (offloaded) workpackage from the workrecords array
+        nmpirecvtasks = SIZE(wptr%mpirecvtasks, 2) - 1
+        nmpisendtasks = SIZE(wptr%mpisendtasks, 2) - 1
+        nsendtasks = SIZE(wptr%sendtasks, 2) - 1
+        nselftasks = SIZE(wptr%selftasks, 2) - 1
+        nrecvtasks = SIZE(wptr%recvtasks, 2) - 1
+
+        CALL process_mpirecv(nmpirecvtasks, wptr%mpirecvtasks)
+        CALL process_sendtasks(nsendtasks, wptr%sendtasks)
+        CALL process_mpisend(nmpisendtasks, wptr%mpisendtasks)
+        CALL process_selftasks(nselftasks, wptr%selftasks)
+        CALL MPI_Waitall(nrecv, recvreqs, MPI_STATUSES_IGNORE)
+        CALL process_recvtasks(nrecvtasks, wptr%recvtasks)
+        CALL MPI_Waitall(nsend, sendreqs, MPI_STATUSES_IGNORE)
+    END SUBROUTINE recorded_ftoc2
+
+
+    SUBROUTINE recv_mpi_all(ilevel, flag, v1, v2, v3, s1, s2, s3)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: ilevel
+        CHARACTER(len=1), INTENT(in) :: flag
+        TYPE(field_t), INTENT(in), OPTIONAL :: v1, v2, v3, s1, s2, s3
+
+        ! Local variables
+        INTEGER(intk) :: i, iprocnbr, igridf
+        INTEGER(int32) :: recvcounter, messagelength, ncells
+
+        recvcounter = 0
+        messagelength = 0
+        nrecv = 0
+        recvidxlist = -HUGE(1_intk)
+        recvlist = 0
+
+        DO i = 1, irecv
+            igridf = recvconns(3, i)
+            iprocnbr = recvconns(1, i)  ! The sender process (fine side)
+            IF (iprocnbr == myid) CYCLE
+
+            IF (ilevel == level(igridf)) THEN
+                CALL count_ncells(ncells, flag, igridf, v1, v2, v3, s1, s2, s3)
+                recvidxlist(1, i) = iprocnbr
+                recvidxlist(2, i) = ncells
+                recvidxlist(3, i) = recvcounter + messagelength
+                messagelength = messagelength + ncells
+
+                IF (recvcounter + messagelength > idim_mg_bufs) THEN
+                    CALL errr(__FILE__, __LINE__)
+                END IF
+            END IF
+
+            IF (messagelength > 0) THEN
+                IF (i == irecv) THEN
+                    CALL post_recv(iprocnbr, messagelength, recvcounter)
+                ELSE IF (recvconns(1, i + 1) /= iprocnbr) THEN
+                    CALL post_recv(iprocnbr, messagelength, recvcounter)
+                END IF
+            END IF
+        END DO
+    END SUBROUTINE recv_mpi_all
+
+
+    SUBROUTINE post_recv(iprocnbr, messagelength, recvcounter)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: iprocnbr
+        INTEGER(int32), INTENT(inout) :: messagelength
+        INTEGER(int32), INTENT(inout) :: recvcounter
+
+        ! Local variables
+        ! none...
+
+        nrecv = nrecv + 1
+        recvlist(nrecv) = iprocnbr
+
+        !$omp target data use_device_addr(recvbuf)
+        CALL MPI_Irecv(recvbuf(recvcounter+1), messagelength, &
+            mglet_mpi_real, iprocnbr, 1, MPI_COMM_WORLD, recvreqs(nrecv))
+        !$omp end target data
+
+        recvcounter = recvcounter + messagelength
+        messagelength = 0
+    END SUBROUTINE post_recv
+
+
+    SUBROUTINE recording_pass(wptr, ilevel, flag, nvars, v1, v2, v3, s1, s2, s3)
+        ! Subroutine arguments
+        TYPE(work_t), INTENT(inout) :: wptr
+        INTEGER(intk), INTENT(in) :: ilevel
+        CHARACTER(len=1), INTENT(in) :: flag
+        INTEGER(intk), INTENT(in) :: nvars
+        TYPE(field_t), OPTIONAL, INTENT(inout) :: v1, v2, v3, s1, s2, s3
+
+        ! Local variables
+        INTEGER(intk) :: nsendtasks, nrecvtasks, nselftasks
+        INTEGER(intk) :: nmpisendtasks, nmpirecvtasks
+
+        IF (wptr%is_init) THEN
+            WRITE(*, *) "Combination already recorded."
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        ! It is necessary to execute one cycle with communication
+        ! as otherwise many valuable checks are not possible
+
+        CALL prepare_mpirecvtasks(mpirecvtasks, nmpirecvtasks, ilevel, flag, &
+            v1, v2, v3, s1, s2, s3)
+        CALL prepare_tasks_all(sendtasks, nsendtasks, selftasks, nselftasks, &
+            mpisendtasks, nmpisendtasks, ilevel, flag, v1, v2, v3, s1, s2, s3)
+
+        !$omp target update to( &
+        !$omp& sendtasks(1:sendtasksize, 1:nsendtasks+1), &
+        !$omp& selftasks(1:selftasksize, 1:nselftasks+1))
+
+        CALL process_mpirecv(nmpirecvtasks, mpirecvtasks)
+        CALL process_sendtasks(nsendtasks, sendtasks)
+        CALL process_mpisend(nmpisendtasks, mpisendtasks)
+        CALL process_selftasks(nselftasks, selftasks)
+        CALL prepare_recvtasks_all(recvtasks, nrecvtasks, flag, &
+            v1, v2, v3, s1, s2, s3)
+
+        !$omp target update to(recvtasks(1:recvtasksize, 1:nrecvtasks+1))
+        CALL process_recvtasks(nrecvtasks, recvtasks)
+
+        ! Allocate the workpackage arrays in the exact sizes
+        ALLOCATE(wptr%sendtasks(sendtasksize, nsendtasks+1))
+        ALLOCATE(wptr%recvtasks(recvtasksize, nrecvtasks+1))
+        ALLOCATE(wptr%selftasks(selftasksize, nselftasks+1))
+        ALLOCATE(wptr%mpisendtasks(mpitasksize, nmpisendtasks+1))
+        ALLOCATE(wptr%mpirecvtasks(mpitasksize, nmpirecvtasks+1))
+
+        ! Store the workpackage in the workrecords array and map
+        wptr%sendtasks = sendtasks(:, 1:nsendtasks+1)
+        wptr%recvtasks = recvtasks(:, 1:nrecvtasks+1)
+        wptr%selftasks = selftasks(:, 1:nselftasks+1)
+        wptr%mpisendtasks = mpisendtasks(:, 1:nmpisendtasks+1)
+        wptr%mpirecvtasks = mpirecvtasks(:, 1:nmpirecvtasks+1)
+
+        !$omp target enter data map(to: &
+        !$omp&  wptr%sendtasks(1:sendtasksize, 1:nsendtasks+1), &
+        !$omp&  wptr%recvtasks(1:recvtasksize, 1:nrecvtasks+1), &
+        !$omp&  wptr%selftasks(1:selftasksize, 1:nselftasks+1))
+
+        ! Mark the workpackage as initialized
+        wptr%is_init = .TRUE.
+    END SUBROUTINE recording_pass
+
+
+    SUBROUTINE process_recvtasks(nrtasks, rtasks)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nrtasks
+        INTEGER(intk), INTENT(in) :: rtasks(recvtasksize, nrtasks+1)
+
+        ! Local variables
+        INTEGER(intk) :: itask, fieldid, tasksize, recvidx, igridc
+        CHARACTER(len=1) :: flag
+        INTEGER(intk) :: kk, jj, ii, ip3
+        INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
+        INTEGER(intk) :: ipos, jpos, kpos
+
+        IF (nrtasks == 0) RETURN
+
+        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
+                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("process_recvtasks")
+#endif
+
+        !$omp target teams distribute private(itask, fieldid, flag, &
+        !$omp& tasksize, recvidx, igridc, istart, istop, jstart, jstop, &
+        !$omp& kstart, kstop, ipos, jpos, kpos, kk, jj, ii, ip3)
+        DO itask = 1, nrtasks
+            fieldid = rtasks(1, itask)
+            flag = ACHAR(rtasks(2, itask))
+            tasksize = rtasks(3, itask)
+            recvidx = rtasks(4, itask)
+            igridc = rtasks(6, itask)
+            istart = rtasks(7, itask)
+            istop = rtasks(8, itask)
+            jstart = rtasks(9, itask)
+            jstop = rtasks(10, itask)
+            kstart = rtasks(11, itask)
+            kstop = rtasks(12, itask)
+            ipos = rtasks(13, itask)
+            jpos = rtasks(14, itask)
+            kpos = rtasks(15, itask)
+
+            CALL get_mgdims(kk, jj, ii, igridc)
+            CALL get_ip3(ip3, igridc)
+
+            SELECT CASE(fieldid)
+            CASE (1)
+                CALL unpack_restricted_buffer(flag, kk, jj, ii, a1(ip3), &
+                    recvbuf(recvidx:recvidx+tasksize-1), tasksize, istart, &
+                    istop, jstart, jstop, kstart, kstop, ipos, jpos, kpos)
+            CASE (2)
+                CALL unpack_restricted_buffer(flag, kk, jj, ii, a2(ip3), &
+                    recvbuf(recvidx:recvidx+tasksize-1), tasksize, istart, &
+                    istop, jstart, jstop, kstart, kstop, ipos, jpos, kpos)
+            CASE (3)
+                CALL unpack_restricted_buffer(flag, kk, jj, ii, a3(ip3), &
+                    recvbuf(recvidx:recvidx+tasksize-1), tasksize, istart, &
+                    istop, jstart, jstop, kstart, kstop, ipos, jpos, kpos)
+            CASE (4)
+                CALL unpack_restricted_buffer(flag, kk, jj, ii, a4(ip3), &
+                    recvbuf(recvidx:recvidx+tasksize-1), tasksize, istart, &
+                    istop, jstart, jstop, kstart, kstop, ipos, jpos, kpos)
+            CASE (5)
+                CALL unpack_restricted_buffer(flag, kk, jj, ii, a5(ip3), &
+                    recvbuf(recvidx:recvidx+tasksize-1), tasksize, istart, &
+                    istop, jstart, jstop, kstart, kstop, ipos, jpos, kpos)
+            CASE (6)
+                CALL unpack_restricted_buffer(flag, kk, jj, ii, a6(ip3), &
+                    recvbuf(recvidx:recvidx+tasksize-1), tasksize, istart, &
+                    istop, jstart, jstop, kstart, kstop, ipos, jpos, kpos)
+#ifdef _MGLET_DEBUG_
+            CASE DEFAULT
+                CALL errr(__FILE__, __LINE__)
+#endif
+            END SELECT
+        END DO
+        !$omp end target teams distribute
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+
+        END ASSOCIATE
+
+        IF (.NOT. ALL(rtasks(:, nrtasks+1) == -1)) THEN
+            WRITE(*, *) "Did not encounter the expected dummy task."
+            CALL errr(__FILE__, __LINE__)
+        END IF
+    END SUBROUTINE process_recvtasks
+
+
+    SUBROUTINE prepare_recvtasks_all(rtasks, nrtasks, flag, &
+            v1, v2, v3, s1, s2, s3)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(inout) :: rtasks(recvtasksize, maxrecvtasks)
+        INTEGER(intk), INTENT(out) :: nrtasks
+        CHARACTER(len=1), INTENT(in) :: flag
+        TYPE(field_t), OPTIONAL, INTENT(inout) :: v1, v2, v3, s1, s2, s3
+
+        ! Local variables
+        INTEGER(intk) :: irtask
+        TYPE(MPI_Status) :: recvstatus
+        INTEGER(int32) :: idx, i, recvmessagelen, unpacklen
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("prepare_recvtasks_all")
+#endif
+
+        irtask = 0
+        DO WHILE(.TRUE.)
+            IF (nrecv == 0) EXIT
+            CALL MPI_Waitany(nrecv, recvreqs, idx, recvstatus)
+
+            IF (idx /= MPI_UNDEFINED) THEN
+                CALL MPI_Get_count(recvstatus, mglet_mpi_real, recvmessagelen)
+
+                unpacklen = 0
+                DO i = 1, irecv
+                    IF (recvidxlist(1, i) == recvlist(idx) &
+                            .AND. recvidxlist(2, i) > 0) THEN
+                        CALL prepare_recvtask(rtasks, irtask, i, flag, &
+                            v1, v2, v3, s1, s2, s3)
+                        unpacklen = unpacklen + recvidxlist(2, i)
+                    END IF
+                END DO
+
+                IF (recvmessagelen /= unpacklen) THEN
+                    CALL errr(__FILE__, __LINE__)
+                END IF
+            ELSE
+                EXIT
+            END IF
+        END DO
+
+        CALL MPI_Waitall(nsend, sendreqs, MPI_STATUSES_IGNORE)
+        nrtasks = irtask
+        rtasks(:, nrtasks+1) = -1
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE prepare_recvtasks_all
+
+
+    SUBROUTINE prepare_recvtask(rtasks, irtask, recvid, flag, &
+            v1, v2, v3, s1, s2, s3)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(inout) :: rtasks(recvtasksize, maxrecvtasks)
+        INTEGER(intk), INTENT(inout) :: irtask
+        INTEGER(intk), INTENT(in) :: recvid
+        CHARACTER(len=1), INTENT(in) :: flag
+        TYPE(field_t), OPTIONAL, INTENT(inout) :: v1, v2, v3, s1, s2, s3
+
+        ! Local variables
+        INTEGER(intk) :: igridf, igridc
+        INTEGER(int32) :: ncells, offset, icount
+        CHARACTER(len=1) :: flag_u
+
+        igridf = recvconns(3, recvid)
+        igridc = recvconns(4, recvid)
+
+        CALL count_ncells(ncells, flag, igridf, &
+            v1, v2, v3, s1, s2, s3)
+
+        offset = INT(recvidxlist(3, recvid), kind=int32) + 1
+        icount = offset
+
+        IF (PRESENT(v1)) THEN
+            IF (flag == '*') THEN
+                flag_u = 'U'
+            ELSE
+                flag_u = flag
+            END IF
+
+            irtask = irtask + 1
+            CALL add_single_recvtask(rtasks(:, irtask), 1, flag_u, icount, &
+                igridf, igridc)
+        END IF
+
+        IF (PRESENT(v2)) THEN
+            irtask = irtask + 1
+            CALL add_single_recvtask(rtasks(:, irtask), 2, 'V', icount, &
+                igridf, igridc)
+        END IF
+
+        IF (PRESENT(v3)) THEN
+            irtask = irtask + 1
+            CALL add_single_recvtask(rtasks(:, irtask), 3, 'W', icount, &
+                igridf, igridc)
+        END IF
+
+        IF (PRESENT(s1)) THEN
+            irtask = irtask + 1
+            CALL add_single_recvtask(rtasks(:, irtask), 4, 'P', icount, &
+                igridf, igridc)
+        END IF
+
+        IF (PRESENT(s2)) THEN
+            irtask = irtask + 1
+            CALL add_single_recvtask(rtasks(:, irtask), 5, 'P', icount, &
+                igridf, igridc)
+        END IF
+
+        IF (PRESENT(s3)) THEN
+            irtask = irtask + 1
+            CALL add_single_recvtask(rtasks(:, irtask), 6, 'P', icount, &
+                igridf, igridc)
+        END IF
+
+        IF (ncells /= (icount - offset)) THEN
+            WRITE(*, *) "ncells:", ncells, "recv_len:", icount - offset
+            CALL errr(__FILE__, __LINE__)
+        END IF
+    END SUBROUTINE prepare_recvtask
+
+
+    SUBROUTINE process_selftasks(netasks, etasks)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: netasks
+        INTEGER(intk), INTENT(in) :: etasks(selftasksize, netasks+1)
+
+        ! Local variables
+        TYPE(field_t), POINTER :: ddx, ddy, ddz, bp, bt
+        LOGICAL :: foundbt
+
+        IF (netasks == 0) RETURN
+
+        CALL get_field(ddx, "DDX")
+        CALL get_field(ddy, "DDY")
+        CALL get_field(ddz, "DDZ")
+
+        SELECT CASE (ib%type)
+        CASE ("NONE")
+            CALL process_selftasks_noib(netasks, etasks, ddx, ddy, ddz)
+        CASE ("GHOSTCELL")
+            CALL get_field(bp, "BP")
+            CALL get_field(bt, "BT", foundbt)
+            IF (.NOT. foundbt) THEN
+                ! For non-scalar cases, point bt to bp. It is unused anyways.
+                bt => bp
+            END IF
+            CALL process_selftasks_gc(netasks, etasks, ddx, ddy, ddz, bp, bt)
+        CASE DEFAULT
+            CALL errr(__FILE__, __LINE__)
+        END SELECT
+
+        ! Safety check based on final dummy entry
+        IF (.NOT. ALL(etasks(:, netasks+1) == -1)) THEN
+            WRITE(*, *) "Did not encounter the expected dummy task."
+            CALL errr(__FILE__, __LINE__)
+        END IF
+    END SUBROUTINE process_selftasks
+
+
+    SUBROUTINE process_selftasks_noib(netasks, etasks, ddx, ddy, ddz)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: netasks
+        INTEGER(intk), INTENT(in) :: etasks(selftasksize, netasks+1)
+        TYPE(field_t), INTENT(in) :: ddx, ddy, ddz
+
+        ! Local variables
+        INTEGER(intk) :: itask, kkf, jjf, iif, kkc, jjc, iic
+        INTEGER(intk) :: ip3f, ip3c, ipx, ipy, ipz
+        INTEGER(intk) :: fieldid, tasksize, igridf, igridc, &
+            istart, istop, jstart, jstop, kstart, kstop, ipos, jpos, kpos, &
+            scratchidx
+        CHARACTER(len=1) :: flag
+
+        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
+                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr, &
+                  ddx => ddx%arr, ddy => ddy%arr, ddz => ddz%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("process_selftasks_noib")
+#endif
+
+        !$omp target teams distribute private(itask, fieldid, flag, &
+        !$omp& tasksize, scratchidx, igridf, igridc, istart, istop, jstart, &
+        !$omp& jstop, kstart, kstop, ipos, jpos, kpos, kkf, jjf, iif, kkc, &
+        !$omp& jjc, iic, ip3f, ip3c, ipx, ipy, ipz)
+        DO itask = 1, netasks
+            fieldid = etasks(1, itask)
+            flag = ACHAR(etasks(2, itask))
+            tasksize = etasks(3, itask)
+            scratchidx = etasks(4, itask)
+            igridf = etasks(5, itask)
+            igridc = etasks(6, itask)
+            istart = etasks(7, itask)
+            istop = etasks(8, itask)
+            jstart = etasks(9, itask)
+            jstop = etasks(10, itask)
+            kstart = etasks(11, itask)
+            kstop = etasks(12, itask)
+            ipos = etasks(13, itask)
+            jpos = etasks(14, itask)
+            kpos = etasks(15, itask)
+
+            CALL get_mgdims(kkf, jjf, iif, igridf)
+            CALL get_mgdims(kkc, jjc, iic, igridc)
+            CALL get_ip3(ip3f, igridf)
+            CALL get_ip3(ip3c, igridc)
+            CALL get_ip1x(ipx, igridf)
+            CALL get_ip1y(ipy, igridf)
+            CALL get_ip1z(ipz, igridf)
+
+            SELECT CASE(fieldid)
+            CASE (1)
+                CALL restrict_sendtask_noib(flag, kkf, jjf, iif, &
+                    a1(ip3f), ddx(ipx), ddy(ipy), ddz(ipz), &
+                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    kstart, kstop)
+                CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
+                    a1(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop, &
+                    ipos, jpos, kpos)
+            CASE (2)
+                CALL restrict_sendtask_noib(flag, kkf, jjf, iif, &
+                    a2(ip3f), ddx(ipx), ddy(ipy), ddz(ipz), &
+                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    kstart, kstop)
+                CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
+                    a2(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop, &
+                    ipos, jpos, kpos)
+            CASE (3)
+                CALL restrict_sendtask_noib(flag, kkf, jjf, iif, &
+                    a3(ip3f), ddx(ipx), ddy(ipy), ddz(ipz), &
+                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    kstart, kstop)
+                CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
+                    a3(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop, &
+                    ipos, jpos, kpos)
+            CASE (4)
+                CALL restrict_sendtask_noib(flag, kkf, jjf, iif, &
+                    a4(ip3f), ddx(ipx), ddy(ipy), ddz(ipz), &
+                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    kstart, kstop)
+                CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
+                    a4(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop, &
+                    ipos, jpos, kpos)
+            CASE (5)
+                CALL restrict_sendtask_noib(flag, kkf, jjf, iif, &
+                    a5(ip3f), ddx(ipx), ddy(ipy), ddz(ipz), &
+                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    kstart, kstop)
+                CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
+                    a5(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop, &
+                    ipos, jpos, kpos)
+            CASE (6)
+                CALL restrict_sendtask_noib(flag, kkf, jjf, iif, &
+                    a6(ip3f), ddx(ipx), ddy(ipy), ddz(ipz), &
+                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    kstart, kstop)
+                CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
+                    a6(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop, &
+                    ipos, jpos, kpos)
+#ifdef _MGLET_DEBUG_
+            CASE DEFAULT
+                CALL errr(__FILE__, __LINE__)
+#endif
+            END SELECT
+        END DO
+        !$omp end target teams distribute
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+
+        END ASSOCIATE
+    END SUBROUTINE process_selftasks_noib
+
+
+    SUBROUTINE process_selftasks_gc(netasks, etasks, ddx_f, ddy_f, ddz_f, &
+            bp_f, bt_f)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: netasks
+        INTEGER(intk), INTENT(in) :: etasks(selftasksize, netasks+1)
+        TYPE(field_t), INTENT(in) :: ddx_f, ddy_f, ddz_f, bp_f, bt_f
+
+        ! Local variables
+        INTEGER(intk) :: itask, kkf, jjf, iif, kkc, jjc, iic
+        INTEGER(intk) :: ip3f, ip3c, ipx, ipy, ipz
+        INTEGER(intk) :: fieldid, tasksize, igridf, igridc, &
+            istart, istop, jstart, jstop, kstart, kstop, ipos, jpos, kpos, &
+            scratchidx
+        CHARACTER(len=1) :: flag
+
+        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
+                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr, &
+                  ddx => ddx_f%arr, ddy => ddy_f%arr, ddz => ddz_f%arr, &
+                  bp => bp_f%arr, bt => bt_f%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("process_selftasks_gc")
+#endif
+
+        !$omp target teams distribute private(itask, fieldid, flag, &
+        !$omp& tasksize, scratchidx, igridf, igridc, istart, istop, jstart, &
+        !$omp& jstop, kstart, kstop, ipos, jpos, kpos, kkf, jjf, iif, kkc, &
+        !$omp& jjc, iic, ip3f, ip3c, ipx, ipy, ipz)
+        DO itask = 1, netasks
+            fieldid = etasks(1, itask)
+            flag = ACHAR(etasks(2, itask))
+            tasksize = etasks(3, itask)
+            scratchidx = etasks(4, itask)
+            igridf = etasks(5, itask)
+            igridc = etasks(6, itask)
+            istart = etasks(7, itask)
+            istop = etasks(8, itask)
+            jstart = etasks(9, itask)
+            jstop = etasks(10, itask)
+            kstart = etasks(11, itask)
+            kstop = etasks(12, itask)
+            ipos = etasks(13, itask)
+            jpos = etasks(14, itask)
+            kpos = etasks(15, itask)
+
+            CALL get_mgdims(kkf, jjf, iif, igridf)
+            CALL get_mgdims(kkc, jjc, iic, igridc)
+            CALL get_ip3(ip3f, igridf)
+            CALL get_ip3(ip3c, igridc)
+            CALL get_ip1x(ipx, igridf)
+            CALL get_ip1y(ipy, igridf)
+            CALL get_ip1z(ipz, igridf)
+
+            SELECT CASE(fieldid)
+            CASE (1)
+                CALL restrict_sendtask_gc(flag, kkf, jjf, iif, a1(ip3f), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
+                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    kstart, kstop)
+                CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
+                    a1(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop, &
+                    ipos, jpos, kpos)
+            CASE (2)
+                CALL restrict_sendtask_gc(flag, kkf, jjf, iif, a2(ip3f), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
+                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    kstart, kstop)
+                CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
+                    a2(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop, &
+                    ipos, jpos, kpos)
+            CASE (3)
+                CALL restrict_sendtask_gc(flag, kkf, jjf, iif, a3(ip3f), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
+                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    kstart, kstop)
+                CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
+                    a3(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop, &
+                    ipos, jpos, kpos)
+            CASE (4)
+                CALL restrict_sendtask_gc(flag, kkf, jjf, iif, a4(ip3f), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
+                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    kstart, kstop)
+                CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
+                    a4(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop, &
+                    ipos, jpos, kpos)
+            CASE (5)
+                CALL restrict_sendtask_gc(flag, kkf, jjf, iif, a5(ip3f), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
+                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    kstart, kstop)
+                CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
+                    a5(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop, &
+                    ipos, jpos, kpos)
+            CASE (6)
+                CALL restrict_sendtask_gc(flag, kkf, jjf, iif, a6(ip3f), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
+                    tasksize, scratchidx, istart, istop, jstart, jstop, &
+                    kstart, kstop)
+                CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
+                    a6(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
+                    tasksize, istart, istop, jstart, jstop, kstart, kstop, &
+                    ipos, jpos, kpos)
+            CASE DEFAULT
+                CALL errr(__FILE__, __LINE__)
+            END SELECT
+        END DO
+        !$omp end target teams distribute
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+
+        END ASSOCIATE
+    END SUBROUTINE process_selftasks_gc
+
+
+    SUBROUTINE unpack_restricted_buffer(flag, kk, jj, ii, fc, buffer, &
+            tasksize, istart, istop, jstart, jstop, kstart, kstop, ipos, &
+            jpos, kpos)
+        !$omp declare target
+        ! Subroutine arguments
+        CHARACTER(len=1), INTENT(in) :: flag
+        INTEGER(intk), INTENT(in) :: kk, jj, ii, tasksize
+        REAL(realk), INTENT(inout) :: fc(kk, jj, ii)
+        REAL(realk), INTENT(in) :: buffer(tasksize)
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
+        INTEGER(intk), INTENT(in) :: ipos, jpos, kpos
+
+        IF (flag == 'N') THEN
+            CALL unpack_restricted_buffer_n(kk, jj, ii, fc, buffer, tasksize, &
+                istart, istop, jstart, jstop, kstart, kstop, ipos, jpos, kpos)
+        ELSE
+            CALL unpack_restricted_buffer_open(flag, kk, jj, ii, fc, &
+                buffer, tasksize, istart, istop, jstart, jstop, kstart, &
+                kstop, ipos, jpos, kpos)
+        END IF
+    END SUBROUTINE unpack_restricted_buffer
+
+
+    SUBROUTINE unpack_restricted_buffer_open(flag, kk, jj, ii, fc, buffer, &
+            tasksize, istart, istop, jstart, jstop, kstart, kstop, ipos, &
+            jpos, kpos)
+        !$omp declare target
+        ! Subroutine arguments
+        CHARACTER(len=1), INTENT(in) :: flag
+        INTEGER(intk), INTENT(in) :: kk, jj, ii, tasksize
+        REAL(realk), INTENT(inout) :: fc(kk, jj, ii)
+        REAL(realk), INTENT(in) :: buffer(tasksize)
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
+        INTEGER(intk), INTENT(in) :: ipos, jpos, kpos
+
+        ! Local variables
+        INTEGER(intk) :: i, j, k, ic, jc, kc, ic0, jc0, kc0, icount
+        INTEGER(intk) :: ni, nj, nk
+
+        ic0 = 0
+        jc0 = 0
+        kc0 = 0
+        SELECT CASE (flag)
+        CASE ('U')
+            ic0 = 1
+        CASE ('V')
+            jc0 = 1
+        CASE ('W')
+            kc0 = 1
+        END SELECT
+
+        ni = (istop - istart)/2 + 1
+        nj = (jstop - jstart)/2 + 1
+        nk = (kstop - kstart)/2 + 1
+
+        !$omp parallel do collapse(3) private(ic, jc, kc, icount)
+        DO i = istart, istop, 2
+            DO j = jstart, jstop, 2
+                DO k = kstart, kstop, 2
+                    ic = ipos + (i-3+ic0)/2 - ic0
+                    jc = jpos + (j-3+jc0)/2 - jc0
+                    kc = kpos + (k-3+kc0)/2 - kc0
+                    icount = ((i-istart)/2*nj + (j-jstart)/2)*nk + &
+                        (k-kstart)/2 + 1
+                    fc(kc, jc, ic) = buffer(icount)
+                END DO
+            END DO
+        END DO
+        !$omp end parallel do
+
+#ifdef _MGLET_DEBUG_
+        IF (ni*nj*nk /= tasksize) CALL errr(__FILE__, __LINE__)
+#endif
+    END SUBROUTINE unpack_restricted_buffer_open
+
+
+    SUBROUTINE unpack_restricted_buffer_n(kk, jj, ii, fc, buffer, tasksize, &
+            istart, istop, jstart, jstop, kstart, kstop, ipos, jpos, kpos)
+        !$omp declare target
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: kk, jj, ii, tasksize
+        REAL(realk), INTENT(inout) :: fc(kk, jj, ii)
+        REAL(realk), INTENT(in) :: buffer(tasksize)
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
+        INTEGER(intk), INTENT(in) :: ipos, jpos, kpos
+
+        ! Local variables
+        INTEGER(intk) :: i, j, k, ic, jc, kc, icount
+        INTEGER(intk) :: ni, nj, nk
+
+        ni = (istop - istart)/2 + 1
+        nj = (jstop - jstart)/2 + 1
+        nk = (kstop - kstart)/2 + 1
+
+        !$omp parallel do collapse(3) private(ic, jc, kc, icount)
+        DO i = istart, istop, 2
+            DO j = jstart, jstop, 2
+                DO k = kstart, kstop, 2
+                    ic = ipos + (i-2)/2 - 1
+                    jc = jpos + (j-2)/2 - 1
+                    kc = kpos + (k-2)/2 - 1
+                    icount = ((i-istart)/2*nj + (j-jstart)/2)*nk + &
+                        (k-kstart)/2 + 1
+                    IF (ABS(fc(kc, jc, ic)) < TINY(1.0_realk) .AND. &
+                            buffer(icount) >= 1.0_realk) THEN
+                        fc(kc, jc, ic) = buffer(icount)
+                    END IF
+                END DO
+            END DO
+        END DO
+        !$omp end parallel do
+
+#ifdef _MGLET_DEBUG_
+        IF (ni*nj*nk /= tasksize) CALL errr(__FILE__, __LINE__)
+#endif
+    END SUBROUTINE unpack_restricted_buffer_n
+
+
+    SUBROUTINE process_mpisend(nmpistasks, mpistasks)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nmpistasks
+        INTEGER(intk), INTENT(in) :: mpistasks(mpitasksize, nmpistasks+1)
+
+        ! Local variables
+        INTEGER(intk) :: itask
+        INTEGER(int32) :: iprocnbr, messagelength, sendcounter
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("process_mpisend")
+#endif
+
+        DO itask = 1, nmpistasks
+            iprocnbr = INT(mpistasks(1, itask), kind=int32)
+            messagelength = INT(mpistasks(2, itask), kind=int32)
+            sendcounter = INT(mpistasks(3, itask), kind=int32)
+
+            !$omp target data use_device_addr(sendbuf)
+            CALL MPI_Isend(sendbuf(sendcounter+1), messagelength, &
+                mglet_mpi_real, iprocnbr, 1, MPI_COMM_WORLD, sendreqs(itask))
+            !$omp end target data
+        END DO
+
+        nsend = nmpistasks
+
+        ! Safety check based on final dummy entry
+        IF (nmpistasks < maxmpisendtasks) THEN
+            IF (.NOT. ALL(mpistasks(:, nmpistasks+1) == -1)) THEN
+                WRITE(*, *) "Did not encounter the expected dummy task."
+                CALL errr(__FILE__, __LINE__)
+            END IF
+        END IF
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE process_mpisend
+
+
+    SUBROUTINE process_sendtasks(nstasks, stasks)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nstasks
+        INTEGER(intk), INTENT(in) :: stasks(sendtasksize, nstasks+1)
+
+        ! Local variables
+        TYPE(field_t), POINTER :: ddx, ddy, ddz, bp, bt
+        LOGICAL :: foundbt
+
+        IF (nstasks == 0) RETURN
+
+        CALL get_field(ddx, "DDX")
+        CALL get_field(ddy, "DDY")
+        CALL get_field(ddz, "DDZ")
+
+        SELECT CASE (ib%type)
+        CASE ("NONE")
+            CALL process_sendtasks_noib(nstasks, stasks, ddx, ddy, ddz)
+        CASE ("GHOSTCELL")
+            CALL get_field(bp, "BP")
+            CALL get_field(bt, "BT", foundbt)
+            IF (.NOT. foundbt) THEN
+                ! For non-scalar cases, point bt to bp. It is unused anyways.
+                bt => bp
+            END IF
+            CALL process_sendtasks_gc(nstasks, stasks, ddx, ddy, ddz, bp, bt)
+        CASE DEFAULT
+            CALL errr(__FILE__, __LINE__)
+        END SELECT
+
+        ! Safety check based on final dummy entry
+        IF (.NOT. ALL(stasks(:, nstasks+1) == -1)) THEN
+            WRITE(*, *) "Did not encounter the expected dummy task."
+            CALL errr(__FILE__, __LINE__)
+        END IF
+    END SUBROUTINE process_sendtasks
+
+
+    SUBROUTINE process_sendtasks_noib(nstasks, stasks, ddx_f, ddy_f, ddz_f)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nstasks
+        INTEGER(intk), INTENT(in) :: stasks(sendtasksize, nstasks+1)
+        TYPE(field_t), INTENT(in) :: ddx_f, ddy_f, ddz_f
+
+        ! Local variables
+        INTEGER(intk) :: itask, kk, jj, ii, ip3, ipx, ipy, ipz
+        INTEGER(intk) :: fieldid, icount, tasksize, igrid, &
+            istart, istop, jstart, jstop, kstart, kstop
+        CHARACTER(len=1) :: flag
+
+        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
+                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr, &
+                  ddx => ddx_f%arr, ddy => ddy_f%arr, ddz => ddz_f%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("process_sendtasks_noib")
+#endif
+
+        !$omp target teams distribute private(itask, fieldid, flag, icount, &
+        !$omp& tasksize, igrid, istart, istop, jstart, jstop, kstart, kstop, &
+        !$omp& kk, jj, ii, ip3, ipx, ipy, ipz)
+        DO itask = 1, nstasks
+            fieldid = stasks(1, itask)
+            flag = ACHAR(stasks(2, itask))
+            icount = stasks(3, itask)
+            tasksize = stasks(4, itask)
+            igrid = stasks(5, itask)
+            istart = stasks(6, itask)
+            istop = stasks(7, itask)
+            jstart = stasks(8, itask)
+            jstop = stasks(9, itask)
+            kstart = stasks(10, itask)
+            kstop = stasks(11, itask)
+
+            CALL get_mgdims(kk, jj, ii, igrid)
+            CALL get_ip3(ip3, igrid)
+            CALL get_ip1x(ipx, igrid)
+            CALL get_ip1y(ipy, igrid)
+            CALL get_ip1z(ipz, igrid)
+
+            SELECT CASE(fieldid)
+            CASE (1)
+                CALL restrict_sendtask_noib(flag, kk, jj, ii, a1(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), tasksize, icount, &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE (2)
+                CALL restrict_sendtask_noib(flag, kk, jj, ii, a2(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), tasksize, icount, &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE (3)
+                CALL restrict_sendtask_noib(flag, kk, jj, ii, a3(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), tasksize, icount, &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE (4)
+                CALL restrict_sendtask_noib(flag, kk, jj, ii, a4(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), tasksize, icount, &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE (5)
+                CALL restrict_sendtask_noib(flag, kk, jj, ii, a5(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), tasksize, icount, &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE (6)
+                CALL restrict_sendtask_noib(flag, kk, jj, ii, a6(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), tasksize, icount, &
+                    istart, istop, jstart, jstop, kstart, kstop)
+#ifdef _MGLET_DEBUG_
+            CASE DEFAULT
+                CALL errr(__FILE__, __LINE__)
+#endif
+            END SELECT
+        END DO
+        !$omp end target teams distribute
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+
+        END ASSOCIATE
+    END SUBROUTINE process_sendtasks_noib
+
+
+    SUBROUTINE process_sendtasks_gc(nstasks, stasks, ddx_f, ddy_f, ddz_f, &
+            bp_f, bt_f)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nstasks
+        INTEGER(intk), INTENT(in) :: stasks(sendtasksize, nstasks+1)
+        TYPE(field_t), INTENT(in) :: ddx_f, ddy_f, ddz_f, bp_f, bt_f
+
+        ! Local variables
+        INTEGER(intk) :: itask, kk, jj, ii, ip3, ipx, ipy, ipz
+        INTEGER(intk) :: fieldid, icount, tasksize, igrid, &
+            istart, istop, jstart, jstop, kstart, kstop
+        CHARACTER(len=1) :: flag
+
+        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
+                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr, &
+                  ddx => ddx_f%arr, ddy => ddy_f%arr, ddz => ddz_f%arr, &
+                  bp => bp_f%arr, bt => bt_f%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("process_sendtasks_gc")
+#endif
+
+        !$omp target teams distribute private(itask, fieldid, flag, icount, &
+        !$omp& tasksize, igrid, istart, istop, jstart, jstop, kstart, kstop, &
+        !$omp& kk, jj, ii, ip3, ipx, ipy, ipz)
+        DO itask = 1, nstasks
+            fieldid = stasks(1, itask)
+            flag = ACHAR(stasks(2, itask))
+            icount = stasks(3, itask)
+            tasksize = stasks(4, itask)
+            igrid = stasks(5, itask)
+            istart = stasks(6, itask)
+            istop = stasks(7, itask)
+            jstart = stasks(8, itask)
+            jstop = stasks(9, itask)
+            kstart = stasks(10, itask)
+            kstop = stasks(11, itask)
+
+            CALL get_mgdims(kk, jj, ii, igrid)
+            CALL get_ip3(ip3, igrid)
+            CALL get_ip1x(ipx, igrid)
+            CALL get_ip1y(ipy, igrid)
+            CALL get_ip1z(ipz, igrid)
+
+            SELECT CASE(fieldid)
+            CASE (1)
+                CALL restrict_sendtask_gc(flag, kk, jj, ii, a1(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), tasksize, &
+                    icount, istart, istop, jstart, jstop, kstart, kstop)
+            CASE (2)
+                CALL restrict_sendtask_gc(flag, kk, jj, ii, a2(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), tasksize, &
+                    icount, istart, istop, jstart, jstop, kstart, kstop)
+            CASE (3)
+                CALL restrict_sendtask_gc(flag, kk, jj, ii, a3(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), tasksize, &
+                    icount, istart, istop, jstart, jstop, kstart, kstop)
+            CASE (4)
+                CALL restrict_sendtask_gc(flag, kk, jj, ii, a4(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), tasksize, &
+                    icount, istart, istop, jstart, jstop, kstart, kstop)
+            CASE (5)
+                CALL restrict_sendtask_gc(flag, kk, jj, ii, a5(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), tasksize, &
+                    icount, istart, istop, jstart, jstop, kstart, kstop)
+            CASE (6)
+                CALL restrict_sendtask_gc(flag, kk, jj, ii, a6(ip3), &
+                    ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3), bt(ip3), tasksize, &
+                    icount, istart, istop, jstart, jstop, kstart, kstop)
+#ifdef _MGLET_DEBUG_
+            CASE DEFAULT
+                CALL errr(__FILE__, __LINE__)
+#endif
+            END SELECT
+        END DO
+        !$omp end target teams distribute
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+
+        END ASSOCIATE
+    END SUBROUTINE process_sendtasks_gc
+
+
+    SUBROUTINE restrict_sendtask_noib(flag, kk, jj, ii, ff, ddx, ddy, &
+            ddz, tasksize, icount, istart, istop, jstart, jstop, kstart, kstop)
+        !$omp declare target
+        ! Subroutine arguments
+        CHARACTER(len=1), INTENT(in) :: flag
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(in) :: ff(kk, jj, ii)
+        REAL(realk), INTENT(in) :: ddx(ii), ddy(jj), ddz(kk)
+        INTEGER(intk), INTENT(in) :: tasksize, icount
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
+
+        ! Local variables
+        INTEGER(int32) :: targetidx, messagelength
+
+        messagelength = INT(tasksize, kind=int32)
+        targetidx = icount + tasksize - 1
+
+        SELECT CASE (flag)
+        CASE ('U')
+            CALL restrict_noib_u(kk, jj, ii, ff, ddx, ddy, ddz, &
+                messagelength, sendbuf(icount:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ('V')
+            CALL restrict_noib_v(kk, jj, ii, ff, ddx, ddy, ddz, &
+                messagelength, sendbuf(icount:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ('W')
+            CALL restrict_noib_w(kk, jj, ii, ff, ddx, ddy, ddz, &
+                messagelength, sendbuf(icount:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ('P', 'R', 'S', 'T')
+            CALL restrict_noib_s(kk, jj, ii, ff, ddx, ddy, ddz, &
+                messagelength, sendbuf(icount:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+#ifdef _MGLET_DEBUG_
+        CASE DEFAULT
+            CALL errr(__FILE__, __LINE__)
+#endif
+        END SELECT
+    END SUBROUTINE restrict_sendtask_noib
+
+
+    SUBROUTINE restrict_sendtask_gc(flag, kk, jj, ii, ff, ddx, ddy, &
+            ddz, bp, bt, tasksize, icount, istart, istop, jstart, jstop, &
+            kstart, kstop)
+        !$omp declare target
+        ! Subroutine arguments
+        CHARACTER(len=1), INTENT(in) :: flag
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(in) :: ff(kk, jj, ii)
+        REAL(realk), INTENT(in) :: ddx(ii), ddy(jj), ddz(kk)
+        REAL(realk), INTENT(in) :: bp(kk, jj, ii), bt(kk, jj, ii)
+        INTEGER(intk), INTENT(in) :: tasksize, icount
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
+
+        ! Local variables
+        INTEGER(int32) :: messagelength
+        INTEGER(intk) :: targetidx
+
+        messagelength = INT(tasksize, kind=int32)
+        targetidx = icount + tasksize - 1
+
+        SELECT CASE (flag)
+            CASE ('U')
+                CALL restrict_noib_u(kk, jj, ii, ff, ddx, ddy, ddz, &
+                    messagelength, sendbuf(icount:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('V')
+                CALL restrict_noib_v(kk, jj, ii, ff, ddx, ddy, ddz, &
+                    messagelength, sendbuf(icount:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('W')
+                CALL restrict_noib_w(kk, jj, ii, ff, ddx, ddy, ddz, &
+                    messagelength, sendbuf(icount:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('P')
+                CALL restrict_gc_p_t(kk, jj, ii, ff, ddx, ddy, ddz, bp, &
+                    messagelength, sendbuf(icount:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('T')
+                CALL restrict_gc_p_t(kk, jj, ii, ff, ddx, ddy, ddz, bt, &
+                    messagelength, sendbuf(icount:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('R')
+                CALL restrict_gc_r(kk, jj, ii, ff, ddx, ddy, ddz, bp, &
+                    messagelength, sendbuf(icount:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('S')
+                CALL restrict_noib_s(kk, jj, ii, ff, ddx, ddy, ddz, &
+                    messagelength, sendbuf(icount:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('N')
+                CALL restrict_gc_n(kk, jj, ii, ff, messagelength, &
+                    sendbuf(icount:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('E')
+                CALL restrict_gc_e(kk, jj, ii, ff, messagelength, &
+                    sendbuf(icount:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('F')
+                CALL restrict_gc_f(kk, jj, ii, ff, messagelength, &
+                    sendbuf(icount:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('I')
+                CALL restrict_gc_i(kk, jj, ii, ff, messagelength, &
+                    sendbuf(icount:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+#ifdef _MGLET_DEBUG_
+            CASE DEFAULT
+                CALL errr(__FILE__, __LINE__)
+#endif
+            END SELECT
+    END SUBROUTINE restrict_sendtask_gc
+
+
+    SUBROUTINE process_mpirecv(nmpirtasks, mpirtasks)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nmpirtasks
+        INTEGER(intk), INTENT(in) :: mpirtasks(mpitasksize, nmpirtasks+1)
+
+        ! Local variables
+        INTEGER(intk) :: itask
+        INTEGER(int32) :: iprocnbr, messagelength, recvcounter
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("process_mpirecv")
+#endif
+
+        DO itask = 1, nmpirtasks
+            iprocnbr = INT(mpirtasks(1, itask), kind=int32)
+            messagelength = INT(mpirtasks(2, itask), kind=int32)
+            recvcounter = INT(mpirtasks(3, itask), kind=int32)
+
+            !$omp target data use_device_addr(recvbuf)
+            CALL MPI_Irecv(recvbuf(recvcounter+1), messagelength, &
+                mglet_mpi_real, iprocnbr, 1, MPI_COMM_WORLD, recvreqs(itask))
+            !$omp end target data
+        END DO
+
+        nrecv = nmpirtasks
+
+        ! Safety check based on final dummy entry
+        IF (.NOT. ALL(mpirtasks(:, nmpirtasks+1) == -1)) THEN
+            WRITE(*, *) "Did not encounter the expected dummy task."
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE process_mpirecv
+
+
+    SUBROUTINE prepare_mpirecvtasks(mpirtasks, nmpirtasks, ilevel, flag, &
+            v1, v2, v3, s1, s2, s3)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(inout) :: mpirtasks(mpitasksize, maxmpirecvtasks)
+        INTEGER(intk), INTENT(out) :: nmpirtasks
+        INTEGER(intk), INTENT(in) :: ilevel
+        CHARACTER(len=1), INTENT(in) :: flag
+        TYPE(field_t), OPTIONAL, INTENT(inout) :: v1, v2, v3, s1, s2, s3
+
+        ! Local variables
+        INTEGER(intk) :: i, iprocnbr, igridf, impirtask
+        INTEGER(int32) :: ncells, messagelength, recvcounter
+
+        recvcounter = 0
+        messagelength = 0
+        nrecv = 0
+        recvidxlist = -HUGE(1_intk)
+        recvlist = 0
+        impirtask = 0
+
+        DO i = 1, irecv
+            iprocnbr = recvconns(1, i)  ! The sender process (fine side)
+            IF (iprocnbr == myid) CYCLE
+
+            igridf = recvconns(3, i)
+            IF (ilevel == level(igridf)) THEN
+                CALL count_ncells(ncells, flag, igridf, v1, v2, v3, s1, s2, s3)
+                recvidxlist(1, i) = iprocnbr
+                recvidxlist(2, i) = ncells
+                recvidxlist(3, i) = recvcounter + messagelength
+                messagelength = messagelength + ncells
+
+                IF (recvcounter + messagelength > idim_mg_bufs) THEN
+                    CALL errr(__FILE__, __LINE__)
+                END IF
+            END IF
+
+            IF (messagelength > 0) THEN
+                IF (i == irecv) THEN
+                    CALL add_mpi_task(mpirtasks, impirtask, iprocnbr, &
+                        messagelength, recvcounter, 'recv')
+                ELSE IF (recvconns(1, i + 1) /= iprocnbr) THEN
+                    CALL add_mpi_task(mpirtasks, impirtask, iprocnbr, &
+                        messagelength, recvcounter, 'recv')
+                END IF
+            END IF
+        END DO
+
+        nmpirtasks = impirtask
+        ! Add a harmful dummy task at (ntasks+1) for checking
+        mpirtasks(:, nmpirtasks+1) = -1
+    END SUBROUTINE prepare_mpirecvtasks
+
+
+    SUBROUTINE prepare_tasks_all(stasks, nstasks, etasks, netasks, mpistasks, &
+        nmpistasks, ilevel, flag, v1, v2, v3, s1, s2, s3)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(inout) :: stasks(sendtasksize, maxsendtasks)
+        INTEGER(intk), INTENT(out) :: nstasks
+        INTEGER(intk), INTENT(inout) :: etasks(selftasksize, maxselftasks)
+        INTEGER(intk), INTENT(out) :: netasks
+        INTEGER(intk), INTENT(inout) :: mpistasks(mpitasksize, maxmpisendtasks)
+        INTEGER(intk), INTENT(out) :: nmpistasks
+        INTEGER(intk), INTENT(in) :: ilevel
+        CHARACTER(len=1), INTENT(in) :: flag
+        TYPE(field_t), OPTIONAL, INTENT(inout) :: v1, v2, v3, s1, s2, s3
+
+        ! Local variables
+        INTEGER(intk) :: i, iprocnbr, igridf, istask, ietask, impistask
+        INTEGER(int32) :: ncells, ncells_total, messagelength, sendcounter, &
+            selfcounter
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("prepare_tasks_all")
+#endif
+
+        ! Pack all buffers and send data
+        sendcounter = 0
+        CALL count_sendcells(ncells_total, ilevel, flag, v1, v2, v3, &
+            s1, s2, s3)
+        selfcounter = 1 + ncells_total
+        messagelength = 0
+        nsend = 0
+
+        ! Initialize the task counters to zero
+        istask = 0
+        ietask = 0
+        impistask = 0
+
+        DO i = 1, isend
+            iprocnbr = sendconns(2, i)
+            igridf = sendconns(3, i)
+
+            IF (ilevel == level(igridf)) THEN
+                IF (iprocnbr == myid) THEN
+                    CALL prepare_selftask(etasks, ietask, i, flag, &
+                        selfcounter, v1, v2, v3, s1, s2, s3)
+                ELSE
+                    CALL prepare_sendtask(stasks, istask, i, &
+                        messagelength, sendcounter, flag, &
+                        v1, v2, v3, s1, s2, s3)
+                    CALL count_ncells(ncells, flag, igridf, &
+                        v1, v2, v3, s1, s2, s3)
+                    ! ncells already sums over all args (nvars not needed)
+                    messagelength = messagelength + ncells
+                END IF
+            END IF
+
+            IF (messagelength > 0) THEN
+                IF (i == isend) THEN
+                    CALL add_mpi_task(mpistasks, impistask, iprocnbr, &
+                        messagelength, sendcounter, 'send')
+                ELSE IF (sendconns(2, i + 1) /= iprocnbr) THEN
+                    CALL add_mpi_task(mpistasks, impistask, iprocnbr, &
+                        messagelength, sendcounter, 'send')
+                END IF
+            END IF
+        END DO
+
+        ! Set the output task counters
+        nstasks = istask
+        netasks = ietask
+        nmpistasks = impistask
+
+        IF (sendcounter >= selfcounter) CALL errr(__FILE__, __LINE__)
+        IF (selfcounter > idim_mg_bufs + 1) CALL errr(__FILE__, __LINE__)
+
+        ! Add a harmful dummy task at (ntasks+1) for checking
+        stasks(:, nstasks+1) = -1
+        etasks(:, netasks+1) = -1
+        mpistasks(:, nmpistasks+1) = -1
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE prepare_tasks_all
+
+
+    SUBROUTINE prepare_selftask(etasks, ietask, sendid, flag, selfcounter, &
+            v1, v2, v3, s1, s2, s3)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(inout) :: etasks(selftasksize, maxselftasks)
+        INTEGER(intk), INTENT(inout) :: ietask
+        INTEGER(intk), INTENT(in) :: sendid
+        CHARACTER(len=1), INTENT(in) :: flag
+        INTEGER(int32), INTENT(inout) :: selfcounter
+        TYPE(field_t), OPTIONAL, INTENT(inout) :: v1, v2, v3, s1, s2, s3
+
+        ! Local variables
+        INTEGER(intk) :: igridf, igridc
+        INTEGER(int32) :: ncells, icount
+        CHARACTER(len=1) :: flag_u
+
+        igridf = sendconns(3, sendid)
+        igridc = sendconns(4, sendid)
+
+        CALL count_ncells(ncells, flag, igridf, &
+            v1, v2, v3, s1, s2, s3)
+
+        icount = 0
+
+        IF (PRESENT(v1)) THEN
+            IF (flag == '*') THEN
+                flag_u = 'U'
+            ELSE
+                flag_u = flag
+            END IF
+
+            ietask = ietask + 1
+            CALL add_single_selftask(etasks(:, ietask), 1, flag_u, icount, &
+                selfcounter, igridf, igridc)
+        END IF
+
+        IF (PRESENT(v2)) THEN
+            ietask = ietask + 1
+            CALL add_single_selftask(etasks(:, ietask), 2, 'V', icount, &
+                selfcounter, igridf, igridc)
+        END IF
+
+        IF (PRESENT(v3)) THEN
+            ietask = ietask + 1
+            CALL add_single_selftask(etasks(:, ietask), 3, 'W', icount, &
+                selfcounter, igridf, igridc)
+        END IF
+
+        IF (PRESENT(s1)) THEN
+            ietask = ietask + 1
+            CALL add_single_selftask(etasks(:, ietask), 4, 'P', icount, &
+                selfcounter, igridf, igridc)
+        END IF
+
+        IF (PRESENT(s2)) THEN
+            ietask = ietask + 1
+            CALL add_single_selftask(etasks(:, ietask), 5, 'P', icount, &
+                selfcounter, igridf, igridc)
+        END IF
+
+        IF (PRESENT(s3)) THEN
+            ietask = ietask + 1
+            CALL add_single_selftask(etasks(:, ietask), 6, 'P', icount, &
+                selfcounter, igridf, igridc)
+        END IF
+
+        IF (ncells /= icount) THEN
+            WRITE(*, *) "ncells:", ncells, "self_len:", icount
+            CALL errr(__FILE__, __LINE__)
+        END IF
+    END SUBROUTINE prepare_selftask
+
+
+    SUBROUTINE prepare_sendtask(stasks, istask, sendid, messagelength, &
+            sendcounter, flag, v1, v2, v3, s1, s2, s3)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(inout) :: stasks(sendtasksize, maxsendtasks)
+        INTEGER(intk), INTENT(inout) :: istask
+        INTEGER(intk), INTENT(in) :: sendid
+        INTEGER(int32), INTENT(in) :: messagelength
+        INTEGER(int32), INTENT(inout) :: sendcounter
+        CHARACTER(len=1), INTENT(in) :: flag
+        TYPE(field_t), OPTIONAL, INTENT(inout) :: v1, v2, v3, s1, s2, s3
+
+        ! Local variables
+        INTEGER(intk) :: igrid
+        INTEGER(int32) :: ncells, offset, icount
+        CHARACTER(len=1) :: flag_u
+
+        igrid = sendconns(3, sendid)
+
+        CALL count_ncells(ncells, flag, igrid, &
+            v1, v2, v3, s1, s2, s3)
+
+        ! Check that buffer does not overflow
+        IF (sendcounter + messagelength + ncells > idim_mg_bufs) THEN
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        ! Reset message size counter
+        offset = sendcounter + messagelength + 1
+        icount = offset
+
+        IF (PRESENT(v1)) THEN
+            IF (flag == '*') THEN
+                flag_u = 'U'
+            ELSE
+                flag_u = flag
+            END IF
+
+            istask = istask + 1
+            CALL add_single_sendtask(stasks(:, istask), 1, flag_u, icount, &
+                igrid)
+        END IF
+
+        IF (PRESENT(v2)) THEN
+            istask = istask + 1
+            CALL add_single_sendtask(stasks(:, istask), 2, 'V', icount, igrid)
+        END IF
+
+        IF (PRESENT(v3)) THEN
+            istask = istask + 1
+            CALL add_single_sendtask(stasks(:, istask), 3, 'W', icount, igrid)
+        END IF
+
+        IF (PRESENT(s1)) THEN
+            istask = istask + 1
+            CALL add_single_sendtask(stasks(:, istask), 4, 'P', icount, igrid)
+        END IF
+
+        IF (PRESENT(s2)) THEN
+            istask = istask + 1
+            CALL add_single_sendtask(stasks(:, istask), 5, 'P', icount, igrid)
+        END IF
+
+        IF (PRESENT(s3)) THEN
+            istask = istask + 1
+            CALL add_single_sendtask(stasks(:, istask), 6, 'P', icount, igrid)
+        END IF
+
+        IF (ncells /= (icount - offset)) THEN
+            WRITE(*, *) "ncells:", ncells, "packed_len:", icount - offset
+            CALL errr(__FILE__, __LINE__)
+        END IF
+    END SUBROUTINE prepare_sendtask
+
+
+    SUBROUTINE add_single_selftask(task, fieldid, flag, icount, selfcounter, &
+            igridf, igridc)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(out) :: task(selftasksize)
+        INTEGER(intk), INTENT(in) :: fieldid
+        CHARACTER(len=1), INTENT(in) :: flag
+        INTEGER(int32), INTENT(inout) :: icount
+        INTEGER(int32), INTENT(inout) :: selfcounter
+        INTEGER(intk), INTENT(in) :: igridf, igridc
+
+        ! Local variables
+        INTEGER(intk) :: flagidx, istart, istop, jstart, jstop, kstart, kstop
+        INTEGER(int32) :: tasksize
+
+        flagidx = IACHAR(flag)
+
+        CALL message_length(tasksize, flag, igridf)
+        CALL start_and_stop(istart, istop, jstart, jstop, kstart, kstop, &
+            flag, igridf)
+
+        IF (selfcounter + tasksize - 1 > idim_mg_bufs) THEN
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        task(1) = fieldid
+        task(2) = flagidx
+        task(3) = INT(tasksize, kind=intk)
+        task(4) = INT(selfcounter, kind=intk)
+        task(5) = igridf
+        task(6) = igridc
+        task(7) = istart
+        task(8) = istop
+        task(9) = jstart
+        task(10) = jstop
+        task(11) = kstart
+        task(12) = kstop
+        task(13) = iposition(igridf)
+        task(14) = jposition(igridf)
+        task(15) = kposition(igridf)
+
+        icount = icount + tasksize
+        selfcounter = selfcounter + tasksize
+    END SUBROUTINE add_single_selftask
+
+
+    SUBROUTINE count_sendcells(ncells_total, ilevel, flag, v1, v2, v3, &
+            s1, s2, s3)
+        ! Subroutine arguments
+        INTEGER(int32), INTENT(out) :: ncells_total
+        INTEGER(intk), INTENT(in) :: ilevel
+        CHARACTER(len=1), INTENT(in) :: flag
+        TYPE(field_t), OPTIONAL, INTENT(inout) :: v1, v2, v3, s1, s2, s3
+
+        ! Local variables
+        INTEGER(intk) :: i, iprocnbr, igridf
+        INTEGER(int32) :: ncells
+
+        ncells_total = 0
+        DO i = 1, isend
+            iprocnbr = sendconns(2, i)
+            IF (iprocnbr == myid) CYCLE
+
+            igridf = sendconns(3, i)
+            IF (ilevel == level(igridf)) THEN
+                CALL count_ncells(ncells, flag, igridf, &
+                    v1, v2, v3, s1, s2, s3)
+                ncells_total = ncells_total + ncells
+            END IF
+        END DO
+    END SUBROUTINE count_sendcells
+
+
+    SUBROUTINE add_single_sendtask(task, fieldid, flag, icount, igrid)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(out) :: task(sendtasksize)
+        INTEGER(intk), INTENT(in) :: fieldid
+        CHARACTER(len=1), INTENT(in) :: flag
+        INTEGER(int32), INTENT(inout) :: icount
+        INTEGER(intk), INTENT(in) :: igrid
+
+        ! Local variables
+        INTEGER(intk) :: flagidx, istart, istop, jstart, jstop, kstart, kstop
+        INTEGER(int32) :: tasksize
+
+        flagidx = IACHAR(flag)
+
+        CALL message_length(tasksize, flag, igrid)
+        CALL start_and_stop(istart, istop, jstart, jstop, kstart, kstop, flag, &
+            igrid)
+
+        task(1) = fieldid
+        task(2) = flagidx
+        task(3) = INT(icount, kind=intk)
+        task(4) = INT(tasksize, kind=intk)
+        task(5) = igrid
+        task(6) = istart
+        task(7) = istop
+        task(8) = jstart
+        task(9) = jstop
+        task(10) = kstart
+        task(11) = kstop
+
+        icount = icount + tasksize
+    END SUBROUTINE add_single_sendtask
+
+
+    SUBROUTINE add_single_recvtask(task, fieldid, flag, icount, igridf, igridc)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(out) :: task(recvtasksize)
+        INTEGER(intk), INTENT(in) :: fieldid
+        CHARACTER(len=1), INTENT(in) :: flag
+        INTEGER(int32), INTENT(inout) :: icount
+        INTEGER(intk), INTENT(in) :: igridf, igridc
+
+        ! Local variables
+        INTEGER(intk) :: flagidx, istart, istop, jstart, jstop, kstart, kstop
+        INTEGER(int32) :: tasksize
+
+        flagidx = IACHAR(flag)
+
+        CALL message_length(tasksize, flag, igridf)
+        CALL start_and_stop(istart, istop, jstart, jstop, kstart, kstop, &
+            flag, igridf)
+
+        task(1) = fieldid
+        task(2) = flagidx
+        task(3) = INT(tasksize, kind=intk)
+        task(4) = INT(icount, kind=intk)
+        task(5) = igridf
+        task(6) = igridc
+        task(7) = istart
+        task(8) = istop
+        task(9) = jstart
+        task(10) = jstop
+        task(11) = kstart
+        task(12) = kstop
+        task(13) = iposition(igridf)
+        task(14) = jposition(igridf)
+        task(15) = kposition(igridf)
+
+        icount = icount + tasksize
+    END SUBROUTINE add_single_recvtask
+
+
+    SUBROUTINE add_mpi_task(mpitasks, impitask, iprocnbr, messagelength, &
+            counter, type)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(inout) :: mpitasks(mpitasksize, *)
+        INTEGER(intk), INTENT(inout) :: impitask
+        INTEGER(intk), INTENT(in) :: iprocnbr
+        INTEGER(int32), INTENT(inout) :: messagelength
+        INTEGER(int32), INTENT(inout) :: counter
+        CHARACTER(len=4), INTENT(in) :: type
+
+        ! Local variables
+        ! none...
+
+        IF (type == 'send') THEN
+            nsend = nsend + 1
+        ELSE IF (type == 'recv') THEN
+            nrecv = nrecv + 1
+            recvlist(nrecv) = iprocnbr
+        ELSE
+            CALL errr(__FILE__, __LINE__)
+        END IF
+
+        ! Add the MPI send task to the mpitasks array
+        impitask = impitask + 1
+
+        mpitasks(1, impitask) = iprocnbr
+        mpitasks(2, impitask) = messagelength
+        mpitasks(3, impitask) = counter
+
+        counter = counter + messagelength
+        messagelength = 0
+    END SUBROUTINE add_mpi_task
 
 
     SUBROUTINE init_ftoc2()
@@ -68,7 +1875,7 @@ CONTAINS
         ! none...
 
         ! Local variables
-        ! none...
+        INTEGER(intk) :: nselfsend, nselfrecv
 
         IF (is_init) CALL errr(__FILE__, __LINE__)
 
@@ -82,8 +1889,152 @@ CONTAINS
         nsend = 0
         nrecv = 0
 
+        ! Allocating the workpackage arrays
+        ! Always add 1 extra dummy task for error checking purposes
+        maxsendtasks = 6 * isend + 1
+        maxrecvtasks = 6 * irecv + 1
+        ALLOCATE(sendtasks(sendtasksize, maxsendtasks))
+        ALLOCATE(recvtasks(recvtasksize, maxrecvtasks))
+        !$omp target enter data map(always, to: sendtasks, recvtasks)
+
+        CALL count_selftasks(nselfsend, nselfrecv)
+        maxselftasks = 6 * (nselfsend + nselfrecv) + 1
+        ALLOCATE(selftasks(selftasksize, maxselftasks))
+        !$omp target enter data map(always, to: selftasks)
+
+        ! MPI tasks are only used on the host and do not exceed isend/irecv+1
+        maxmpisendtasks = isend + 1
+        maxmpirecvtasks = irecv + 1
+        ALLOCATE(mpisendtasks(mpitasksize, maxmpisendtasks))
+        ALLOCATE(mpirecvtasks(mpitasksize, maxmpirecvtasks))
+
+        ! Allocate the workrecords array for all possible types of parent
+        ! dimension 1 = ilevel
+        ! dimension 2 = argument combination (6 bits = 2^6-1 = 63)
+        ! dimension 3 = flag (any ASCII char from '*'=42 to 'Z'=90)
+        ALLOCATE(workrecords(minlevel:maxlevel, 1:63, IACHAR('*'):IACHAR('Z')))
+
+        CALL check_sendbuf_capacity()
+
         is_init = .TRUE.
+
+        ! Record relevant calls for later efficient reuse on device
+        CALL run_recording_pass()
     END SUBROUTINE init_ftoc2
+
+
+    SUBROUTINE check_sendbuf_capacity()
+        ! Subroutine arguments
+        ! none...
+
+        ! Local variables
+        INTEGER(intk) :: i, iprocnbr, igridf
+        INTEGER(int32) :: sendcells, selfcells, ncells, messagelength
+
+        sendcells = 0
+        selfcells = 0
+
+        DO i = 1, isend
+            iprocnbr = sendconns(2, i)
+            igridf = sendconns(3, i)
+
+            ncells = 0
+            CALL message_length(messagelength, 'U', igridf)
+            ncells = ncells + messagelength
+            CALL message_length(messagelength, 'V', igridf)
+            ncells = ncells + messagelength
+            CALL message_length(messagelength, 'W', igridf)
+            ncells = ncells + messagelength
+            CALL message_length(messagelength, 'P', igridf)
+            ncells = ncells + 3*messagelength
+
+            IF (iprocnbr == myid) THEN
+                selfcells = selfcells + ncells
+            ELSE
+                sendcells = sendcells + ncells
+            END IF
+        END DO
+
+        IF (sendcells + selfcells > idim_mg_bufs) THEN
+            WRITE(*, *) "ftoc2 sendbuf too small for send+self upper bound."
+            WRITE(*, *) "send cells:", sendcells, " self cells:", selfcells
+            WRITE(*, *) "required:", sendcells+selfcells, &
+                " available:", idim_mg_bufs
+            CALL errr(__FILE__, __LINE__)
+        END IF
+    END SUBROUTINE check_sendbuf_capacity
+
+
+    SUBROUTINE run_recording_pass()
+        ! Subroutine arguments
+        ! none...
+
+        ! Local variables
+        TYPE(field_t) :: udummy, vdummy, wdummy, pdummy
+        INTEGER(intk) :: ilevel
+
+        is_recording = .TRUE.
+
+        CALL udummy%init("U_DUMMY", istag=1)
+        CALL vdummy%init("V_DUMMY", jstag=1)
+        CALL wdummy%init("W_DUMMY", kstag=1)
+        CALL pdummy%init("P_DUMMY")
+
+        !$omp target enter data map(to: udummy%arr, vdummy%arr, wdummy%arr, &
+        !$omp& pdummy%arr)
+
+        ! START -- This section defines the record variants of ftoc2 ---
+
+        DO ilevel = maxlevel, minlevel, -1
+            ! Outer pressuresolver iterations
+            CALL ftoc2(ilevel, pdummy, pdummy, flag='P')
+            ! Pre pressuresolver iterations in mgpoisl
+            CALL ftoc2(ilevel, pdummy, pdummy, flag='R')
+            ! Post pressuresolver iterations in mgpoisl
+            CALL ftoc2(ilevel, udummy, vdummy, wdummy, pdummy)
+        END DO
+
+        ! END -- This section defines the record variants of ftoc2 ---
+
+        !$omp target exit data map(delete: udummy%arr, vdummy%arr, wdummy%arr, &
+        !$omp& pdummy%arr)
+
+        CALL udummy%finish()
+        CALL vdummy%finish()
+        CALL wdummy%finish()
+        CALL pdummy%finish()
+
+        is_recording = .FALSE.
+    END SUBROUTINE run_recording_pass
+
+
+    SUBROUTINE count_selftasks(nselfsend, nselfrecv)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(out) :: nselfsend, nselfrecv
+
+        ! Local variables
+        INTEGER(intk) :: i, iprocnbr
+
+        nselfsend = 0
+        DO i = 1, isend
+            iprocnbr = sendconns(2, i)
+            IF (iprocnbr == myid) THEN
+                nselfsend = nselfsend + 1
+            END IF
+        END DO
+
+        nselfrecv = 0
+        DO i = 1, irecv
+            iprocnbr = recvconns(1, i)
+            IF (iprocnbr == myid) THEN
+                nselfrecv = nselfrecv + 1
+            END IF
+        END DO
+
+        IF (nselfsend /= nselfrecv) THEN
+            CALL errr(__FILE__, __LINE__)
+        END IF
+    END SUBROUTINE count_selftasks
 
 
     SUBROUTINE finish_ftoc2()
@@ -95,13 +2046,50 @@ CONTAINS
 
         IF (.NOT. is_init) CALL errr(__FILE__, __LINE__)
 
+        nsend = 0
+        nrecv = 0
         DEALLOCATE(recvreqs)
         DEALLOCATE(sendreqs)
         DEALLOCATE(recvlist)
         DEALLOCATE(recvidxlist)
-        nsend = 0
-        nrecv = 0
+
+        !$omp target exit data map(always, delete: sendtasks, recvtasks, &
+        !$omp& selftasks)
+        DEALLOCATE(sendtasks)
+        DEALLOCATE(recvtasks)
+        DEALLOCATE(selftasks)
+
+        DEALLOCATE(mpisendtasks)
+        DEALLOCATE(mpirecvtasks)
+
+        CALL purge_workrecords()
+        DEALLOCATE(workrecords)
 
         is_init = .FALSE.
     END SUBROUTINE finish_ftoc2
+
+
+    SUBROUTINE purge_workrecords()
+        ! Subroutine arguments
+        ! none...
+
+        ! Local variables
+        TYPE(work_t), POINTER :: wrptr(:)
+        INTEGER(intk) :: i
+
+        wrptr(1:SIZE(workrecords)) => workrecords
+
+        DO i = 1, SIZE(workrecords)
+            IF (.NOT. wrptr(i)%is_init) CYCLE
+
+            !$omp target exit data map(delete: wrptr(i)%sendtasks, &
+            !$omp& wrptr(i)%recvtasks, wrptr(i)%selftasks)
+            DEALLOCATE(wrptr(i)%sendtasks)
+            DEALLOCATE(wrptr(i)%recvtasks)
+            DEALLOCATE(wrptr(i)%selftasks)
+            DEALLOCATE(wrptr(i)%mpisendtasks)
+            DEALLOCATE(wrptr(i)%mpirecvtasks)
+            wrptr(i)%is_init = .FALSE.
+        END DO
+    END SUBROUTINE purge_workrecords
 END MODULE ftoc2_mod

--- a/src/ib/ftoc/ftoc2_mod.F90
+++ b/src/ib/ftoc/ftoc2_mod.F90
@@ -1,0 +1,107 @@
+MODULE ftoc2_mod
+    USE MPI_f08
+    USE core_mod
+    USE ftoc_core_mod
+    USE ibcore_mod, ONLY: ib
+    USE restrict_mod, ONLY: restrict, message_length, start_and_stop
+
+    IMPLICIT NONE (type, external)
+    PRIVATE
+
+    ! Lists that hold the send and receive request arrays
+    TYPE(MPI_Request), ALLOCATABLE :: sendreqs(:), recvreqs(:)
+
+    ! Lists that hold the messages that are ACTUALLY sendt and received
+    INTEGER(intk) :: nsend, nrecv
+    INTEGER(int32), ALLOCATABLE :: recvlist(:)
+    INTEGER(intk), ALLOCATABLE :: recvidxlist(:, :)
+
+    ! Variable to indicate if the required data structures have been created
+    LOGICAL :: is_init = .FALSE.
+
+    INTERFACE ftoc2
+        MODULE PROCEDURE :: ftoc2_one, ftoc2_multiple
+    END INTERFACE ftoc2
+
+    ! contained functions
+    PUBLIC :: ftoc2, init_ftoc2, finish_ftoc2
+CONTAINS
+    SUBROUTINE ftoc2_one(ilevel, ff, fc, flag)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: ilevel
+        TYPE(field_t), INTENT(in) :: ff
+        TYPE(field_t), INTENT(inout) :: fc
+        CHARACTER(len=1), INTENT(in) :: flag
+
+        ! Local variables
+        ! none...
+
+
+        IF (.NOT. is_init) CALL errr(__FILE__, __LINE__)
+
+        ! TODO(offload): implement
+
+        nrecv = 0
+        nsend = 0
+    END SUBROUTINE ftoc2_one
+
+
+    SUBROUTINE ftoc2_multiple(ilevel, v1, v2, v3, s1, s2, s3)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: ilevel
+        TYPE(field_t), INTENT(inout), OPTIONAL :: v1, v2, v3, s1, s2, s3
+
+        ! Local variables
+        CHARACTER(len=*), PARAMETER :: flag = '*'
+
+        IF (.NOT. is_init) CALL errr(__FILE__, __LINE__)
+
+        ! TODO(offload): implement
+
+        nrecv = 0
+        nsend = 0
+    END SUBROUTINE ftoc2_multiple
+
+
+    SUBROUTINE init_ftoc2()
+        ! Subroutine arguments
+        ! none...
+
+        ! Local variables
+        ! none...
+
+        IF (is_init) CALL errr(__FILE__, __LINE__)
+
+        ! Check if ctof_core_mod provides necessary infrastructure
+        IF (.NOT. is_ftoc_core_init) CALL errr(__FILE__, __LINE__)
+
+        ALLOCATE(recvidxlist(3, irecv), source=0_intk)
+        ALLOCATE(recvlist(irecv), source=0_int32)
+        ALLOCATE(sendreqs(numprocs), source=MPI_REQUEST_NULL)
+        ALLOCATE(recvreqs(numprocs), source=MPI_REQUEST_NULL)
+        nsend = 0
+        nrecv = 0
+
+        is_init = .TRUE.
+    END SUBROUTINE init_ftoc2
+
+
+    SUBROUTINE finish_ftoc2()
+        ! Subroutine arguments
+        ! none...
+
+        ! Local variables
+        ! none...
+
+        IF (.NOT. is_init) CALL errr(__FILE__, __LINE__)
+
+        DEALLOCATE(recvreqs)
+        DEALLOCATE(sendreqs)
+        DEALLOCATE(recvlist)
+        DEALLOCATE(recvidxlist)
+        nsend = 0
+        nrecv = 0
+
+        is_init = .FALSE.
+    END SUBROUTINE finish_ftoc2
+END MODULE ftoc2_mod

--- a/src/ib/ftoc/ftoc_core_mod.F90
+++ b/src/ib/ftoc/ftoc_core_mod.F90
@@ -1,0 +1,169 @@
+MODULE ftoc_core_mod
+    USE core_mod
+    USE MPI_f08
+    USE restrict_mod, ONLY: message_length
+
+    IMPLICIT NONE (type, external)
+    PRIVATE
+
+    ! The information in the first dimension is sorted as follows:
+    !   Field 1: Rank of sending process
+    !   Field 2: Rank of receiving process
+    !   Field 3: ID of sending grid (fine grid)
+    !   Field 4: ID of receiving grid (coarse grid)
+    INTEGER(intk), ALLOCATABLE, PROTECTED :: sendconns(:, :), recvconns(:, :)
+
+    ! Number of send and receive connections
+    INTEGER(intk), PROTECTED :: isend = 0, irecv = 0
+
+    ! Variable to indicate if the required data structures have been created
+    LOGICAL, PROTECTED :: is_ftoc_core_init = .FALSE.
+
+    ! Public read-only variables
+    PUBLIC :: sendconns, recvconns, isend, irecv, is_ftoc_core_init
+
+    ! Public subroutines
+    PUBLIC :: init_ftoc_core, finish_ftoc_core, count_ncells
+CONTAINS
+    SUBROUTINE init_ftoc_core()
+        ! Subroutine arguments
+        ! none...
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid, iprocc, ipar, maxconns, nsend
+        INTEGER(int32), ALLOCATABLE :: sendcounts(:), sdispls(:)
+        INTEGER(int32), ALLOCATABLE :: recvcounts(:), rdispls(:)
+        INTEGER(intk), PARAMETER :: ncols = 4
+
+        IF (is_ftoc_core_init) CALL errr(__FILE__, __LINE__)
+
+        CALL set_timer(220, "FTOC")
+
+        maxconns = nmygrids*8
+        ALLOCATE(sendconns(ncols, maxconns))
+
+        ALLOCATE(sendcounts(0:numprocs-1), source=0)
+        ALLOCATE(sdispls(0:numprocs-1), source=0)
+        ALLOCATE(recvcounts(0:numprocs-1), source=0)
+        ALLOCATE(rdispls(0:numprocs-1), source=0)
+
+        nsend = 0
+        DO i = 1, nmygrids
+            igrid = mygrids(i)
+            ipar = iparent(igrid)
+            IF (ipar == 0) CYCLE
+
+            iprocc = idprocofgrd(ipar)
+
+            nsend = nsend + 1
+            IF (nsend > maxconns) THEN
+                CALL errr(__FILE__, __LINE__)
+            END IF
+
+            sendconns(1, nsend) = myid
+            sendconns(2, nsend) = iprocc
+            sendconns(3, nsend) = igrid
+            sendconns(4, nsend) = ipar
+
+            sendcounts(iprocc) = sendcounts(iprocc) + ncols
+        END DO
+        isend = nsend
+
+        ! Sort sendconns by process ID (col 2)
+        CALL sort_conns(sendconns(:, 1:nsend), 2)
+
+        ! Calculate sdispl offset
+        DO i = 1, numprocs-1
+            sdispls(i) = sdispls(i-1) + sendcounts(i-1)
+        END DO
+
+        ! First exchange NUMBER OF ELEMENTS TO RECEIVE, to be able to
+        ! calculate rdispls array
+        CALL MPI_Alltoall(sendcounts, 1, MPI_INTEGER, recvcounts, 1, &
+            MPI_INTEGER, MPI_COMM_WORLD)
+
+        ! Calculate rdispl offset
+        DO i = 1, numprocs-1
+            rdispls(i) = rdispls(i-1) + recvcounts(i-1)
+        END DO
+
+        irecv = (rdispls(numprocs-1) + recvcounts(numprocs-1))/ncols
+        ALLOCATE(recvconns(ncols, irecv))
+        recvconns = 0
+
+        ! Exchange connection information
+        CALL MPI_Alltoallv(sendconns, sendcounts, sdispls, MPI_INTEGER, &
+            recvconns, recvcounts, rdispls, MPI_INTEGER, &
+            MPI_COMM_WORLD)
+
+        DEALLOCATE(rdispls)
+        DEALLOCATE(recvcounts)
+        DEALLOCATE(sdispls)
+        DEALLOCATE(sendcounts)
+
+        is_ftoc_core_init = .TRUE.
+        nsend = 0
+    END SUBROUTINE init_ftoc_core
+
+
+    SUBROUTINE count_ncells(ncells, flag, igrid, v1, v2, v3, s1, s2, s3)
+        ! Subroutine arguments
+        INTEGER(int32), INTENT(out) :: ncells
+        CHARACTER(len=1), INTENT(in) :: flag
+        INTEGER(intk), INTENT(in) :: igrid
+        TYPE(field_t), INTENT(in), OPTIONAL :: v1, v2, v3, s1, s2, s3
+
+        ! Local variables
+        INTEGER(int32) :: messagelength
+
+        ncells = 0
+
+        IF (flag == '*') THEN
+            IF (PRESENT(v1)) THEN
+                CALL message_length(messagelength, 'U', igrid)
+                ncells = ncells + messagelength
+            END IF
+            IF (PRESENT(v2)) THEN
+                CALL message_length(messagelength, 'V', igrid)
+                ncells = ncells + messagelength
+            END IF
+            IF (PRESENT(v3)) THEN
+                CALL message_length(messagelength, 'W', igrid)
+                ncells = ncells + messagelength
+            END IF
+            IF (PRESENT(s1)) THEN
+                CALL message_length(messagelength, 'P', igrid)
+                ncells = ncells + messagelength
+            END IF
+            IF (PRESENT(s2)) THEN
+                CALL message_length(messagelength, 'P', igrid)
+                ncells = ncells + messagelength
+            END IF
+            IF (PRESENT(s3)) THEN
+                CALL message_length(messagelength, 'P', igrid)
+                ncells = ncells + messagelength
+            END IF
+        ELSE
+            CALL message_length(messagelength, flag, igrid)
+            ncells = ncells + messagelength
+        END IF
+    END SUBROUTINE count_ncells
+
+
+    SUBROUTINE finish_ftoc_core()
+        ! Subroutine arguments
+        ! none...
+
+        ! Local variables
+        ! none...
+
+        IF (.NOT. is_ftoc_core_init) CALL errr(__FILE__, __LINE__)
+
+        DEALLOCATE(sendconns)
+        DEALLOCATE(recvconns)
+        isend = 0
+        irecv = 0
+
+        is_ftoc_core_init = .FALSE.
+    END SUBROUTINE finish_ftoc_core
+END MODULE ftoc_core_mod

--- a/src/ib/ftoc/ftoc_mod.F90
+++ b/src/ib/ftoc/ftoc_mod.F90
@@ -30,6 +30,9 @@ CONTAINS
         LOGICAL :: device2
 #endif
 
+        ! The coarsest level cannot restrict values to a coarser level
+        IF (ilevel == minlevel) RETURN
+
         IF (.NOT. is_ftoc_core_init) CALL errr(__FILE__, __LINE__)
 
         CALL start_timer(220)

--- a/src/ib/ftoc/ftoc_mod.F90
+++ b/src/ib/ftoc/ftoc_mod.F90
@@ -1,0 +1,120 @@
+MODULE ftoc_mod
+    USE MPI_f08
+    USE core_mod
+    USE ftoc_core_mod
+    USE ftoc1_mod
+    USE ftoc2_mod
+
+    IMPLICIT NONE (type, external)
+    PRIVATE
+
+    INTERFACE ftoc
+        MODULE PROCEDURE :: ftoc_one, ftoc_multiple
+    END INTERFACE ftoc
+
+    ! No state in this module
+    ! Acts only as a dispatcher for ftoc1 and ftoc2
+
+    PUBLIC :: ftoc, init_ftoc, finish_ftoc
+CONTAINS
+    SUBROUTINE ftoc_one(ilevel, ff, fc, flag, device)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: ilevel
+        TYPE(field_t), INTENT(in) :: ff
+        TYPE(field_t), INTENT(inout) :: fc
+        CHARACTER(len=1), INTENT(in) :: flag
+        LOGICAL, OPTIONAL, INTENT(in) :: device
+
+#ifdef _MGLET_OFFLOAD_
+        ! Local variables
+        LOGICAL :: device2
+#endif
+
+        IF (.NOT. is_ftoc_core_init) CALL errr(__FILE__, __LINE__)
+
+        CALL start_timer(220)
+
+#ifdef _MGLET_OFFLOAD_
+        IF (PRESENT(device)) THEN
+            device2 = device
+        ELSE
+            device2 = .FALSE.
+        END IF
+
+        IF (device2) THEN
+            CALL ftoc2(ilevel, ff, fc, flag)
+        ELSE
+            CALL ftoc1(ilevel, ff, fc, flag)
+        END IF
+#else
+        CALL ftoc1(ilevel, ff, fc, flag)
+#endif
+
+        CALL stop_timer(220)
+    END SUBROUTINE ftoc_one
+
+
+    SUBROUTINE ftoc_multiple(ilevel, v1, v2, v3, s1, s2, s3, device)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: ilevel
+        TYPE(field_t), INTENT(inout), OPTIONAL :: v1, v2, v3, s1, s2, s3
+        LOGICAL, OPTIONAL, INTENT(in) :: device
+
+#ifdef _MGLET_OFFLOAD_
+        ! Local variables
+        LOGICAL :: device2
+#endif
+
+        CALL start_timer(220)
+
+        IF (.NOT. is_ftoc_core_init) CALL errr(__FILE__, __LINE__)
+
+#ifdef _MGLET_OFFLOAD_
+        IF (PRESENT(device)) THEN
+            device2 = device
+        ELSE
+            device2 = .FALSE.
+        END IF
+
+        IF (device2) THEN
+            CALL ftoc2(ilevel, v1, v2, v3, s1, s2, s3)
+        ELSE
+            CALL ftoc1(ilevel, v1, v2, v3, s1, s2, s3)
+        END IF
+#else
+        CALL ftoc1(ilevel, v1, v2, v3, s1, s2, s3)
+#endif
+
+        CALL stop_timer(220)
+    END SUBROUTINE ftoc_multiple
+
+
+    SUBROUTINE init_ftoc()
+        ! Subroutine arguments
+        ! none...
+
+        ! Local variables
+        ! none...
+
+        CALL init_ftoc_core()
+        CALL init_ftoc1()
+#ifdef _MGLET_OFFLOAD_
+        CALL init_ftoc2()
+#endif
+    END SUBROUTINE init_ftoc
+
+
+    SUBROUTINE finish_ftoc()
+        ! Subroutine arguments
+        ! none...
+
+        ! Local variables
+        ! none...
+
+        CALL finish_ftoc_core()
+        CALL finish_ftoc1()
+#ifdef _MGLET_OFFLOAD_
+        CALL finish_ftoc2()
+#endif
+    END SUBROUTINE finish_ftoc
+END MODULE ftoc_mod

--- a/src/ib/gc_restrict_mod.F90
+++ b/src/ib/gc_restrict_mod.F90
@@ -20,67 +20,46 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
-        INTEGER(intk) :: i, j, k, icount
-        INTEGER(intk) :: nk, ink
+        INTEGER(intk) :: i, j, k, idx, nj, nk
 
-        REAL(realk) :: vol1(kk), vol2(kk), vol3(kk), vol4(kk)
-        REAL(realk) :: pv1(kk), pv2(kk), pv3(kk), pv4(kk)
+        REAL(realk) :: vol1, vol2, vol3, vol4, vol5, vol6, vol7, vol8
         REAL(realk) :: sum_pv, sum_v
 
+        nj = (jstop-jstart)/2+1
         ! Number of k iterations
         ! (not to be confused with kk - these are not the same!!!)
         nk = (kstop-kstart)/2+1
 
-        icount = 0
+        !$omp parallel do collapse(3) private(i, j, k, vol1, vol2, vol3, vol4, &
+        !$omp& vol5, vol6, vol7, vol8, sum_pv, sum_v, idx)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
-                ! Vomume
-                DO k = kstart, kstop+1
-                    vol1(k) = b(k, j, i)*ddz(k)*ddy(j)*ddx(i)
-                END DO
-                DO k = kstart, kstop+1
-                    vol2(k) = b(k, j, i+1)*ddz(k)*ddy(j)*ddx(i+1)
-                END DO
-                DO k = kstart, kstop+1
-                    vol3(k) = b(k, j+1, i)*ddz(k)*ddy(j+1)*ddx(i)
-                END DO
-                DO k = kstart, kstop+1
-                    vol4(k) = b(k, j+1, i+1)*ddz(k)*ddy(j+1)*ddx(i+1)
-                END DO
+                DO k = kstart, kstop, 2
+                    vol1 = b(k, j, i)*ddz(k)*ddy(j)*ddx(i)
+                    vol2 = b(k, j, i+1)*ddz(k)*ddy(j)*ddx(i+1)
+                    vol3 = b(k, j+1, i)*ddz(k)*ddy(j+1)*ddx(i)
+                    vol4 = b(k, j+1, i+1)*ddz(k)*ddy(j+1)*ddx(i+1)
+                    vol5 = b(k+1, j, i)*ddz(k+1)*ddy(j)*ddx(i)
+                    vol6 = b(k+1, j, i+1)*ddz(k+1)*ddy(j)*ddx(i+1)
+                    vol7 = b(k+1, j+1, i)*ddz(k+1)*ddy(j+1)*ddx(i)
+                    vol8 = b(k+1, j+1, i+1)*ddz(k+1)*ddy(j+1)*ddx(i+1)
 
-                ! Pressure times volume
-                DO k = kstart, kstop+1
-                    pv1(k) = ff(k, j, i)*vol1(k)
-                END DO
-                DO k = kstart, kstop+1
-                    pv2(k) = ff(k, j, i+1)*vol2(k)
-                END DO
-                DO k = kstart, kstop+1
-                    pv3(k) = ff(k, j+1, i)*vol3(k)
-                END DO
-                DO k = kstart, kstop+1
-                    pv4(k) = ff(k, j+1, i+1)*vol4(k)
-                END DO
+                    sum_pv = ff(k, j, i)*vol1 + ff(k, j, i+1)*vol2 &
+                        + ff(k, j+1, i)*vol3 + ff(k, j+1, i+1)*vol4 &
+                        + ff(k+1, j, i)*vol5 + ff(k+1, j, i+1)*vol6 &
+                        + ff(k+1, j+1, i)*vol7 + ff(k+1, j+1, i+1)*vol8
 
-                ! Sum up and divide
-                DO ink = 1, nk
-                    k = kstart + 2*(ink-1)
+                    sum_v = vol1 + vol2 + vol3 + vol4 &
+                        + vol5 + vol6 + vol7 + vol8
 
-                    sum_pv = pv1(k) + pv2(k) + pv3(k) + pv4(k) &
-                        + pv1(k+1) + pv2(k+1) + pv3(k+1) + pv4(k+1)
-
-                    sum_v = vol1(k) + vol2(k) + vol3(k) + vol4(k) &
-                        + vol1(k+1) + vol2(k+1) + vol3(k+1) + vol4(k+1)
-
+                    idx = ((i-istart)/2*nj+(j-jstart)/2)*nk &
+                        +(k-kstart)/2+1
                     IF (sum_v > 0.0) THEN
-                        sbuf(icount + ink) = sum_pv/sum_v
+                        sbuf(idx) = sum_pv/sum_v
                     ELSE
-                        sbuf(icount + ink) = 0.0
+                        sbuf(idx) = 0.0
                     END IF
                 END DO
-
-                ! Increment counter
-                icount = icount + nk
 
                 ! Legacy code - keep for reference
                 ! DO k = kstart, kstop, 2
@@ -107,6 +86,7 @@ CONTAINS
                 ! END DO
             END DO
         END DO
+        !$omp end parallel do
     END SUBROUTINE restrict_gc_p_t
 
 
@@ -123,50 +103,39 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
-        INTEGER(intk) :: i, j, k, icount
-        INTEGER(intk) :: nk, ink
+        INTEGER(intk) :: i, j, k, idx, nj, nk
 
-        REAL(realk) :: pv1(kk), pv2(kk), pv3(kk), pv4(kk)
         REAL(realk) :: sum_pv, sum_v
 
+        nj = (jstop-jstart)/2+1
         ! Number of k iterations
         ! (not to be confused with kk - these are not the same!!!)
         nk = (kstop-kstart)/2+1
 
-        icount = 0
+        !$omp parallel do collapse(3) private(i, j, k, sum_pv, sum_v, idx)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
-
-                ! Vomume
-                DO k = kstart, kstop+1
-                    pv1(k) = ff(k, j, i)*bp(k, j, i)*ddz(k)*ddy(j)*ddx(i)
-                END DO
-                DO k = kstart, kstop+1
-                    pv2(k) = ff(k, j, i+1)*bp(k, j, i+1)*ddz(k)*ddy(j)*ddx(i+1)
-                END DO
-                DO k = kstart, kstop+1
-                    pv3(k) = ff(k, j+1, i)*bp(k, j+1, i)*ddz(k)*ddy(j+1)*ddx(i)
-                END DO
-                DO k = kstart, kstop+1
-                    pv4(k) = ff(k, j+1, i+1)*bp(k, j+1, i+1) &
-                        *ddz(k)*ddy(j+1)*ddx(i+1)
-                END DO
-
-                ! Sum up and divide
-                DO ink = 1, nk
-                    k = kstart + 2*(ink-1)
-
-                    sum_pv = pv1(k) + pv2(k) + pv3(k) + pv4(k) &
-                        + pv1(k+1) + pv2(k+1) + pv3(k+1) + pv4(k+1)
+                DO k = kstart, kstop, 2
+                    sum_pv = ff(k, j, i)*bp(k, j, i)*ddz(k)*ddy(j)*ddx(i) &
+                        + ff(k, j, i+1)*bp(k, j, i+1)*ddz(k)*ddy(j)*ddx(i+1) &
+                        + ff(k, j+1, i)*bp(k, j+1, i)*ddz(k)*ddy(j+1)*ddx(i) &
+                        + ff(k, j+1, i+1)*bp(k, j+1, i+1) &
+                        *ddz(k)*ddy(j+1)*ddx(i+1) &
+                        + ff(k+1, j, i)*bp(k+1, j, i)*ddz(k+1)*ddy(j)*ddx(i) &
+                        + ff(k+1, j, i+1)*bp(k+1, j, i+1) &
+                        *ddz(k+1)*ddy(j)*ddx(i+1) &
+                        + ff(k+1, j+1, i)*bp(k+1, j+1, i) &
+                        *ddz(k+1)*ddy(j+1)*ddx(i) &
+                        + ff(k+1, j+1, i+1)*bp(k+1, j+1, i+1) &
+                        *ddz(k+1)*ddy(j+1)*ddx(i+1)
 
                     sum_v = (ddx(i) + ddx(i+1))*(ddy(j) + ddy(j+1)) &
                         *(ddz(k) + ddz(k+1))
 
-                    sbuf(icount + ink) = sum_pv/sum_v
+                    idx = ((i-istart)/2*nj+(j-jstart)/2)*nk &
+                        +(k-kstart)/2+1
+                    sbuf(idx) = sum_pv/sum_v
                 END DO
-
-                ! Increment counter
-                icount = icount + nk
 
                 ! Legacy code - keep for reference
                 ! DO k = kstart, kstop, 2
@@ -187,6 +156,7 @@ CONTAINS
                 ! END DO
             END DO
         END DO
+        !$omp end parallel do
     END SUBROUTINE restrict_gc_r
 
 
@@ -201,17 +171,22 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
-        INTEGER(intk) :: i, j, k, icount
+        INTEGER(intk) :: i, j, k, idx, nj, nk
 
-        icount = 0
+        nj = (jstop-jstart)/2+1
+        nk = (kstop-kstart)/2+1
+
+        !$omp parallel do collapse(3) private(i, j, k, idx)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
-                    icount = icount + 1
-                    sbuf(icount) = ff(k, j, i)
+                    idx = ((i-istart)/2*nj+(j-jstart)/2)*nk &
+                        +(k-kstart)/2+1
+                    sbuf(idx) = ff(k, j, i)
                 END DO
             END DO
         END DO
+        !$omp end parallel do
     END SUBROUTINE restrict_gc_n
 
 
@@ -226,16 +201,20 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
-        INTEGER(intk) :: i, j, k, icount
+        INTEGER(intk) :: i, j, k, idx, nj, nk
 
-        icount = 0
+        nj = (jstop-jstart)/2+1
+        nk = (kstop-kstart)/2+1
+
+        !$omp parallel do collapse(3) private(i, j, k, idx)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
-                    icount = icount + 1
                     ! TODO: Check purpose of MIN(1.0, ...) MAX(...) is never
                     ! greater than 1 ???
-                    sbuf(icount) = MIN(1.0_realk, MAX(ff(k, j, i), &
+                    idx = ((i-istart)/2*nj+(j-jstart)/2)*nk &
+                        +(k-kstart)/2+1
+                    sbuf(idx) = MIN(1.0_realk, MAX(ff(k, j, i), &
                         ff(k, j, i+1), &
                         ff(k, j+1, i), &
                         ff(k, j+1, i+1), &
@@ -246,6 +225,7 @@ CONTAINS
                 END DO
             END DO
         END DO
+        !$omp end parallel do
     END SUBROUTINE restrict_gc_e
 
 
@@ -260,14 +240,18 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
-        INTEGER(intk) :: i, j, k, icount
+        INTEGER(intk) :: i, j, k, idx, nj, nk
 
-        icount = 0
+        nj = (jstop-jstart)/2+1
+        nk = (kstop-kstart)/2+1
+
+        !$omp parallel do collapse(3) private(i, j, k, idx)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
-                    icount = icount + 1
-                    sbuf(icount) = MIN(2.0_realk, MAX(ff(k, j, i), &
+                    idx = ((i-istart)/2*nj+(j-jstart)/2)*nk &
+                        +(k-kstart)/2+1
+                    sbuf(idx) = MIN(2.0_realk, MAX(ff(k, j, i), &
                         ff(k, j, i+1), &
                         ff(k, j+1, i), &
                         ff(k, j+1, i+1), &
@@ -278,6 +262,7 @@ CONTAINS
                 END DO
             END DO
         END DO
+        !$omp end parallel do
     END SUBROUTINE restrict_gc_f
 
 
@@ -292,14 +277,18 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
-        INTEGER(intk) :: i, j, k, icount
+        INTEGER(intk) :: i, j, k, idx, nj, nk
 
-        icount = 0
+        nj = (jstop-jstart)/2+1
+        nk = (kstop-kstart)/2+1
+
+        !$omp parallel do collapse(3) private(i, j, k, idx)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
-                    icount = icount + 1
-                    sbuf(icount) = MAX(ff(k, j, i), &
+                    idx = ((i-istart)/2*nj+(j-jstart)/2)*nk &
+                        +(k-kstart)/2+1
+                    sbuf(idx) = MAX(ff(k, j, i), &
                         ff(k, j, i+1), &
                         ff(k, j+1, i), &
                         ff(k, j+1, i+1), &
@@ -322,5 +311,6 @@ CONTAINS
                 END DO
             END DO
         END DO
+        !$omp end parallel do
     END SUBROUTINE restrict_gc_i
 END MODULE gc_restrict_mod

--- a/src/ib/noib_restrict_mod.F90
+++ b/src/ib/noib_restrict_mod.F90
@@ -18,10 +18,13 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
-        INTEGER(intk) :: i, j, k, icount
+        INTEGER(intk) :: i, j, k, idx, nj, nk
         REAL(realk) :: sum_ua, sum_a
 
-        icount = 0
+        nj = (jstop-jstart)/2+1
+        nk = (kstop-kstart)/2+1
+
+        !$omp parallel do collapse(3) private(i, j, k, idx, sum_ua, sum_a)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
@@ -32,11 +35,13 @@ CONTAINS
 
                     sum_a = (ddy(j) + ddy(j+1))*(ddz(k) + ddz(k+1))
 
-                    icount = icount + 1
-                    sbuf(icount) = sum_ua/sum_a
+                    idx = ((i-istart)/2*nj+(j-jstart)/2)*nk &
+                        +(k-kstart)/2+1
+                    sbuf(idx) = sum_ua/sum_a
                 END DO
             END DO
         END DO
+        !$omp end parallel do
     END SUBROUTINE restrict_noib_u
 
 
@@ -52,10 +57,13 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
-        INTEGER(intk) :: i, j, k, icount
+        INTEGER(intk) :: i, j, k, idx, nj, nk
         REAL(realk) :: sum_va, sum_a
 
-        icount = 0
+        nj = (jstop-jstart)/2+1
+        nk = (kstop-kstart)/2+1
+
+        !$omp parallel do collapse(3) private(i, j, k, idx, sum_va, sum_a)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
@@ -66,11 +74,13 @@ CONTAINS
 
                     sum_a = (ddx(i) + ddx(i+1))*(ddz(k) + ddz(k+1))
 
-                    icount = icount + 1
-                    sbuf(icount) = sum_va/sum_a
+                    idx = ((i-istart)/2*nj+(j-jstart)/2)*nk &
+                        +(k-kstart)/2+1
+                    sbuf(idx) = sum_va/sum_a
                 END DO
             END DO
         END DO
+        !$omp end parallel do
     END SUBROUTINE restrict_noib_v
 
 
@@ -86,10 +96,13 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
-        INTEGER(intk) :: i, j, k, icount
+        INTEGER(intk) :: i, j, k, idx, nj, nk
         REAL(realk) :: sum_wa, sum_a
 
-        icount = 0
+        nj = (jstop-jstart)/2+1
+        nk = (kstop-kstart)/2+1
+
+        !$omp parallel do collapse(3) private(i, j, k, idx, sum_wa, sum_a)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
@@ -100,11 +113,13 @@ CONTAINS
 
                     sum_a = (ddx(i) + ddx(i+1))*(ddy(j) + ddy(j+1))
 
-                    icount = icount + 1
-                    sbuf(icount) = sum_wa/sum_a
+                    idx = ((i-istart)/2*nj+(j-jstart)/2)*nk &
+                        +(k-kstart)/2+1
+                    sbuf(idx) = sum_wa/sum_a
                 END DO
             END DO
         END DO
+        !$omp end parallel do
     END SUBROUTINE restrict_noib_w
 
 
@@ -120,10 +135,13 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
 
         ! Local variables
-        INTEGER(intk) :: i, j, k, icount
+        INTEGER(intk) :: i, j, k, idx, nj, nk
         REAL(realk) :: sum_pv, sum_v
 
-        icount = 0
+        nj = (jstop-jstart)/2+1
+        nk = (kstop-kstart)/2+1
+
+        !$omp parallel do collapse(3) private(i, j, k, idx, sum_pv, sum_v)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
@@ -139,10 +157,12 @@ CONTAINS
                     sum_v = (ddx(i) + ddx(i+1))*(ddy(j) + ddy(j+1)) &
                         *(ddz(k) + ddz(k+1))
 
-                    icount = icount + 1
-                    sbuf(icount) = sum_pv/sum_v
+                    idx = ((i-istart)/2*nj+(j-jstart)/2)*nk &
+                        +(k-kstart)/2+1
+                    sbuf(idx) = sum_pv/sum_v
                 END DO
             END DO
         END DO
+        !$omp end parallel do
     END SUBROUTINE restrict_noib_s
 END MODULE noib_restrict_mod

--- a/src/ib/restrict_mod.F90
+++ b/src/ib/restrict_mod.F90
@@ -12,7 +12,8 @@ MODULE restrict_mod
         MODULE PROCEDURE :: message_length_B
     END INTERFACE message_length
 
-    PUBLIC :: restrict, message_length, start_and_stop
+    PUBLIC :: restrict, message_length, start_and_stop, restrict_noib_flag, &
+        restrict_gc_flag
 CONTAINS
     SUBROUTINE restrict(ib, ctyp, field, igrid, offset)
         ! Subroutine arguments
@@ -66,29 +67,52 @@ CONTAINS
 
         CALL f_t%get_ptr(f, igrid)
 
-        SELECT CASE (ctyp)
-        CASE ("U")
-            CALL restrict_noib_u(kk, jj, ii, f, ddx, ddy, ddz, &
-                messagelength, sendbuf(offset:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE ("V")
-            CALL restrict_noib_v(kk, jj, ii, f, ddx, ddy, ddz, &
-                messagelength, sendbuf(offset:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE ("W")
-            CALL restrict_noib_w(kk, jj, ii, f, ddx, ddy, ddz, &
-                messagelength, sendbuf(offset:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE ("P", "R", "S", "T")
-            CALL restrict_noib_s(kk, jj, ii, f, ddx, ddy, ddz, &
-                messagelength, sendbuf(offset:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE DEFAULT
-            CALL errr(__FILE__, __LINE__)
-        END SELECT
+        CALL restrict_noib_flag(ctyp, kk, jj, ii, f, ddx, ddy, ddz, offset, &
+            messagelength, istart, istop, jstart, jstop, kstart, kstop)
 
         offset = offset + messagelength
     END SUBROUTINE restrict_noib
+
+
+    SUBROUTINE restrict_noib_flag(flag, kk, jj, ii, ff, ddx, ddy, ddz, offset, &
+            messagelength, istart, istop, jstart, jstop, kstart, kstop)
+        !$omp declare target
+        ! Subroutine arguments
+        CHARACTER(len=1), INTENT(in) :: flag
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(in) :: ff(kk, jj, ii)
+        REAL(realk), INTENT(in) :: ddx(ii), ddy(jj), ddz(kk)
+        INTEGER(int32), INTENT(in) :: offset, messagelength
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
+
+        ! Local variables
+        INTEGER(int32) :: targetidx
+
+        targetidx = offset + messagelength - 1
+
+        SELECT CASE (flag)
+        CASE ('U')
+            CALL restrict_noib_u(kk, jj, ii, ff, ddx, ddy, ddz, &
+                messagelength, sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ('V')
+            CALL restrict_noib_v(kk, jj, ii, ff, ddx, ddy, ddz, &
+                messagelength, sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ('W')
+            CALL restrict_noib_w(kk, jj, ii, ff, ddx, ddy, ddz, &
+                messagelength, sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+        CASE ('P', 'R', 'S', 'T')
+            CALL restrict_noib_s(kk, jj, ii, ff, ddx, ddy, ddz, &
+                messagelength, sendbuf(offset:targetidx), &
+                istart, istop, jstart, jstop, kstart, kstop)
+#ifdef _MGLET_DEBUG_
+        CASE DEFAULT
+            CALL errr(__FILE__, __LINE__)
+#endif
+        END SELECT
+    END SUBROUTINE restrict_noib_flag
 
 
     SUBROUTINE restrict_gc(ctyp, f_t, igrid, offset)
@@ -99,13 +123,13 @@ CONTAINS
         INTEGER(int32), INTENT(inout) :: offset
 
         ! Local variables
-        TYPE(field_t), POINTER :: ddx_f, ddy_f, ddz_f, b_f
-        REAL(realk), POINTER, CONTIGUOUS, DIMENSION(:, :, :) :: f, b
+        TYPE(field_t), POINTER :: ddx_f, ddy_f, ddz_f, bp_f, bt_f
+        REAL(realk), POINTER, CONTIGUOUS, DIMENSION(:, :, :) :: f, bp, bt
         REAL(realk), POINTER, CONTIGUOUS, DIMENSION(:) :: ddx, ddy, ddz
-
         INTEGER(intk) :: kk, jj, ii
         INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
         INTEGER(int32) :: messagelength, targetidx
+        LOGICAL :: foundbt
 
         CALL get_mgdims(kk, jj, ii, igrid)
         CALL start_and_stop(istart, istop, jstart, jstop, kstart, kstop, ctyp, &
@@ -117,70 +141,96 @@ CONTAINS
         CALL get_field(ddx_f, "DDX")
         CALL get_field(ddy_f, "DDY")
         CALL get_field(ddz_f, "DDZ")
+        CALL get_field(bp_f, "BP")
+        CALL get_field(bt_f, "BT", foundbt)
+        IF (.NOT. foundbt) THEN
+            ! For non-scalar cases, point bt to bp. It is unused anyways.
+            bt_f => bp_f
+        END IF
 
         CALL ddx_f%get_ptr(ddx, igrid)
         CALL ddy_f%get_ptr(ddy, igrid)
         CALL ddz_f%get_ptr(ddz, igrid)
+        CALL bp_f%get_ptr(bp, igrid)
+        CALL bt_f%get_ptr(bt, igrid)
 
         CALL f_t%get_ptr(f, igrid)
 
-        SELECT CASE (ctyp)
-        CASE ("U")
-            CALL restrict_noib_u(kk, jj, ii, f, ddx, ddy, ddz, &
-                messagelength, sendbuf(offset:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE ("V")
-            CALL restrict_noib_v(kk, jj, ii, f, ddx, ddy, ddz, &
-                messagelength, sendbuf(offset:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE ("W")
-            CALL restrict_noib_w(kk, jj, ii, f, ddx, ddy, ddz, &
-                messagelength, sendbuf(offset:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE ("P")
-            CALL get_field(b_f, "BP")
-            CALL b_f%get_ptr(b, igrid)
-            CALL restrict_gc_p_t(kk, jj, ii, f, ddx, ddy, ddz, b, &
-                messagelength, sendbuf(offset:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE ("T")
-            CALL get_field(b_f, "BT")
-            CALL b_f%get_ptr(b, igrid)
-            CALL restrict_gc_p_t(kk, jj, ii, f, ddx, ddy, ddz, b, &
-                messagelength, sendbuf(offset:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE ("R")
-            CALL get_field(b_f, "BP")
-            CALL b_f%get_ptr(b, igrid)
-            CALL restrict_gc_r(kk, jj, ii, f, ddx, ddy, ddz, b, &
-                messagelength, sendbuf(offset:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE ("S")
-            CALL restrict_noib_s(kk, jj, ii, f, ddx, ddy, ddz, &
-                messagelength, sendbuf(offset:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE ("N")
-            CALL restrict_gc_n(kk, jj, ii, f, messagelength, &
-                sendbuf(offset:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE ("E")
-            CALL restrict_gc_e(kk, jj, ii, f, messagelength, &
-                sendbuf(offset:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE ("F")
-            CALL restrict_gc_f(kk, jj, ii, f, messagelength, &
-                sendbuf(offset:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE ("I")
-            CALL restrict_gc_i(kk, jj, ii, f, messagelength, &
-                sendbuf(offset:targetidx), &
-                istart, istop, jstart, jstop, kstart, kstop)
-        CASE DEFAULT
-            CALL errr(__FILE__, __LINE__)
-        END SELECT
+        CALL restrict_gc_flag(ctyp, kk, jj, ii, f, ddx, ddy, ddz, bp, bt, &
+            offset, messagelength, istart, istop, jstart, jstop, kstart, kstop)
 
         offset = offset + messagelength
     END SUBROUTINE restrict_gc
+
+
+    SUBROUTINE restrict_gc_flag(flag, kk, jj, ii, ff, ddx, ddy, ddz, bp, bt, &
+            offset, messagelength, istart, istop, jstart, jstop, kstart, kstop)
+        !$omp declare target
+        ! Subroutine arguments
+        CHARACTER(len=1), INTENT(in) :: flag
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(in) :: ff(kk, jj, ii)
+        REAL(realk), INTENT(in) :: ddx(ii), ddy(jj), ddz(kk)
+        REAL(realk), INTENT(in) :: bp(kk, jj, ii), bt(kk, jj, ii)
+        INTEGER(int32), INTENT(in) :: offset, messagelength
+        INTEGER(intk), INTENT(in) :: istart, istop, jstart, jstop, kstart, kstop
+
+        ! Local variables
+        INTEGER(int32) :: targetidx
+
+        targetidx = offset + messagelength - 1
+
+        SELECT CASE (flag)
+            CASE ('U')
+                CALL restrict_noib_u(kk, jj, ii, ff, ddx, ddy, ddz, &
+                    messagelength, sendbuf(offset:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('V')
+                CALL restrict_noib_v(kk, jj, ii, ff, ddx, ddy, ddz, &
+                    messagelength, sendbuf(offset:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('W')
+                CALL restrict_noib_w(kk, jj, ii, ff, ddx, ddy, ddz, &
+                    messagelength, sendbuf(offset:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('P')
+                CALL restrict_gc_p_t(kk, jj, ii, ff, ddx, ddy, ddz, bp, &
+                    messagelength, sendbuf(offset:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('T')
+                CALL restrict_gc_p_t(kk, jj, ii, ff, ddx, ddy, ddz, bt, &
+                    messagelength, sendbuf(offset:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('R')
+                CALL restrict_gc_r(kk, jj, ii, ff, ddx, ddy, ddz, bp, &
+                    messagelength, sendbuf(offset:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('S')
+                CALL restrict_noib_s(kk, jj, ii, ff, ddx, ddy, ddz, &
+                    messagelength, sendbuf(offset:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('N')
+                CALL restrict_gc_n(kk, jj, ii, ff, messagelength, &
+                    sendbuf(offset:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('E')
+                CALL restrict_gc_e(kk, jj, ii, ff, messagelength, &
+                    sendbuf(offset:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('F')
+                CALL restrict_gc_f(kk, jj, ii, ff, messagelength, &
+                    sendbuf(offset:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+            CASE ('I')
+                CALL restrict_gc_i(kk, jj, ii, ff, messagelength, &
+                    sendbuf(offset:targetidx), &
+                    istart, istop, jstart, jstop, kstart, kstop)
+#ifdef _MGLET_DEBUG_
+            CASE DEFAULT
+                CALL errr(__FILE__, __LINE__)
+#endif
+            END SELECT
+    END SUBROUTINE restrict_gc_flag
 
 
     SUBROUTINE message_length_A(messagelength, ctyp, igrid)


### PR DESCRIPTION
Depends on https://github.com/kmturbulenz/mglet-base/pull/213

- mgpcorr now runs on device
- Removed the bp check (increases the number of multiplications)

I also measured the difference of using `!$omp parallel` outside of the grid subroutine while using `!$omp do collapse(3)` inside (mgpcorr uses 4 inner loops over grid cells) instead of a `!$omp parallel do collapse(3)` on each cell loop. Using `!$omp parallel` outside of the grid subroutine decreases runtime of the kernel by roughly 30% (probably avoids synchronization points). This could be interesting for https://github.com/kmturbulenz/mglet-base/pull/206.