### PR TITLE
Update build flags for AMD compilers

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -248,7 +248,7 @@
 
                 "MGLET_C_FLAGS": "",
                 "MGLET_CXX_FLAGS": "",
-                "MGLET_Fortran_FLAGS": "-fimplicit-none",
+                "MGLET_Fortran_FLAGS": "-fimplicit-none;-Wno-assumed-type-size-dummy",
 
                 "MGLET_C_FLAGS_RELEASE": "-O3;-g",
                 "MGLET_CXX_FLAGS_RELEASE": "-O3;-g",


### PR DESCRIPTION
This flag suppress the following warning coming from recent AMD compilers (ROCm 7.14):

```
/home/hakostra/MGLET/mglet-ce/src/core/fieldio2_mod.F90:1359:36: portability: A scalar actual argument for an assumed-size TYPE(*) dummy is not portable [-Wassumed-type-size-dummy]
                      CALL MPI_Isend(buffer(bufptr), nelems, &
```

which occur hundreds of times in MGLET.

In the future, we should maybe look into the root cause of this (is it more portable/correct to pass an array slice maybe??), but as of now we silence it as it does not seem to be any problems.