### PR TITLE
Refactor and Offload divcal

### DIFF
--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -191,17 +191,25 @@ CONTAINS
         CALL push_field(res, "RES")
         CALL set_field_arr(dp, 0.0_realk, device=.TRUE.)
         CALL set_field_arr(hilf, 0.0_realk, device=.TRUE.)
-        CALL set_field_arr(rhs, 0.0_realk)
+        CALL set_field_arr(rhs, 0.0_realk, device=.TRUE.)
         CALL set_field_arr(res, 0.0_realk, device=.TRUE.)
 
+        ! TODO(offload): Remove once surrounding subroutines are offloaded
+        CALL map_arr_to_device(u, v, w, p, message="to:u|v|w|p%arr")
 
         ! laplace(dp) = prefak * div(u) is the underlying equation
         prefak = rho/dt
-        CALL ib%divcal(rhs, u, v, w, prefak)
+        CALL divcal(rhs, u, v, w, prefak, device=.TRUE.)
+
+        ! TODO(offload): Remove once surrounding subroutines are offloaded
+        CALL map_arr_from_device(rhs, message="from:rhs%arr")
 
         DO ilevel = maxlevel, minlevel, -1
             CALL ftoc(ilevel, rhs, rhs, 'R')
         END DO
+
+        ! TODO(offload): Remove once surrounding subroutines are offloaded
+        CALL map_arr_to_device(rhs, message="to:rhs%arr")
 
         ! For debug logging
         IF (loglevel >= 3) THEN
@@ -214,9 +222,6 @@ CONTAINS
             END DO
             CALL print_plog(ittot, irk, 0)
         END IF
-
-        ! TODO(offload): Remove once surrounding subroutines are offloaded
-        CALL map_arr_to_device(rhs, message="to:rhs%arr")
 
         ipc = 0
         outer: DO ipcount = 1, nouter
@@ -328,9 +333,6 @@ CONTAINS
             CALL parent(ilevel, s1=dp, device=.TRUE.)
             CALL bound_pressure(ilevel, dp, bp)
         END DO
-
-        ! TODO(offload): Remove once surrounding subroutines are offloaded
-        CALL map_arr_to_device(u, v, w, p, message="to:u|v|w|p%arr")
 
         ! Pressure correction: P = P + dtrk/rho*DP
         ! Velocity fields are modified and become solenoidal based on DP

--- a/src/ib/CMakeLists.txt
+++ b/src/ib/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(ib STATIC
     ctof/ctof2_mod.F90
     ctof/ctof_core_mod.F90
     cutcorner_mod.F90
+    divcal_mod.F90
     fillfollower_mod.F90
     filling_mod.F90
     findinterface_mod.F90

--- a/src/ib/divcal_mod.F90
+++ b/src/ib/divcal_mod.F90
@@ -1,0 +1,98 @@
+MODULE divcal_mod
+    USE core_mod
+
+    IMPLICIT NONE
+    PRIVATE
+
+    PUBLIC :: divcal
+CONTAINS
+    SUBROUTINE divcal(div_f, u_f, v_f, w_f, fak, device)
+        ! Subroutine arguments
+        TYPE(field_t), INTENT(inout) :: div_f
+        TYPE(field_t), INTENT(in) :: u_f, v_f, w_f
+        REAL(realk), INTENT(in) :: fak
+        LOGICAL, OPTIONAL, INTENT(in) :: device
+
+        ! Local variables
+        TYPE(field_t), POINTER :: rddx_f, rddy_f, rddz_f, bp_f
+        INTEGER(intk) :: i, igrid, ilevel, ip3, ip1x, ip1y, ip1z, kk, jj, ii
+        LOGICAL :: device2
+
+        CALL start_timer(240)
+
+        IF (PRESENT(device)) THEN
+            device2 = device
+        ELSE
+            device2 = .FALSE.
+        END IF
+
+        CALL get_field(rddx_f, "RDDX")
+        CALL get_field(rddy_f, "RDDY")
+        CALL get_field(rddz_f, "RDDZ")
+        CALL get_field(bp_f, "BP")
+
+        ASSOCIATE(div => div_f%arr, u => u_f%arr, v => v_f%arr, w => w_f%arr, &
+                  rddx => rddx_f%arr, rddy => rddy_f%arr, rddz => rddz_f%arr, &
+                  bp => bp_f%arr, active_level => u_f%active_level)
+
+        ! For now, avoid mapping active_level for every field in order not to
+        ! pollute the mapping table. Mapping one array of size minlevel:maxlevel
+        ! per kernel launch is still very cheap.
+
+        !$omp target teams distribute private(kk, jj, ii, ip3, ip1x, ip1y, &
+        !$omp& ip1z, igrid, ilevel) &
+        !$omp& map(to: active_level) &
+        !$omp& if(device2)
+        DO i = 1, nmygrids
+            igrid = mygrids(i)
+            ilevel = level(igrid)
+
+            ! Assume that U, V, W and DIV are defined on the same levels!!!
+            IF (.NOT. active_level(ilevel)) CYCLE
+
+            CALL get_mgdims(kk, jj, ii, igrid)
+            CALL get_ip3(ip3, igrid)
+            CALL get_ip1x(ip1x, igrid)
+            CALL get_ip1y(ip1y, igrid)
+            CALL get_ip1z(ip1z, igrid)
+
+            CALL divcal_grid(kk, jj, ii, div(ip3), u(ip3), v(ip3), w(ip3), &
+                bp(ip3), rddx(ip1x), rddy(ip1y), rddz(ip1z), fak)
+        END DO
+        !$omp end target teams distribute
+
+        END ASSOCIATE
+
+        CALL stop_timer(240)
+    END SUBROUTINE divcal
+
+
+    SUBROUTINE divcal_grid(kk, jj, ii, div, u, v, w, bp, rddx, rddy, rddz, fak)
+        !$omp declare target
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: kk, jj, ii
+        REAL(realk), INTENT(inout) :: div(kk, jj, ii)
+        REAL(realk), INTENT(in) :: u(kk, jj, ii)
+        REAL(realk), INTENT(in) :: v(kk, jj, ii)
+        REAL(realk), INTENT(in) :: w(kk, jj, ii)
+        REAL(realk), INTENT(in) :: bp(kk, jj, ii)
+        REAL(realk), INTENT(in) :: rddx(ii), rddy(jj), rddz(kk)
+        REAL(realk), INTENT(in) :: fak
+
+        ! Local variables
+        INTEGER(intk) :: k, j, i
+
+        !$omp parallel do collapse(3) private(k, j, i)
+        DO i = 3, ii-2
+            DO j = 3, jj-2
+                DO k = 3, kk-2
+                    div(k, j, i) = fak*((u(k, j, i) - u(k, j, i-1))*rddx(i) &
+                        + (v(k, j, i) - v(k, j-1, i))*rddy(j) &
+                        + (w(k, j, i) - w(k-1, j, i))*rddz(k)) &
+                        * bp(k, j, i)
+                END DO
+            END DO
+        END DO
+        !$omp end parallel do
+    END SUBROUTINE divcal_grid
+END MODULE divcal_mod

--- a/src/ib/gc_mod.F90
+++ b/src/ib/gc_mod.F90
@@ -26,7 +26,6 @@ MODULE gc_mod
     CONTAINS
         PROCEDURE :: blockbp
         PROCEDURE :: read_stencils
-        PROCEDURE :: divcal
         PROCEDURE, PRIVATE :: calc_nvecs
         PROCEDURE, NOPASS, PRIVATE :: calc_nvecs_grid
         FINAL :: destructor
@@ -269,77 +268,4 @@ CONTAINS
             END DO
         END DO
     END SUBROUTINE calc_nvecs_grid
-
-
-    SUBROUTINE divcal(this, div, u, v, w, fak, ctyp)
-        ! Subroutine arguments
-        CLASS(gc_t), INTENT(inout) :: this
-        TYPE(field_t), INTENT(inout) :: div
-        TYPE(field_t), INTENT(in) :: u
-        TYPE(field_t), INTENT(in) :: v
-        TYPE(field_t), INTENT(in) :: w
-        REAL(realk), INTENT(in) :: fak
-        CHARACTER(len=1), INTENT(in), OPTIONAL :: ctyp
-
-        ! Local variables
-        INTEGER(intk) :: i, igrid, ilevel
-        INTEGER(intk) :: kk, jj, ii
-        LOGICAL :: use_sdiv
-        TYPE(field_t), POINTER :: rddx_f, rddy_f, rddz_f
-        TYPE(field_t), POINTER :: sdiv_f, bp_f
-        REAL(realk), CONTIGUOUS, POINTER :: rddx(:), rddy(:), rddz(:)
-        REAL(realk), CONTIGUOUS, POINTER :: sdiv(:, :, :), bp(:, :, :), &
-            div_p(:, :, :), u_p(:, :, :), v_p(:, :, :), w_p(:, :, :)
-
-        CALL start_timer(240)
-
-        ! For safety
-        NULLIFY(bp_f)
-        NULLIFY(sdiv_f)
-        NULLIFY(sdiv)
-
-        CALL get_field(rddx_f, "RDDX")
-        CALL get_field(rddy_f, "RDDY")
-        CALL get_field(rddz_f, "RDDZ")
-        CALL get_field(bp_f, "BP")
-
-        use_sdiv = .TRUE.
-        IF (PRESENT(ctyp)) THEN
-            IF (ctyp == "W") THEN
-                use_sdiv = .FALSE.
-            END IF
-        END IF
-
-        IF (use_sdiv) THEN
-            CALL get_field(sdiv_f, "SDIV")
-        END IF
-
-        DO ilevel = minlevel, maxlevel
-            ! Assume that U, V, W and DIV are defined on the same levels!!!
-            IF (.NOT. u%active_level(ilevel)) CYCLE
-
-            DO i = 1, nmygridslvl(ilevel)
-                igrid = mygridslvl(i, ilevel)
-                CALL get_mgdims(kk, jj, ii, igrid)
-
-                CALL rddx_f%get_ptr(rddx, igrid)
-                CALL rddy_f%get_ptr(rddy, igrid)
-                CALL rddz_f%get_ptr(rddz, igrid)
-                CALL bp_f%get_ptr(bp, igrid)
-
-                CALL div%get_ptr(div_p, igrid)
-                CALL u%get_ptr(u_p, igrid)
-                CALL v%get_ptr(v_p, igrid)
-                CALL w%get_ptr(w_p, igrid)
-
-                IF (use_sdiv) CALL sdiv_f%get_ptr(sdiv, igrid)
-
-                CALL this%divcal_grid(kk, jj, ii, fak, div_p, &
-                    u_p, v_p, w_p, rddx, rddy, rddz, bp, sdiv)
-            END DO
-        END DO
-
-        CALL stop_timer(240)
-    END SUBROUTINE divcal
-
 END MODULE gc_mod

--- a/src/ib/ib_mod.F90
+++ b/src/ib/ib_mod.F90
@@ -5,6 +5,7 @@ MODULE ib_mod
     USE checkzelle_mod, ONLY: checkzelle
     USE ctof_mod
     USE cutcorner_mod
+    USE divcal_mod
     USE filling_mod, ONLY: fillfluid
     USE findinterface_mod
     USE flzelle_mod

--- a/src/ib/ibmodel_mod.F90
+++ b/src/ib/ibmodel_mod.F90
@@ -10,7 +10,6 @@ MODULE ibmodel_mod
         PROCEDURE(blockbp_i), DEFERRED :: blockbp
         PROCEDURE(read_stencils_i), DEFERRED :: read_stencils
         PROCEDURE(giteig_i), NOPASS, DEFERRED :: giteig
-        PROCEDURE(divcal_i), DEFERRED :: divcal
     END TYPE ibmodel_t
 
     ABSTRACT INTERFACE
@@ -35,17 +34,6 @@ MODULE ibmodel_mod
 
         SUBROUTINE giteig_i()
         END SUBROUTINE giteig_i
-
-        SUBROUTINE divcal_i(this, div, u, v, w, fak, ctyp)
-            IMPORT :: field_t, ibmodel_t, realk
-            CLASS(ibmodel_t), INTENT(inout) :: this
-            TYPE(field_t), INTENT(inout) :: div
-            TYPE(field_t), INTENT(in) :: u
-            TYPE(field_t), INTENT(in) :: v
-            TYPE(field_t), INTENT(in) :: w
-            REAL(realk), INTENT(in) :: fak
-            CHARACTER(len=1), INTENT(in), OPTIONAL :: ctyp
-        END SUBROUTINE divcal_i
     END INTERFACE
 
     PUBLIC :: ibmodel_t

--- a/src/ib/noib_mod.F90
+++ b/src/ib/noib_mod.F90
@@ -11,8 +11,6 @@ MODULE noib_mod
         PROCEDURE :: blockbp
         PROCEDURE :: read_stencils
         PROCEDURE, NOPASS :: giteig
-        PROCEDURE :: divcal
-        PROCEDURE, NOPASS :: divcal_grid
         FINAL :: destructor
     END TYPE noib_t
 
@@ -244,108 +242,4 @@ CONTAINS
             message="to:gs-neighbors")
         CALL map_arr_to_device(gsap, message="to:gs-ap")
     END SUBROUTINE giteig
-
-
-    SUBROUTINE divcal(this, div, u, v, w, fak, ctyp)
-        ! Subroutine arguments
-        CLASS(noib_t), INTENT(inout) :: this
-        TYPE(field_t), INTENT(inout) :: div
-        TYPE(field_t), INTENT(in) :: u
-        TYPE(field_t), INTENT(in) :: v
-        TYPE(field_t), INTENT(in) :: w
-        REAL(realk), INTENT(in) :: fak
-        CHARACTER(len=1), INTENT(in), OPTIONAL :: ctyp
-
-        ! Local variables
-        INTEGER(intk) :: i, ilevel, igrid
-        INTEGER(intk) :: kk, jj, ii
-        TYPE(field_t), POINTER :: rddx_f, rddy_f, rddz_f
-        REAL(realk), CONTIGUOUS, POINTER :: rddx(:), rddy(:), rddz(:)
-        REAL(realk), CONTIGUOUS, POINTER :: div_p(:, :, :), u_p(:, :, :), &
-            v_p(:, :, :), w_p(:, :, :)
-
-        CALL start_timer(240)
-
-        CALL get_field(rddx_f, "RDDX")
-        CALL get_field(rddy_f, "RDDY")
-        CALL get_field(rddz_f, "RDDZ")
-
-        DO ilevel = minlevel, maxlevel
-            ! Assume that U, V, W and DIV are defined on the same levels!!!
-            IF (.NOT. u%active_level(ilevel)) CYCLE
-
-            DO i = 1, nmygridslvl(ilevel)
-
-                igrid = mygridslvl(i, ilevel)
-                CALL get_mgdims(kk, jj, ii, igrid)
-
-                CALL rddx_f%get_ptr(rddx, igrid)
-                CALL rddy_f%get_ptr(rddy, igrid)
-                CALL rddz_f%get_ptr(rddz, igrid)
-
-                CALL div%get_ptr(div_p, igrid)
-                CALL u%get_ptr(u_p, igrid)
-                CALL v%get_ptr(v_p, igrid)
-                CALL w%get_ptr(w_p, igrid)
-
-                CALL divcal_grid(kk, jj, ii, fak, div_p, u_p, &
-                    v_p, w_p, rddx, rddy, rddz)
-            END DO
-        END DO
-
-        CALL stop_timer(240)
-    END SUBROUTINE divcal
-
-
-    PURE SUBROUTINE divcal_grid(kk, jj, ii, fak, div, u, v, w, rddx, rddy, &
-            rddz, bp, sdiv)
-        ! Subroutine arguments
-        INTEGER(intk), INTENT(in) :: kk, jj, ii
-        REAL(realk), INTENT(in) :: fak
-        REAL(realk), INTENT(inout) :: div(kk, jj, ii)
-        REAL(realk), INTENT(in) :: u(kk, jj, ii)
-        REAL(realk), INTENT(in) :: v(kk, jj, ii)
-        REAL(realk), INTENT(in) :: w(kk, jj, ii)
-        REAL(realk), INTENT(in) :: rddx(ii)
-        REAL(realk), INTENT(in) :: rddy(jj)
-        REAL(realk), INTENT(in) :: rddz(kk)
-        REAL(realk), INTENT(in), OPTIONAL :: bp(kk, jj, ii)
-        REAL(realk), INTENT(in), OPTIONAL :: sdiv(kk, jj, ii)
-
-        ! Local variables
-        INTEGER(intk) :: k, j, i
-
-        DO i = 3, ii-2
-            DO j = 3, jj-2
-                DO k = 3, kk-2
-                    div(k, j, i) = fak*((u(k, j, i) - u(k, j, i-1))*rddx(i) &
-                        + (v(k, j, i) - v(k, j-1, i))*rddy(j) &
-                        + (w(k, j, i) - w(k-1, j, i))*rddz(k))
-                END DO
-            END DO
-        END DO
-
-        ! TODO: If SDIV is properly masked in the ghost layers, the indices
-        ! here could be from 1 to ii etc. That will lead to ever so slightly
-        ! better performance. I leave it as is until SDIV is properly checked.
-        IF (PRESENT(sdiv)) THEN
-            DO i = 3, ii-2
-                DO j = 3, jj-2
-                    DO k = 3, kk-2
-                        div(k, j, i) = div(k, j, i) + fak*sdiv(k, j, i)
-                    END DO
-                END DO
-            END DO
-        END IF
-
-        IF (PRESENT(bp)) THEN
-            DO i = 1, ii
-                DO j = 1, jj
-                    DO k = 1, kk
-                        div(k, j, i) = bp(k, j, i)*div(k, j, i)
-                    END DO
-                END DO
-            END DO
-        END IF
-    END SUBROUTINE divcal_grid
 END MODULE noib_mod

--- a/src/plugins/derivfields_mod.F90
+++ b/src/plugins/derivfields_mod.F90
@@ -1,5 +1,6 @@
 MODULE derivfields_mod
     USE core_mod
+    USE divcal_mod
     USE MPI_f08
     USE ib_mod, ONLY: ib
 
@@ -77,7 +78,7 @@ CONTAINS
                     CALL get_field(u, "U")
                     CALL get_field(v, "V")
                     CALL get_field(w, "W")
-                    CALL ib%divcal(field, u, v, w, 1.0_realk)
+                    CALL divcal(field, u, v, w, 1.0_realk)
                 END BLOCK
             CASE DEFAULT
                 CALL errr(__FILE__, __LINE__)


### PR DESCRIPTION
- Intentionally removed the `ctyp` parameter
- Intentionally removed the `SDIV` path

The `device=.FALSE.` path of `divcal` in `derivfields_mod` is using a non-offloaded `divcal` by using the OpenMP `if` construct. One should set `OMP_NUM_THREADS=1` in order not to use multiple threads on the CPU in the `divcal_grid` subroutine in offload builds. This should be a general guideline.