### PR TITLE
Workaround for Non-Deterministic Kernel Crashes and Memory Leaks in Parallel Regions

### DIFF
--- a/src/core/connect/conn2_mod.F90
+++ b/src/core/connect/conn2_mod.F90
@@ -1243,27 +1243,40 @@ CONTAINS
     ! Routine with offloaded kernel to process all sendtasks on the device
     !
     SUBROUTINE process_sendtasks(nstasks, stasks)
-
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: nstasks
         INTEGER(intk), INTENT(in) :: stasks(buffertasksize, nstasks)
 
         ! Local variables
-        INTEGER(intk) :: itask, fieldid, icount, igrid, istart, istop, &
-            jstart, jstop, kstart, kstop, ii, jj, kk, ip3
+        ! none...
 
         IF (nstasks == 0) THEN
             RETURN
         END IF
 
-        ! At all cost, avoid pointers within the kernel or, even worse,
-        ! pointer operations within the kernel!
-        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
-                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr)
-
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("process_sendtasks")
 #endif
+
+        CALL process_sendtasks_impl(nstasks, stasks, f1%arr, f2%arr, &
+            f3%arr, f4%arr, f5%arr, f6%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE process_sendtasks
+
+
+    SUBROUTINE process_sendtasks_impl(nstasks, stasks, a1, a2, a3, a4, a5, a6)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nstasks
+        INTEGER(intk), INTENT(in) :: stasks(buffertasksize, nstasks)
+        REAL(realk), INTENT(in) :: a1(*), a2(*), a3(*), a4(*), a5(*), a6(*)
+
+        ! Local variables
+        INTEGER(intk) :: itask, fieldid, icount, igrid, istart, istop, &
+            jstart, jstop, kstart, kstop, ii, jj, kk, ip3
+
         !$omp target teams distribute private(itask, fieldid, icount, &
         !$omp&  igrid, istart, istop, jstart, jstop, kstart, kstop, &
         !$omp&  ii, jj, kk, ip3)
@@ -1284,6 +1297,7 @@ CONTAINS
             CALL get_ip3(ip3, igrid)
             CALL get_mgdims(kk, jj, ii, igrid)
 
+            !$omp parallel
             ! Assign the correct field pointer based on ifield
             SELECT CASE (fieldid)
             CASE (1)
@@ -1307,14 +1321,10 @@ CONTAINS
             CASE DEFAULT
                 CALL errr(__FILE__, __LINE__)
             END SELECT
-
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-        END ASSOCIATE
-    END SUBROUTINE process_sendtasks
+    END SUBROUTINE process_sendtasks_impl
 
 
     SUBROUTINE arr_to_buf(kk, jj, ii, arr, istart, istop, &
@@ -1331,7 +1341,7 @@ CONTAINS
         kkl = kstop - kstart + 1
         jjl = jstop - jstart + 1
 
-        !$omp parallel do collapse(3) private(i, j, k, idx_b)
+        !$omp do collapse(3) private(i, j, k, idx_b)
         DO i = istart, istop
             DO j = jstart, jstop
                 DO k = kstart, kstop
@@ -1341,36 +1351,46 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
-
+        !$omp end do
     END SUBROUTINE arr_to_buf
 
 
     ! Routine with offloaded kernel to process all receive tasks on the device
     !
     SUBROUTINE process_recvtasks(nrtasks, rtasks)
-
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: nrtasks
         INTEGER(intk), INTENT(in) :: rtasks(buffertasksize, nrtasks)
 
         ! Local variables
-        INTEGER(intk) :: itask, fieldid, icount, igrid, istart, istop, &
-            jstart, jstop, kstart, kstop, ii, jj, kk, ip3
+        ! none...
 
         IF (nrtasks == 0) THEN
             RETURN
         END IF
 
-        ! At all cost, avoid pointers within the kernel or, even worse,
-        ! pointer operations within the kernel!
-        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
-                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr)
-
-
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("process_recvtasks")
 #endif
+
+        CALL process_recvtasks_impl(nrtasks, rtasks, f1%arr, f2%arr, &
+            f3%arr, f4%arr, f5%arr, f6%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE process_recvtasks
+
+
+    SUBROUTINE process_recvtasks_impl(nrtasks, rtasks, a1, a2, a3, a4, a5, a6)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nrtasks
+        INTEGER(intk), INTENT(in) :: rtasks(buffertasksize, nrtasks)
+        REAL(realk), INTENT(inout) :: a1(*), a2(*), a3(*), a4(*), a5(*), a6(*)
+
+        ! Local variables
+        INTEGER(intk) :: itask, fieldid, icount, igrid, istart, istop, &
+            jstart, jstop, kstart, kstop, ii, jj, kk, ip3
 
         !$omp target teams distribute private(itask, fieldid, icount, &
         !$omp&  igrid, istart, istop, jstart, jstop, kstart, kstop, &
@@ -1392,6 +1412,7 @@ CONTAINS
             CALL get_ip3(ip3, igrid)
             CALL get_mgdims(kk, jj, ii, igrid)
 
+            !$omp parallel
             ! Assign the correct field pointer
             SELECT CASE (fieldid)
             CASE (1)
@@ -1415,14 +1436,10 @@ CONTAINS
             CASE DEFAULT
                 CALL errr(__FILE__, __LINE__)
             END SELECT
-
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-        END ASSOCIATE
-    END SUBROUTINE process_recvtasks
+    END SUBROUTINE process_recvtasks_impl
 
 
     SUBROUTINE buf_to_arr(kk, jj, ii, arr, istart, istop, &
@@ -1439,7 +1456,7 @@ CONTAINS
         kkl = kstop - kstart + 1
         jjl = jstop - jstart + 1
 
-        !$omp parallel do collapse(3) private(i, j, k, idx_b)
+        !$omp do collapse(3) private(i, j, k, idx_b)
         DO i = istart, istop
             DO j = jstart, jstop
                 DO k = kstart, kstop
@@ -1449,7 +1466,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
 
     END SUBROUTINE buf_to_arr
 
@@ -1457,29 +1474,41 @@ CONTAINS
     ! Routine with offloaded kernel to process all selftasks on the device
     !
     SUBROUTINE process_selftasks(nstasks, stasks)
-
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: nstasks
         INTEGER(intk), INTENT(in) :: stasks(selftasksize, nstasks)
 
         ! Local variables
-        INTEGER(intk) :: itask, fieldid, igrid, igrid_d, ip3, ip3_d, &
-            kk, jj, ii, istart, istop, jstart, jstop, kstart, kstop, &
-            istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d
+        ! none...
 
         ! Precheck to avoid kernel launch overhead
         IF (nstasks == 0) THEN
             RETURN
         END IF
 
-        ! At all cost, avoid pointers within the kernel or, even worse,
-        ! pointer operations within the kernel!
-        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
-                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr)
-
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("process_selftasks")
 #endif
+
+        CALL process_selftasks_impl(nstasks, stasks, f1%arr, f2%arr, &
+            f3%arr, f4%arr, f5%arr, f6%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE process_selftasks
+
+
+    SUBROUTINE process_selftasks_impl(nstasks, stasks, a1, a2, a3, a4, a5, a6)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nstasks
+        INTEGER(intk), INTENT(in) :: stasks(selftasksize, nstasks)
+        REAL(realk), INTENT(inout) :: a1(*), a2(*), a3(*), a4(*), a5(*), a6(*)
+
+        ! Local variables
+        INTEGER(intk) :: itask, fieldid, igrid, igrid_d, ip3, ip3_d, &
+            kk, jj, ii, istart, istop, jstart, jstop, kstart, kstop, &
+            istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d
 
         !$omp target teams distribute private(itask, fieldid, igrid, igrid_d, &
         !$omp&  istart, istop, jstart, jstop, kstart, kstop, &
@@ -1509,6 +1538,7 @@ CONTAINS
             CALL get_ip3(ip3_d, igrid_d)
             CALL get_mgdims(kk, jj, ii, igrid)
 
+            !$omp parallel
             SELECT CASE (fieldid)
             CASE (1)
                 CALL arr_to_arr(kk, jj, ii, a1(ip3_d), a1(ip3), &
@@ -1537,14 +1567,10 @@ CONTAINS
             CASE DEFAULT
                 CALL errr(__FILE__, __LINE__)
             END SELECT
-
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-        END ASSOCIATE
-    END SUBROUTINE process_selftasks
+    END SUBROUTINE process_selftasks_impl
 
 
     PURE SUBROUTINE arr_to_arr(kk, jj, ii, dst_rarr, src_rarr, &
@@ -1564,7 +1590,7 @@ CONTAINS
         joff = jstart - jstart_d
         ioff = istart - istart_d
 
-        !$omp parallel do collapse(3) private(i, j, k)
+        !$omp do collapse(3) private(i, j, k)
         DO i = istart_d, istop_d
             DO j = jstart_d, jstop_d
                 DO k = kstart_d, kstop_d
@@ -1573,7 +1599,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
 
     END SUBROUTINE arr_to_arr
 

--- a/src/core/fieldhelper_mod.F90
+++ b/src/core/fieldhelper_mod.F90
@@ -3,7 +3,7 @@ MODULE fieldhelper_mod
     USE err_mod, ONLY: errr
     USE field_mod, ONLY: field_t, intfield_t
     USE grids_mod, ONLY: get_mgdims, mygrids, nmygrids, level, get_imygrid
-    USE pointers_mod, ONLY: get_ipbb
+    USE pointers_mod, ONLY: get_ipbb, get_ip3
     USE precision_mod, ONLY: realk, intk, ifk
     USE profile_tools_mod, ONLY: profile_range_push, profile_range_pop
 
@@ -40,7 +40,7 @@ CONTAINS
 
         IF (device2) THEN
             n = SIZE(field%arr)
-            CALL set_field_arr_realk_impl(field%arr, n, val)
+            CALL set_field_arr_realk_impl(field%arr, val)
         ELSE
             field%arr = val
         END IF
@@ -51,20 +51,33 @@ CONTAINS
     END SUBROUTINE set_field_arr_realk
 
 
-    SUBROUTINE set_field_arr_realk_impl(arr, n, val)
+    SUBROUTINE set_field_arr_realk_impl(arr, val)
         ! Subroutine arguments
         REAL(realk), INTENT(inout) :: arr(*)
-        INTEGER(intk), INTENT(in) :: n
         REAL(realk), INTENT(in) :: val
 
         ! Local variables
-        INTEGER(intk) :: i
+        INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
 
-        !$omp target teams loop
-        DO i = 1, n
-            arr(i) = val
+        ! This is a 4D loop only because there are random crashes with 1D loops
+        ! using the amd compiler
+        !$omp target teams distribute
+        DO imygrid = 1, nmygrids
+            igrid = mygrids(imygrid)
+            CALL get_mgdims(kk, jj, ii, igrid)
+            CALL get_ip3(ip3, igrid)
+
+            !$omp parallel do collapse(3)
+            DO i = 1, ii
+                DO j = 1, jj
+                    DO k = 1, kk
+                        idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj
+                        arr(idx) = val
+                    END DO
+                END DO
+            END DO
+            !$omp end parallel do
         END DO
-        !$omp end target teams loop
     END SUBROUTINE set_field_arr_realk_impl
 
 
@@ -90,7 +103,7 @@ CONTAINS
 
         IF (device2) THEN
             n = SIZE(field%arr)
-            CALL set_field_arr_ifk_impl(field%arr, n, val)
+            CALL set_field_arr_ifk_impl(field%arr, val)
         ELSE
             field%arr = val
         END IF
@@ -101,20 +114,33 @@ CONTAINS
     END SUBROUTINE set_field_arr_ifk
 
 
-    SUBROUTINE set_field_arr_ifk_impl(arr, n, val)
+    SUBROUTINE set_field_arr_ifk_impl(arr, val)
         ! Subroutine arguments
         INTEGER(ifk), INTENT(inout) :: arr(*)
-        INTEGER(intk), INTENT(in) :: n
         INTEGER(ifk), INTENT(in) :: val
 
         ! Local variables
-        INTEGER(intk) :: i
+        INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
 
-        !$omp target teams loop
-        DO i = 1, n
-            arr(i) = val
+        ! This is a 4D loop only because there are random crashes with 1D loops
+        ! using the amd compiler
+        !$omp target teams distribute
+        DO imygrid = 1, nmygrids
+            igrid = mygrids(imygrid)
+            CALL get_mgdims(kk, jj, ii, igrid)
+            CALL get_ip3(ip3, igrid)
+
+            !$omp parallel do collapse(3)
+            DO i = 1, ii
+                DO j = 1, jj
+                    DO k = 1, kk
+                        idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj
+                        arr(idx) = val
+                    END DO
+                END DO
+            END DO
+            !$omp end parallel do
         END DO
-        !$omp end target teams loop
     END SUBROUTINE set_field_arr_ifk_impl
 
 

--- a/src/core/fieldhelper_mod.F90
+++ b/src/core/fieldhelper_mod.F90
@@ -25,7 +25,7 @@ CONTAINS
         LOGICAL, OPTIONAL, INTENT(in) :: device
 
         ! Local variables
-        INTEGER(intk) :: i, n
+        INTEGER(intk) :: n
         LOGICAL :: device2
 
         IF (PRESENT(device)) THEN
@@ -34,26 +34,38 @@ CONTAINS
             device2 = .FALSE.
         END IF
 
-        IF (device2) THEN
-            n = SIZE(field%arr)
-
-            ASSOCIATE(arr => field%arr)
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
             CALL profile_range_push("set_field_arr_realk")
 #endif
-            !$omp target teams loop
-            DO i = 1, n
-                arr(i) = val
-            END DO
-            !$omp end target teams loop
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-            CALL profile_range_pop()
-#endif
-            END ASSOCIATE
+
+        IF (device2) THEN
+            n = SIZE(field%arr)
+            CALL set_field_arr_realk_impl(field%arr, n, val)
         ELSE
             field%arr = val
         END IF
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+            CALL profile_range_pop()
+#endif
     END SUBROUTINE set_field_arr_realk
+
+
+    SUBROUTINE set_field_arr_realk_impl(arr, n, val)
+        ! Subroutine arguments
+        REAL(realk), INTENT(inout) :: arr(*)
+        INTEGER(intk), INTENT(in) :: n
+        REAL(realk), INTENT(in) :: val
+
+        ! Local variables
+        INTEGER(intk) :: i
+
+        !$omp target teams loop
+        DO i = 1, n
+            arr(i) = val
+        END DO
+        !$omp end target teams loop
+    END SUBROUTINE set_field_arr_realk_impl
 
 
     SUBROUTINE set_field_arr_ifk(field, val, device)
@@ -63,7 +75,7 @@ CONTAINS
         LOGICAL, OPTIONAL, INTENT(in) :: device
 
         ! Local variables
-        INTEGER(intk) :: i, n
+        INTEGER(intk) :: n
         LOGICAL :: device2
 
         IF (PRESENT(device)) THEN
@@ -72,26 +84,38 @@ CONTAINS
             device2 = .FALSE.
         END IF
 
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("set_field_arr_ifk")
+#endif
+
         IF (device2) THEN
             n = SIZE(field%arr)
-
-            ASSOCIATE(arr => field%arr)
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-            CALL profile_range_push("set_field_arr_ifk")
-#endif
-            !$omp target teams loop
-            DO i = 1, n
-                arr(i) = val
-            END DO
-            !$omp end target teams loop
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-            CALL profile_range_pop()
-#endif
-            END ASSOCIATE
+            CALL set_field_arr_ifk_impl(field%arr, n, val)
         ELSE
             field%arr = val
         END IF
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+            CALL profile_range_pop()
+#endif
     END SUBROUTINE set_field_arr_ifk
+
+
+    SUBROUTINE set_field_arr_ifk_impl(arr, n, val)
+        ! Subroutine arguments
+        INTEGER(ifk), INTENT(inout) :: arr(*)
+        INTEGER(intk), INTENT(in) :: n
+        INTEGER(ifk), INTENT(in) :: val
+
+        ! Local variables
+        INTEGER(intk) :: i
+
+        !$omp target teams loop
+        DO i = 1, n
+            arr(i) = val
+        END DO
+        !$omp end target teams loop
+    END SUBROUTINE set_field_arr_ifk_impl
 
 
     SUBROUTINE map_arr_to_device(f1, f2, f3, f4, f5, f6, f7, message)

--- a/src/flow/bound_pressure_mod.F90
+++ b/src/flow/bound_pressure_mod.F90
@@ -139,27 +139,37 @@ CONTAINS
         TYPE(field_t), POINTER, INTENT(in) :: ddx_f, ddy_f, ddz_f
 
         ! Local variables
-        INTEGER(intk) :: nboundtasks, ilevel_index, i, igrid, iface
-        INTEGER(intk) :: kk, jj, ii, ip3, ipx, ipy, ipz, ipbb
+        INTEGER(intk) :: nboundtasks, ilevel_index
 
         CALL level_index(ilevel_index, ilevel)
         nboundtasks = nboundtaskslvl(ilevel_index)
 
-        ASSOCIATE( &
-            p => dp_f%arr, &
-            pbuffer => dp_f%buffers, &
-            bp => bp_f%arr, &
-            dx => dx_f%arr, &
-            dy => dy_f%arr, &
-            dz => dz_f%arr, &
-            ddx => ddx_f%arr, &
-            ddy => ddy_f%arr, &
-            ddz => ddz_f%arr)
-
-
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("bound_pressure_impl_bp")
 #endif
+
+        CALL bound_pressure_impl_bp_arr(nboundtasks, ilevel_index, dp_f%arr, &
+            dp_f%buffers, bp_f%arr, dx_f%arr, dy_f%arr, dz_f%arr, &
+            ddx_f%arr, ddy_f%arr, ddz_f%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE bound_pressure_impl_bp
+
+
+    SUBROUTINE bound_pressure_impl_bp_arr(nboundtasks, ilevel_index, p, &
+            pbuffer, bp, dx, dy, dz, ddx, ddy, ddz)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nboundtasks, ilevel_index
+        REAL(realk), INTENT(inout) :: p(*), pbuffer(*)
+        REAL(realk), INTENT(in) :: bp(*), dx(*), dy(*), dz(*)
+        REAL(realk), INTENT(in) :: ddx(*), ddy(*), ddz(*)
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid, iface
+        INTEGER(intk) :: kk, jj, ii, ip3, ipx, ipy, ipz, ipbb
+
         !$omp target teams distribute private(i, igrid, iface, kk, jj, ii, &
         !$omp& ip3, ipx, ipy, ipz, ipbb)
         DO i = 1, nboundtasks
@@ -173,6 +183,7 @@ CONTAINS
             CALL get_ip1y(ipy, igrid)
             CALL get_ip1z(ipz, igrid)
 
+            !$omp parallel
             SELECT CASE (iface)
             CASE (1)
                 CALL bfront_bp(kk, jj, ii, 2, 3, 4, 2, &
@@ -199,13 +210,10 @@ CONTAINS
                     pbuffer(ipbb), p(ip3), bp(ip3), &
                     ddx(ipx), ddy(ipy), ddz(ipz), dz(ipz))
             END SELECT
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-        END ASSOCIATE
-    END SUBROUTINE bound_pressure_impl_bp
+    END SUBROUTINE bound_pressure_impl_bp_arr
 
 
     SUBROUTINE bound_pressure_impl_nobp(ilevel, dp_f, dx_f, dy_f, dz_f, &
@@ -217,25 +225,37 @@ CONTAINS
         TYPE(field_t), POINTER, INTENT(in) :: ddx_f, ddy_f, ddz_f
 
         ! Local variables
-        INTEGER(intk) :: nboundtasks, ilevel_index, i, igrid, iface
-        INTEGER(intk) :: kk, jj, ii, ip3, ipx, ipy, ipz, ipbb
+        INTEGER(intk) :: nboundtasks, ilevel_index
 
         CALL level_index(ilevel_index, ilevel)
         nboundtasks = nboundtaskslvl(ilevel_index)
 
-        ASSOCIATE( &
-            p => dp_f%arr, &
-            pbuffer => dp_f%buffers, &
-            dx => dx_f%arr, &
-            dy => dy_f%arr, &
-            dz => dz_f%arr, &
-            ddx => ddx_f%arr, &
-            ddy => ddy_f%arr, &
-            ddz => ddz_f%arr)
-
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("bound_pressure_impl_nobp")
 #endif
+
+        CALL bound_pressure_impl_nobp_arr(nboundtasks, ilevel_index, &
+            dp_f%arr, dp_f%buffers, dx_f%arr, dy_f%arr, dz_f%arr, &
+            ddx_f%arr, ddy_f%arr, ddz_f%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE bound_pressure_impl_nobp
+
+
+    SUBROUTINE bound_pressure_impl_nobp_arr(nboundtasks, ilevel_index, p, &
+            pbuffer, dx, dy, dz, ddx, ddy, ddz)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nboundtasks, ilevel_index
+        REAL(realk), INTENT(inout) :: p(*), pbuffer(*)
+        REAL(realk), INTENT(in) :: dx(*), dy(*), dz(*)
+        REAL(realk), INTENT(in) :: ddx(*), ddy(*), ddz(*)
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid, iface
+        INTEGER(intk) :: kk, jj, ii, ip3, ipx, ipy, ipz, ipbb
+
         !$omp target teams distribute private(i, igrid, iface, kk, jj, ii, &
         !$omp& ip3, ipx, ipy, ipz, ipbb)
         DO i = 1, nboundtasks
@@ -249,6 +269,7 @@ CONTAINS
             CALL get_ip1y(ipy, igrid)
             CALL get_ip1z(ipz, igrid)
 
+            !$omp parallel
             SELECT CASE (iface)
             CASE (1)
                 CALL bfront(kk, jj, ii, 2, 3, 4, 2, &
@@ -275,13 +296,10 @@ CONTAINS
                     pbuffer(ipbb), p(ip3), &
                     ddx(ipx), ddy(ipy), ddz(ipz), dz(ipz))
             END SELECT
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-        END ASSOCIATE
-    END SUBROUTINE bound_pressure_impl_nobp
+    END SUBROUTINE bound_pressure_impl_nobp_arr
 
 
     SUBROUTINE bfront(kk, jj, ii, i2, i3, i4, istag2, pbuffer, &
@@ -300,7 +318,7 @@ CONTAINS
 
         i = MIN(i3, i4)
 
-        !$omp parallel do collapse(2) private(j, k, pcnew, bpc, m, n)
+        !$omp do collapse(2) private(j, k, pcnew, bpc, m, n)
         DO j = 3, jj-2, 2
             DO k = 3, kk-2, 2
                 CALL pressureftocone(k, j, i, kk, jj, ii, p, &
@@ -314,7 +332,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE bfront
 
 
@@ -335,7 +353,7 @@ CONTAINS
 
         i = MIN(i3, i4)
 
-        !$omp parallel do collapse(2) private(j, k, pcnew, bpc, sb11, sb12, &
+        !$omp do collapse(2) private(j, k, pcnew, bpc, sb11, sb12, &
         !$omp& sb13, sb14, fak, m, n)
         DO j = 3, jj-2, 2
             DO k = 3, kk-2, 2
@@ -363,7 +381,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE bfront_bp
 
 
@@ -383,7 +401,7 @@ CONTAINS
 
         j = MIN(j3, j4)
 
-        !$omp parallel do collapse(2) private(i, k, pcnew, bpc, l, n)
+        !$omp do collapse(2) private(i, k, pcnew, bpc, l, n)
         DO i = 3, ii-2, 2
             DO k = 3, kk-2, 2
                 CALL pressureftocone(k, j, i, kk, jj, ii, p, &
@@ -397,7 +415,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE bright
 
 
@@ -418,7 +436,7 @@ CONTAINS
 
         j = MIN(j3, j4)
 
-        !$omp parallel do collapse(2) private(i, k, pcnew, bpc, sb11, sb12, &
+        !$omp do collapse(2) private(i, k, pcnew, bpc, sb11, sb12, &
         !$omp& sb13, sb14, fak, l, n)
         DO i = 3, ii-2, 2
             DO k = 3, kk-2, 2
@@ -446,7 +464,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE bright_bp
 
 
@@ -466,7 +484,7 @@ CONTAINS
 
         k = MIN(k3, k4)
 
-        !$omp parallel do collapse(2) private(j, i, pcnew, bpc, l, m)
+        !$omp do collapse(2) private(j, i, pcnew, bpc, l, m)
         DO i = 3, ii-2, 2
             DO j = 3, jj-2, 2
                 CALL pressureftocone(k, j, i, kk, jj, ii, p, &
@@ -480,7 +498,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE bbottom
 
 
@@ -501,7 +519,7 @@ CONTAINS
 
         k = MIN(k3, k4)
 
-        !$omp parallel do collapse(2) private(j, i, pcnew, bpc, sb11, sb12, &
+        !$omp do collapse(2) private(j, i, pcnew, bpc, sb11, sb12, &
         !$omp& sb13, sb14, fak, l, m)
         DO i = 3, ii-2, 2
             DO j = 3, jj-2, 2
@@ -529,7 +547,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE bbottom_bp
 
 

--- a/src/flow/laplacephi_mod.F90
+++ b/src/flow/laplacephi_mod.F90
@@ -1,23 +1,18 @@
 
 MODULE laplacephi_mod
-
     USE core_mod
 
     IMPLICIT NONE(type, external)
-
     PRIVATE
 
     PUBLIC :: laplacephi, laplacephi_level
-
 CONTAINS
-
     SUBROUTINE laplacephi(res_f, phi_f)
         ! Subroutine arguments
         TYPE(field_t), INTENT(inout) :: res_f
         TYPE(field_t), INTENT(in) :: phi_f
 
         ! Local variables
-        INTEGER(intk) :: i, igrid, kk, jj, ii, ip3, ipx, ipy, ipz
         TYPE(field_t), POINTER :: gsaw, gsae, gsas, gsan, gsab, gsat, gsap, bp_f
 
         CALL get_field(gsaw, "GSAW")
@@ -27,25 +22,31 @@ CONTAINS
         CALL get_field(gsab, "GSAB")
         CALL get_field(gsat, "GSAT")
         CALL get_field(gsap, "GSAP")
-        ! BP for noib is 1.0. Take extra multiplications instead of branching
-        ! in the kernel or duplicating code for now.
         CALL get_field(bp_f, "BP")
-
-        ASSOCIATE ( &
-            phi => phi_f%arr, &
-            res => res_f%arr, &
-            ap  => gsap%arr, &
-            aw  => gsaw%arr, &
-            ae  => gsae%arr, &
-            an  => gsan%arr, &
-            as  => gsas%arr, &
-            at  => gsat%arr, &
-            ab  => gsab%arr, &
-            bp  => bp_f%arr)
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("laplacephi")
 #endif
+
+        CALL laplacephi_impl(res_f%arr, phi_f%arr, gsaw%arr, gsae%arr, &
+            gsas%arr, gsan%arr, gsab%arr, gsat%arr, gsap%arr, bp_f%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE laplacephi
+
+
+    SUBROUTINE laplacephi_impl(res, phi, aw, ae, as, an, ab, at, ap, bp)
+        ! Subroutine arguments
+        REAL(realk), INTENT(inout) :: res(*)
+        REAL(realk), INTENT(in) :: phi(*)
+        REAL(realk), INTENT(in) :: aw(*), ae(*), as(*), an(*), ab(*), at(*)
+        REAL(realk), INTENT(in) :: ap(*), bp(*)
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid, kk, jj, ii, ip3, ipx, ipy, ipz
+
         !$omp target teams distribute private(i, igrid, kk, jj, ii, ip3, ipx, &
         !$omp& ipy, ipz)
         DO i = 1, nmygrids
@@ -57,17 +58,14 @@ CONTAINS
             CALL get_ip1y(ipy, igrid)
             CALL get_ip1z(ipz, igrid)
 
+            !$omp parallel
             CALL laplacephi_grid(kk, jj, ii, res(ip3), phi(ip3), &
                 aw(ipx), ae(ipx), an(ipy), as(ipy), at(ipz), ab(ipz), &
                 ap(ip3), bp(ip3))
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-
-        END ASSOCIATE
-    END SUBROUTINE laplacephi
+    END SUBROUTINE laplacephi_impl
 
 
     SUBROUTINE laplacephi_level(ilevel, res_f, phi_f)
@@ -77,9 +75,6 @@ CONTAINS
         TYPE(field_t), INTENT(in) :: phi_f
 
         ! Local variables
-        INTEGER(intk) :: i, igrid
-        INTEGER(intk) :: kk, jj, ii, ip3, ipx, ipy, ipz
-
         TYPE(field_t), POINTER :: gsaw, gsae, gsas, gsan, gsab, gsat, gsap, bp_f
 
         CALL get_field(gsaw, "GSAW")
@@ -89,25 +84,35 @@ CONTAINS
         CALL get_field(gsab, "GSAB")
         CALL get_field(gsat, "GSAT")
         CALL get_field(gsap, "GSAP")
-        ! BP for noib is 1.0. Take extra multiplications instead of branching
-        ! in the kernel or duplicating code for now.
         CALL get_field(bp_f, "BP")
-
-        ASSOCIATE ( &
-            phi => phi_f%arr, &
-            res => res_f%arr, &
-            ap  => gsap%arr, &
-            aw  => gsaw%arr, &
-            ae  => gsae%arr, &
-            an  => gsan%arr, &
-            as  => gsas%arr, &
-            at  => gsat%arr, &
-            ab  => gsab%arr, &
-            bp  => bp_f%arr)
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("laplacephi_level")
 #endif
+
+        CALL laplacephi_level_impl(ilevel, res_f%arr, phi_f%arr, gsaw%arr, &
+            gsae%arr, gsas%arr, gsan%arr, gsab%arr, gsat%arr, gsap%arr, &
+            bp_f%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+        END SUBROUTINE laplacephi_level
+
+
+    SUBROUTINE laplacephi_level_impl(ilevel, res, phi, aw, ae, as, an, ab, &
+            at, ap, bp)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: ilevel
+        REAL(realk), INTENT(inout) :: res(*)
+        REAL(realk), INTENT(in) :: phi(*)
+        REAL(realk), INTENT(in) :: aw(*), ae(*), as(*), an(*), ab(*), at(*)
+        REAL(realk), INTENT(in) :: ap(*), bp(*)
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid
+        INTEGER(intk) :: kk, jj, ii, ip3, ipx, ipy, ipz
+
         !$omp target teams distribute private(i, igrid, kk, jj, ii, ip3, ipx, &
         !$omp& ipy, ipz)
         DO i = 1, nmygridslvl(ilevel)
@@ -119,16 +124,14 @@ CONTAINS
             CALL get_ip1y(ipy, igrid)
             CALL get_ip1z(ipz, igrid)
 
+            !$omp parallel
             CALL laplacephi_grid(kk, jj, ii, res(ip3), phi(ip3), &
                 aw(ipx), ae(ipx), an(ipy), as(ipy), at(ipz), ab(ipz), &
                 ap(ip3), bp(ip3))
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-        END ASSOCIATE
-    END SUBROUTINE laplacephi_level
+    END SUBROUTINE laplacephi_level_impl
 
 
     PURE SUBROUTINE laplacephi_grid(kk, jj, ii, res, phi, aw, ae, an, as, &
@@ -146,7 +149,7 @@ CONTAINS
         ! Local variables
         INTEGER :: k, j, i
 
-        !$omp parallel do collapse(3) private(i, j, k)
+        !$omp do collapse(3) private(i, j, k)
         DO i = 3, ii-2
             DO j = 3, jj-2
                 DO k = 3, kk-2
@@ -161,6 +164,6 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE laplacephi_grid
 END MODULE laplacephi_mod

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -504,37 +504,48 @@ CONTAINS
         TYPE(field_t), INTENT(in) :: siplpr
 
         ! Local variables
-        INTEGER(intk) :: i, igrid
-        INTEGER(intk) :: kk, jj, ii, ip3
-
-        ASSOCIATE( &
-            lw => siplw%arr, &
-            ls => sipls%arr, &
-            lb => siplb%arr, &
-            lpr => siplpr%arr, &
-            res => res_f%arr, &
-            rhs => rhs_f%arr, &
-            mip => mip_hp_f%arr, &
-            idx => idx_hp_f%arr)
+        ! none...
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("sipiter1_hp")
 #endif
+
+        CALL sipiter1_hyperplane_level_impl(ilevel, rhs_f%arr, res_f%arr, &
+            siplw%arr, sipls%arr, siplb%arr, siplpr%arr, mip_hp_f%arr, &
+            idx_hp_f%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE sipiter1_hyperplane_level
+
+
+    SUBROUTINE sipiter1_hyperplane_level_impl(ilevel, rhs, res, lw, ls, lb, &
+            lpr, mip, idx)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: ilevel
+        REAL(realk), INTENT(in) :: rhs(*)
+        REAL(realk), INTENT(inout) :: res(*)
+        REAL(realk), INTENT(in) :: lw(*), ls(*), lb(*), lpr(*)
+        INTEGER(ifk), INTENT(in) :: mip(*), idx(*)
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid
+        INTEGER(intk) :: kk, jj, ii, ip3
+
         !$omp target teams distribute private(i, igrid, kk, jj, ii, ip3)
         DO i = 1, nmygridslvl(ilevel)
             igrid = mygridslvl(i, ilevel)
             CALL get_mgdims(kk, jj, ii, igrid)
             CALL get_ip3(ip3, igrid)
 
+            !$omp parallel
             CALL sipiter1_hp(kk, jj, ii, rhs(ip3), res(ip3), lw(ip3), ls(ip3), &
                 lb(ip3), lpr(ip3), mip(ip3), idx(ip3))
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-        END ASSOCIATE
-    END SUBROUTINE sipiter1_hyperplane_level
+    END SUBROUTINE sipiter1_hyperplane_level_impl
 
 
     SUBROUTINE sipiter2_classic_level(ilevel, dp, res, sipue, sipun, siput)
@@ -580,36 +591,47 @@ CONTAINS
         TYPE(field_t), INTENT(in) :: siput_f
 
         ! Local variables
-        INTEGER(intk) :: i, igrid
-        INTEGER(intk) :: kk, jj, ii, ip3
-
-        ASSOCIATE( &
-            dp => dp_f%arr, &
-            res => res_f%arr, &
-            sipue => sipue_f%arr, &
-            sipun => sipun_f%arr, &
-            siput => siput_f%arr, &
-            mip => mip_hp_f%arr, &
-            idx => idx_hp_f%arr)
+        ! none...
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("sipiter2_hp")
 #endif
+
+        CALL sipiter2_hyperplane_level_impl(ilevel, dp_f%arr, res_f%arr, &
+            sipue_f%arr, sipun_f%arr, siput_f%arr, mip_hp_f%arr, &
+            idx_hp_f%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE sipiter2_hyperplane_level
+
+
+    SUBROUTINE sipiter2_hyperplane_level_impl(ilevel, dp, res, sipue, sipun, &
+            siput, mip, idx)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: ilevel
+        REAL(realk), INTENT(inout) :: dp(*), res(*)
+        REAL(realk), INTENT(in) :: sipue(*), sipun(*), siput(*)
+        INTEGER(ifk), INTENT(in) :: mip(*), idx(*)
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid
+        INTEGER(intk) :: kk, jj, ii, ip3
+
         !$omp target teams distribute private(i, igrid, kk, jj, ii, ip3)
         DO i = 1, nmygridslvl(ilevel)
             igrid = mygridslvl(i, ilevel)
             CALL get_mgdims(kk, jj, ii, igrid)
             CALL get_ip3(ip3, igrid)
 
+            !$omp parallel
             CALL sipiter2_hp(kk, jj, ii, dp(ip3), res(ip3), sipue(ip3), &
                 sipun(ip3), siput(ip3), mip(ip3), idx(ip3))
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-        END ASSOCIATE
-    END SUBROUTINE sipiter2_hyperplane_level
+    END SUBROUTINE sipiter2_hyperplane_level_impl
 
 
     SUBROUTINE maxabscal(maxabs, maxabslevel, phi_f)
@@ -620,36 +642,21 @@ CONTAINS
 
         ! Local variables
         REAL(realk), ALLOCATABLE :: maxabsgrid(:)
-        INTEGER(intk) :: imygrid, igrid, ilevel, ip3
-        INTEGER(intk) :: kk, jj, ii
+        INTEGER(intk) :: imygrid, igrid, ilevel
 
         ALLOCATE(maxabsgrid(nmygrids))
         maxabs = 0.0
         maxabslevel = 0.0
 
-        ASSOCIATE(phi => phi_f%arr, maxagrid => maxabsgrid)
-
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("maxabscal")
 #endif
 
-        !$omp target teams distribute private(imygrid, igrid, kk, jj, ii, ip3) &
-        !$omp& map(from: maxagrid)
-        DO imygrid = 1, nmygrids
-            igrid = mygrids(imygrid)
-            maxagrid(imygrid) = -HUGE(1.0_realk)
-
-            CALL get_mgdims(kk, jj, ii, igrid)
-            CALL get_ip3(ip3, igrid)
-            CALL maxabscal_grid(kk, jj, ii, maxagrid(imygrid), phi(ip3))
-        END DO
-        !$omp end target teams distribute
+        CALL maxabscal_impl(phi_f%arr, maxabsgrid)
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_pop()
 #endif
-
-        END ASSOCIATE
 
         DO imygrid = 1, nmygrids
             igrid = mygrids(imygrid)
@@ -663,18 +670,42 @@ CONTAINS
     END SUBROUTINE maxabscal
 
 
+    SUBROUTINE maxabscal_impl(phi, maxagrid)
+        ! Subroutine arguments
+        REAL(realk), INTENT(in) :: phi(*)
+        REAL(realk), INTENT(inout) :: maxagrid(*)
+
+        ! Local variables
+        INTEGER(intk) :: imygrid, igrid, ip3
+        INTEGER(intk) :: kk, jj, ii
+
+        !$omp target teams distribute private(imygrid, igrid, kk, jj, ii, ip3) &
+        !$omp& map(from: maxagrid(1:nmygrids))
+        DO imygrid = 1, nmygrids
+            igrid = mygrids(imygrid)
+            maxagrid(imygrid) = -HUGE(1.0_realk)
+
+            CALL get_mgdims(kk, jj, ii, igrid)
+            CALL get_ip3(ip3, igrid)
+            !$omp parallel
+            CALL maxabscal_grid(kk, jj, ii, maxagrid(imygrid), phi(ip3))
+            !$omp end parallel
+        END DO
+        !$omp end target teams distribute
+    END SUBROUTINE maxabscal_impl
+
+
     PURE SUBROUTINE maxabscal_grid(kk, jj, ii, maxabs, phi)
         ! Subroutine arguments
         !$omp declare target
         INTEGER(intk), INTENT(in) :: kk, jj, ii
-        REAL(realk), INTENT(out) :: maxabs
+        REAL(realk), INTENT(inout) :: maxabs
         REAL(realk), INTENT(in) :: phi(kk, jj, ii)
 
         ! Local variables
         INTEGER(intk) :: k, j, i
 
-        maxabs = 0.0
-        !$omp parallel do collapse(3) private(i, j, k) reduction(max:maxabs)
+        !$omp do collapse(3) private(i, j, k) reduction(max:maxabs)
         DO i = 3, ii-2
             DO j = 3, jj-2
                 DO k = 3, kk-2
@@ -682,7 +713,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE maxabscal_grid
 
 
@@ -692,28 +723,41 @@ CONTAINS
         TYPE(field_t), INTENT(in) :: res_f
 
         ! Local variables
-        INTEGER(intk) :: i, igrid
-        INTEGER(intk) :: kk, jj, ii, ip3
-
-        ASSOCIATE(rhs => rhs_f%arr, res => res_f%arr)
+        ! none...
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("rescal")
 #endif
+
+        CALL rescal_impl(rhs_f%arr, res_f%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE rescal
+
+
+    SUBROUTINE rescal_impl(rhs, res)
+        ! Subroutine arguments
+        REAL(realk), INTENT(inout) :: rhs(*)
+        REAL(realk), INTENT(in) :: res(*)
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid
+        INTEGER(intk) :: kk, jj, ii, ip3
+
         !$omp target teams distribute private(i, igrid, kk, jj, ii, ip3)
         DO i = 1, nmygrids
             igrid = mygrids(i)
             CALL get_mgdims(kk, jj, ii, igrid)
             CALL get_ip3(ip3, igrid)
 
+            !$omp parallel
             CALL rescal_grid(kk, jj, ii, rhs(ip3), res(ip3))
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-        END ASSOCIATE
-    END SUBROUTINE rescal
+    END SUBROUTINE rescal_impl
 
 
     PURE SUBROUTINE rescal_grid(kk, jj, ii, rhs, res)
@@ -727,7 +771,7 @@ CONTAINS
         INTEGER(intk) :: k, j, i
 
         ! TODO: Check if indices can be extended
-        !$omp parallel do collapse(3) private(i, j, k)
+        !$omp do collapse(3) private(i, j, k)
         DO i = 3, ii-2
             DO j = 3, jj-2
                 DO k = 3, kk-2
@@ -735,7 +779,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE rescal_grid
 
 
@@ -746,26 +790,36 @@ CONTAINS
         REAL(realk), INTENT(in) :: rfak
 
         ! Local variables
-        INTEGER(intk) :: i, igrid, ip3, ip1x, ip1y, ip1z
-        INTEGER(intk) :: kk, jj, ii
-
-        TYPE(field_t), POINTER :: rdx_f
-        TYPE(field_t), POINTER :: rdy_f
-        TYPE(field_t), POINTER :: rdz_f
-        TYPE(field_t), POINTER :: bp_f
+        TYPE(field_t), POINTER :: rdx_f, rdy_f, rdz_f, bp_f
 
         CALL get_field(rdx_f, "RDX")
         CALL get_field(rdy_f, "RDY")
         CALL get_field(rdz_f, "RDZ")
         CALL get_field(bp_f, "BP")
 
-        ASSOCIATE(u => u_f%arr, v => v_f%arr, w => w_f%arr, p => p_f%arr, &
-            dp => dp_f%arr, bp => bp_f%arr, &
-            rdx => rdx_f%arr, rdy => rdy_f%arr, rdz => rdz_f%arr)
-
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("mgpcorr")
 #endif
+
+        CALL mgpcorr_impl(u_f%arr, v_f%arr, w_f%arr, p_f%arr, dp_f%arr, &
+            bp_f%arr, rdx_f%arr, rdy_f%arr, rdz_f%arr, rfak)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE mgpcorr
+
+
+    SUBROUTINE mgpcorr_impl(u, v, w, p, dp, bp, rdx, rdy, rdz, rfak)
+        ! Subroutine arguments
+        REAL(realk), INTENT(inout) :: u(*), v(*), w(*), p(*)
+        REAL(realk), INTENT(in) :: dp(*), bp(*)
+        REAL(realk), INTENT(in) :: rdx(*), rdy(*), rdz(*)
+        REAL(realk), INTENT(in) :: rfak
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid, ip3, ip1x, ip1y, ip1z
+        INTEGER(intk) :: kk, jj, ii
 
         !$omp target teams distribute private(i, igrid, kk, jj, ii, ip3, ip1x, &
         !$omp& ip1y, ip1z)
@@ -783,13 +837,7 @@ CONTAINS
             !$omp end parallel
         END DO
         !$omp end target teams distribute
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-
-        END ASSOCIATE
-    END SUBROUTINE mgpcorr
+    END SUBROUTINE mgpcorr_impl
 
 
     PURE SUBROUTINE mgpcorr_grid(kk, jj, ii, u, v, w, p, dp, bp, rdx, rdy, &
@@ -865,25 +913,36 @@ CONTAINS
         TYPE(field_t), INTENT(in) :: hilf
 
         ! Local variables
-        INTEGER(intk) :: i, n
+        INTEGER(intk) :: n
 
         IF (SIZE(dp%arr) /= SIZE(hilf%arr)) CALL errr(__FILE__, __LINE__)
-
-        n = SIZE(dp%arr)
-
-        ASSOCIATE(dp => dp%arr, hilf => hilf%arr)
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("accumulate_pcorr")
 #endif
+
+        n = SIZE(dp%arr)
+        CALL accumulate_pcorr_impl(dp%arr, hilf%arr, n)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE accumulate_pcorr
+
+
+    SUBROUTINE accumulate_pcorr_impl(dp, hilf, n)
+        ! Subroutine arguments
+        REAL(realk), INTENT(inout) :: dp(*)
+        REAL(realk), INTENT(in) :: hilf(*)
+        INTEGER(intk), INTENT(in) :: n
+
+        ! Local variables
+        INTEGER(intk) :: i
+
         !$omp target teams loop
         DO i = 1, n
             dp(i) = dp(i) + hilf(i)
         END DO
         !$omp end target teams loop
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-        END ASSOCIATE
-    END SUBROUTINE accumulate_pcorr
+    END SUBROUTINE accumulate_pcorr_impl
 END MODULE pressuresolver_mod

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -937,12 +937,26 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: n
 
         ! Local variables
-        INTEGER(intk) :: i
+        INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
 
-        !$omp target teams loop
-        DO i = 1, n
-            dp(i) = dp(i) + hilf(i)
+        ! This is a 4D loop only because there are random crashes with 1D loops
+        ! using the amd compiler
+        !$omp target teams distribute
+        DO imygrid = 1, nmygrids
+            igrid = mygrids(imygrid)
+            CALL get_mgdims(kk, jj, ii, igrid)
+            CALL get_ip3(ip3, igrid)
+
+            !$omp parallel do collapse(3)
+            DO i = 1, ii
+                DO j = 1, jj
+                    DO k = 1, kk
+                        idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj
+                        dp(idx) = dp(idx) + hilf(idx)
+                    END DO
+                END DO
+            END DO
+            !$omp end parallel do
         END DO
-        !$omp end target teams loop
     END SUBROUTINE accumulate_pcorr_impl
 END MODULE pressuresolver_mod

--- a/src/flow/sip_hyperplane_mod.F90
+++ b/src/flow/sip_hyperplane_mod.F90
@@ -469,14 +469,13 @@ CONTAINS
         iacc = -1
 
         ! Iterating over the hyperplanes H(k, j, i) = m
-        !$omp parallel private(m, lm, lp, ip, iacc, idx, idx_km, idx_jm, idx_im)
         DO m = n3dmin, n3dmax
 
             lm = INT(mip(m), intk)
             lp = INT(mip(m+1), intk) - lm
 
             ! > Parallel operations on the hyperplane (k, j, i) = m
-            !$omp loop bind(parallel)
+            !$omp do
             DO ip = 1, lp
 
                 ! Computing the contiguous access index
@@ -500,14 +499,15 @@ CONTAINS
                 !     - ls(k, j, i)*res(k, j-1, i) - lb(k, j, i)*res(k-1, j, i)
 
             END DO
-            !$omp end loop
+            !$omp end do
 
-            ! > Implicit barrier at !$omp end do ignored...
+            ! The do construct should be followed by an implicit barrier that
+            ! synchronizes the threads within the team. However, amdflang does
+            ! not seem to implement this behavior as expected. Therefore, we add
+            ! an explicit barrier here to ensure that all threads have completed
+            ! their work before proceeding to the next hyperplane.
             !$omp barrier
-
         END DO
-        !$omp end parallel
-
     END SUBROUTINE sipiter1
 
 
@@ -532,14 +532,13 @@ CONTAINS
         iacc = -1
 
         ! Iterating (REVERSE) over the hyperplanes H(k, j, i) = m
-        !$omp parallel private(m, lm, lp, ip, iacc, idx, idx_kp, idx_jp, idx_ip)
         DO m = n3dmax, n3dmin, -1
 
             lm = INT(mip(m), intk)
             lp = INT(mip(m+1), intk) - lm
 
             ! > Parallel operations on the hyperplane (k, j, i) = m
-            !$omp loop bind(parallel)
+            !$omp do
             DO ip = 1, lp
 
                 ! Computing the contiguous access index
@@ -560,15 +559,20 @@ CONTAINS
                 !     - ue(k, j, i)*res(k, j, i+1) - ut(k, j, i)*res(k+1, j, i)
 
             END DO
-            !$omp end loop
+            !$omp end do
 
-            ! > Implicit barrier at !$omp end do ignored...
+            ! The do construct should be followed by an implicit barrier that
+            ! synchronizes the threads within the team. However, amdflang does
+            ! not seem to implement this behavior as expected. Therefore, we add
+            ! an explicit barrier here to ensure that all threads have completed
+            ! their work before proceeding to the next hyperplane.
             !$omp barrier
-
         END DO
 
+        ! TODO(offload): Barrier maybe not required?
+        !$omp barrier
 
-        !$omp loop bind(parallel) collapse(3) private(i, j, k, idx)
+        !$omp do collapse(3) private(i, j, k, idx)
         DO i = 3, ii-2
             DO j = 3, jj-2
                 DO k = 3, kk-2
@@ -577,8 +581,6 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end loop
-        !$omp end parallel
-
+        !$omp end do
     END SUBROUTINE sipiter2
 END MODULE sip_hyperplane_mod

--- a/src/flow/timeintegration_mod.F90
+++ b/src/flow/timeintegration_mod.F90
@@ -231,24 +231,54 @@ CONTAINS
         ! Local variables
         REAL(realk), ALLOCATABLE :: cflmax_grid(:)
         REAL(realk), ALLOCATABLE :: cflmax_pos_grid(:, :)
-        INTEGER(intk) :: i, igrid, kk, jj, ii, ip3, ip1x, ip1y, ip1z
+        INTEGER(intk) :: i, igrid
 
         ALLOCATE(cflmax_grid(nmygrids))
         ALLOCATE(cflmax_pos_grid(3, nmygrids))
-
-        ASSOCIATE(u => u_f%arr, v => v_f%arr, w => w_f%arr, bp => bp_f%arr, &
-            x => x_f%arr, y => y_f%arr, z => z_f%arr, &
-            dx => dx_f%arr, dy => dy_f%arr, dz => dz_f%arr, &
-            ddx => ddx_f%arr, ddy => ddy_f%arr, ddz => ddz_f%arr, &
-            cflmaxgrid => cflmax_grid, cflmaxposgrid => cflmax_pos_grid)
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("compcflmax")
 #endif
 
+        CALL compcflmax_impl(u_f%arr, v_f%arr, w_f%arr, bp_f%arr, &
+            x_f%arr, y_f%arr, z_f%arr, dx_f%arr, dy_f%arr, dz_f%arr, &
+            ddx_f%arr, ddy_f%arr, ddz_f%arr, cflmax_grid, &
+            cflmax_pos_grid, dt)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+
+        DO i = 1, nmygrids
+            igrid = mygrids(i)
+            CALL itinfo_sample(igrid, cflmax=cflmax_grid(i), &
+                cflmax_pos=cflmax_pos_grid(:, i))
+        END DO
+
+        DEALLOCATE(cflmax_grid)
+        DEALLOCATE(cflmax_pos_grid)
+    END SUBROUTINE compcflmax
+
+
+    SUBROUTINE compcflmax_impl(u, v, w, bp, x, y, z, dx, dy, dz, ddx, ddy, &
+            ddz, cflmaxgrid, cflmaxposgrid, dt)
+        ! Subroutine arguments
+        REAL(realk), INTENT(in) :: u(*), v(*), w(*), bp(*)
+        REAL(realk), INTENT(in) :: x(*), y(*), z(*)
+        REAL(realk), INTENT(in) :: dx(*), dy(*), dz(*)
+        REAL(realk), INTENT(in) :: ddx(*), ddy(*), ddz(*)
+        REAL(realk), INTENT(inout) :: cflmaxgrid(*)
+        REAL(realk), INTENT(inout) :: cflmaxposgrid(3, *)
+        REAL(realk), INTENT(in) :: dt
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid, kk, jj, ii, ip3, ip1x, ip1y, ip1z
+        TYPE(valpos_t) :: maxvalpos
+
         !$omp target teams distribute private(i, igrid, kk, jj, ii, ip3, ip1x, &
-        !$omp& ip1y, ip1z) &
-        !$omp& map(from: cflmaxgrid, cflmaxposgrid)
+        !$omp& ip1y, ip1z, maxvalpos) &
+        !$omp& map(from: cflmaxgrid(1:nmygrids), &
+        !$omp& cflmaxposgrid(1:3, 1:nmygrids))
         DO i = 1, nmygrids
             igrid = mygrids(i)
             cflmaxgrid(i) = -HUGE(1.0_realk)
@@ -262,35 +292,30 @@ CONTAINS
             CALL get_ip1y(ip1y, igrid)
             CALL get_ip1z(ip1z, igrid)
 
-            CALL compcflmax_grid(cflmaxgrid(i), cflmaxposgrid(:, i), dt, &
+            CALL valpos_init(maxvalpos)
+            !$omp parallel
+            CALL compcflmax_grid(maxvalpos, dt, &
                 kk, jj, ii, u(ip3), v(ip3), w(ip3), bp(ip3), &
                 x(ip1x), y(ip1y), z(ip1z), dx(ip1x), dy(ip1y), dz(ip1z), &
                 ddx(ip1x), ddy(ip1y), ddz(ip1z))
+            !$omp end parallel
+
+            IF (maxvalpos%val >= 0.0_realk) THEN
+                cflmaxgrid(i) = maxvalpos%val * 0.25 * dt
+                cflmaxposgrid(1, i) = maxvalpos%x
+                cflmaxposgrid(2, i) = maxvalpos%y
+                cflmaxposgrid(3, i) = maxvalpos%z
+            END IF
         END DO
         !$omp end target teams distribute
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-
-        DO i = 1, nmygrids
-            igrid = mygrids(i)
-            CALL itinfo_sample(igrid, cflmax=cflmaxgrid(i), &
-                cflmax_pos=cflmaxposgrid(:, i))
-        END DO
-
-        END ASSOCIATE
-
-        DEALLOCATE(cflmax_grid)
-        DEALLOCATE(cflmax_pos_grid)
-    END SUBROUTINE compcflmax
+    END SUBROUTINE compcflmax_impl
 
 
-    SUBROUTINE compcflmax_grid(cflmax, cflmax_pos, dt, kk, jj, ii, &
+    SUBROUTINE compcflmax_grid(maxvalpos, dt, kk, jj, ii, &
             u, v, w, bp, x, y, z, dx, dy, dz, ddx, ddy, ddz)
         !$omp declare target
         ! Subroutine arguments
-        REAL(realk), INTENT(out) :: cflmax, cflmax_pos(3)
+        TYPE(valpos_t), INTENT(inout) :: maxvalpos
         REAL(realk), INTENT(in) :: dt
         INTEGER(intk), INTENT(in) :: kk, jj, ii
         REAL(realk), INTENT(in) :: u(kk, jj, ii), v(kk, jj, ii), w(kk, jj, ii)
@@ -300,16 +325,13 @@ CONTAINS
         REAL(realk), INTENT(in) :: ddx(ii), ddy(jj), ddz(kk)
 
         ! Local variables
-        TYPE(valpos_t) :: maxvalpos, localvalpos
+        TYPE(valpos_t) :: localvalpos
         REAL(realk) :: cflmaxtemp, cflu, cflv, cflw
         INTEGER(intk) :: k, j, i
 
         cflmaxtemp = -HUGE(1.0_realk)
-        cflmax = -HUGE(1.0_realk)
-        cflmax_pos = -HUGE(1.0_realk)
-        CALL valpos_init(maxvalpos)
 
-        !$omp parallel do collapse(3) private(i, j, k, cflu, cflv, cflw, &
+        !$omp do collapse(3) private(i, j, k, cflu, cflv, cflw, &
         !$omp& cflmaxtemp, localvalpos) &
         !$omp& reduction(valpos:maxvalpos)
         DO i = 3, ii-2
@@ -355,15 +377,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
-
-        ! Only write output if a valid cell was found.
-        IF (maxvalpos%val >= 0.0_realk) THEN
-            cflmax = maxvalpos%val * 0.25 * dt
-            cflmax_pos(1) = maxvalpos%x
-            cflmax_pos(2) = maxvalpos%y
-            cflmax_pos(3) = maxvalpos%z
-        END IF
+        !$omp end do
     END SUBROUTINE compcflmax_grid
 
 
@@ -379,24 +393,51 @@ CONTAINS
         ! Local variables
         REAL(realk), ALLOCATABLE :: divmax_grid(:)
         REAL(realk), ALLOCATABLE :: divmax_pos_grid(:, :)
-        INTEGER(intk) :: i, igrid, kk, jj, ii, ip3, ip1x, ip1y, ip1z
+        INTEGER(intk) :: i, igrid
 
         ALLOCATE(divmax_grid(nmygrids))
         ALLOCATE(divmax_pos_grid(3, nmygrids))
-
-        ASSOCIATE(u => u_f%arr, v => v_f%arr, w => w_f%arr, bp => bp_f%arr, &
-            x => x_f%arr, y => y_f%arr, z => z_f%arr, &
-            rddx => rddx_f%arr, rddy => rddy_f%arr, rddz => rddz_f%arr, &
-            sdiv => sdiv_f%arr, &
-            divmaxgrid => divmax_grid, divmaxposgrid => divmax_pos_grid)
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("compdivmax")
 #endif
 
+        CALL compdivmax_impl(u_f%arr, v_f%arr, w_f%arr, bp_f%arr, &
+            x_f%arr, y_f%arr, z_f%arr, rddx_f%arr, rddy_f%arr, &
+            rddz_f%arr, sdiv_f%arr, divmax_grid, divmax_pos_grid)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+
+        DO i = 1, nmygrids
+            igrid = mygrids(i)
+            CALL itinfo_sample(igrid, divmax=divmax_grid(i), &
+                divmax_pos=divmax_pos_grid(:, i))
+        END DO
+
+        DEALLOCATE(divmax_grid)
+        DEALLOCATE(divmax_pos_grid)
+    END SUBROUTINE compdivmax
+
+
+    SUBROUTINE compdivmax_impl(u, v, w, bp, x, y, z, rddx, rddy, rddz, &
+            sdiv, divmaxgrid, divmaxposgrid)
+        ! Subroutine arguments
+        REAL(realk), INTENT(in) :: u(*), v(*), w(*), bp(*)
+        REAL(realk), INTENT(in) :: x(*), y(*), z(*)
+        REAL(realk), INTENT(in) :: rddx(*), rddy(*), rddz(*), sdiv(*)
+        REAL(realk), INTENT(inout) :: divmaxgrid(*)
+        REAL(realk), INTENT(inout) :: divmaxposgrid(3, *)
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid, kk, jj, ii, ip3, ip1x, ip1y, ip1z
+        TYPE(valpos_t) :: maxvalpos
+
         !$omp target teams distribute private(i, igrid, kk, jj, ii, ip3, ip1x, &
-        !$omp& ip1y, ip1z) &
-        !$omp& map(from: divmaxgrid, divmaxposgrid)
+        !$omp& ip1y, ip1z, maxvalpos) &
+        !$omp& map(from: divmaxgrid(1:nmygrids), &
+        !$omp& divmaxposgrid(1:3, 1:nmygrids))
         DO i = 1, nmygrids
             igrid = mygrids(i)
             divmaxgrid(i) = -HUGE(1.0_realk)
@@ -410,37 +451,32 @@ CONTAINS
             CALL get_ip1y(ip1y, igrid)
             CALL get_ip1z(ip1z, igrid)
 
-            CALL compdivmax_grid(divmaxgrid(i), divmaxposgrid(:, i), &
+            CALL valpos_init(maxvalpos)
+            !$omp parallel
+            CALL compdivmax_grid(maxvalpos, &
                 kk, jj, ii, u(ip3), v(ip3), w(ip3), x(ip1x), y(ip1y), z(ip1z), &
                 rddx(ip1x), rddy(ip1y), rddz(ip1z), bp(ip3), sdiv(ip3))
+            !$omp end parallel
+
+            IF (maxvalpos%val >= 0.0_realk) THEN
+                divmaxgrid(i) = maxvalpos%val
+                divmaxposgrid(1, i) = maxvalpos%x
+                divmaxposgrid(2, i) = maxvalpos%y
+                divmaxposgrid(3, i) = maxvalpos%z
+            END IF
         END DO
         !$omp end target teams distribute
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-
-        DO i = 1, nmygrids
-            igrid = mygrids(i)
-            CALL itinfo_sample(igrid, divmax=divmaxgrid(i), &
-                divmax_pos=divmaxposgrid(:, i))
-        END DO
-
-        END ASSOCIATE
-
-        DEALLOCATE(divmax_grid)
-        DEALLOCATE(divmax_pos_grid)
-    END SUBROUTINE compdivmax
+    END SUBROUTINE compdivmax_impl
 
 
     ! Simpler routine than "divcal", because this one does only compute the
     ! /max/ divergence and its location, and does not explicitly fill in
     ! a full 3-D divergcence field.
-    SUBROUTINE compdivmax_grid(divmax, divmax_pos, kk, jj, ii, u, v, w, &
+    SUBROUTINE compdivmax_grid(maxvalpos, kk, jj, ii, u, v, w, &
             x, y, z, rddx, rddy, rddz, bp, sdiv)
         !$omp declare target
         ! Subroutine arguments
-        REAL(realk), INTENT(out) :: divmax, divmax_pos(3)
+        TYPE(valpos_t), INTENT(inout) :: maxvalpos
         INTEGER(intk), INTENT(in) :: kk, jj, ii
         REAL(realk), INTENT(in) :: u(kk, jj, ii)
         REAL(realk), INTENT(in) :: v(kk, jj, ii)
@@ -451,15 +487,11 @@ CONTAINS
         REAL(realk), INTENT(in) :: sdiv(kk, jj, ii)
 
         ! Local variables
-        TYPE(valpos_t) :: maxvalpos, localvalpos
+        TYPE(valpos_t) :: localvalpos
         INTEGER(intk) :: k, j, i
         REAL(realk) :: div
 
-        divmax = -HUGE(1.0_realk)
-        divmax_pos = -HUGE(1.0_realk)
-        CALL valpos_init(maxvalpos)
-
-        !$omp parallel do collapse(3) private(i, j, k, div, localvalpos) &
+        !$omp do collapse(3) private(i, j, k, div, localvalpos) &
         !$omp& reduction(valpos:maxvalpos)
         DO i = 3, ii-2
             DO j = 3, jj-2
@@ -478,15 +510,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
-
-        ! Only write output if a valid cell was found.
-        IF (maxvalpos%val >= 0.0_realk) THEN
-            divmax = maxvalpos%val
-            divmax_pos(1) = maxvalpos%x
-            divmax_pos(2) = maxvalpos%y
-            divmax_pos(3) = maxvalpos%z
-        END IF
+        !$omp end do
     END SUBROUTINE compdivmax_grid
 
 
@@ -530,17 +554,43 @@ CONTAINS
         TYPE(field_t), INTENT(in) :: ddx_f, ddy_f, ddz_f
 
         ! Local variables
-        REAL(realk), ALLOCATABLE :: esumg_grid(:)
-        REAL(realk), ALLOCATABLE :: esums_grid(:)
-        INTEGER(intk) :: i, igrid, kk, jj, ii, ip3, ip1x, ip1y, ip1z
+        REAL(realk), ALLOCATABLE :: esumg_grid(:), vsumg_grid(:)
+        REAL(realk), ALLOCATABLE :: esums_grid(:), vsums_grid(:)
+        INTEGER(intk) :: i, igrid
 
         ALLOCATE(esumg_grid(nmygrids))
         ALLOCATE(esums_grid(nmygrids))
+        ALLOCATE(vsumg_grid(nmygrids))
+        ALLOCATE(vsums_grid(nmygrids))
 
-        ASSOCIATE(u => u_f%arr, v => v_f%arr, w => w_f%arr, g => g_f%arr, &
-            dx => dx_f%arr, dy => dy_f%arr, dz => dz_f%arr, &
-            ddx => ddx_f%arr, ddy => ddy_f%arr, ddz => ddz_f%arr, &
-            esumggrid => esumg_grid, esumsgrid => esums_grid)
+        CALL compenergy_impl(u_f%arr, v_f%arr, w_f%arr, g_f%arr, dx_f%arr, &
+            dy_f%arr, dz_f%arr, ddx_f%arr, ddy_f%arr, ddz_f%arr, &
+            esumg_grid, esums_grid, vsumg_grid, vsums_grid)
+
+        DO i = 1, nmygrids
+            igrid = mygrids(i)
+            CALL itinfo_sample(igrid, esumg=esumg_grid(i), &
+                esums=esums_grid(i))
+        END DO
+
+        DEALLOCATE(esumg_grid)
+        DEALLOCATE(vsumg_grid)
+        DEALLOCATE(esums_grid)
+        DEALLOCATE(vsums_grid)
+    END SUBROUTINE compenergy
+
+
+    SUBROUTINE compenergy_impl(u, v, w, g, dx, dy, dz, ddx, ddy, ddz, &
+            esumggrid, esumsgrid, vsumggrid, vsumsgrid)
+        ! Subroutine arguments
+        REAL(realk), INTENT(in) :: u(*), v(*), w(*), g(*)
+        REAL(realk), INTENT(in) :: dx(*), dy(*), dz(*)
+        REAL(realk), INTENT(in) :: ddx(*), ddy(*), ddz(*)
+        REAL(realk), INTENT(inout) :: esumggrid(*), esumsgrid(*)
+        REAL(realk), INTENT(inout) :: vsumggrid(*), vsumsgrid(*)
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid, kk, jj, ii, ip3, ip1x, ip1y, ip1z
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("compenergy")
@@ -548,11 +598,14 @@ CONTAINS
 
         !$omp target teams distribute private(i, igrid, kk, jj, ii, ip3, ip1x, &
         !$omp& ip1y, ip1z) &
-        !$omp& map(from: esumggrid, esumsgrid)
+        !$omp& map(from: esumggrid(1:nmygrids), esumsgrid(1:nmygrids)) &
+        !$omp& map(alloc: vsumggrid(1:nmygrids), vsumsgrid(1:nmygrids))
         DO i = 1, nmygrids
             igrid = mygrids(i)
             esumggrid(i) = 0.0_realk
             esumsgrid(i) = 0.0_realk
+            vsumggrid(i) = 0.0_realk
+            vsumsgrid(i) = 0.0_realk
 
             CALL get_mgdims(kk, jj, ii, igrid)
             CALL get_ip3(ip3, igrid)
@@ -560,10 +613,20 @@ CONTAINS
             CALL get_ip1y(ip1y, igrid)
             CALL get_ip1z(ip1z, igrid)
 
-            CALL enerfg_grid(esumggrid(i), kk, jj, ii, u(ip3), v(ip3), w(ip3), &
-                dx(ip1x), dy(ip1y), dz(ip1z), ddx(ip1x), ddy(ip1y), ddz(ip1z))
-            CALL enerfs_grid(esumsgrid(i), kk, jj, ii, g(ip3), &
+            !$omp parallel
+            CALL enerfg_grid(esumggrid(i), vsumggrid(i), kk, jj, ii, &
+                u(ip3), v(ip3), w(ip3), dx(ip1x), dy(ip1y), dz(ip1z), &
                 ddx(ip1x), ddy(ip1y), ddz(ip1z))
+            CALL enerfs_grid(esumsgrid(i), vsumsgrid(i), kk, jj, ii, g(ip3), &
+                ddx(ip1x), ddy(ip1y), ddz(ip1z))
+            !$omp end parallel
+
+            IF (vsumggrid(i) > 0.0_realk) THEN
+                esumggrid(i) = esumggrid(i)/vsumggrid(i)
+            END IF
+            IF (vsumsgrid(i) > 0.0_realk) THEN
+                esumsgrid(i) = esumsgrid(i)/vsumsgrid(i)
+            END IF
         END DO
         !$omp end target teams distribute
 
@@ -571,35 +634,24 @@ CONTAINS
         CALL profile_range_pop()
 #endif
 
-        DO i = 1, nmygrids
-            igrid = mygrids(i)
-            CALL itinfo_sample(igrid, esumg=esumggrid(i), esums=esumsgrid(i))
-        END DO
-
-        END ASSOCIATE
-
-        DEALLOCATE(esumg_grid)
-        DEALLOCATE(esums_grid)
-    END SUBROUTINE compenergy
+    END SUBROUTINE compenergy_impl
 
 
-    SUBROUTINE enerfg_grid(esum, kk, jj, ii, u, v, w, dx, dy, dz, ddx, ddy, ddz)
+    SUBROUTINE enerfg_grid(esum, vsum, kk, jj, ii, u, v, w, dx, dy, dz, &
+            ddx, ddy, ddz)
         !$omp declare target
         ! Subroutine arguments
-        REAL(realk), INTENT(out) :: esum
+        REAL(realk), INTENT(inout) :: esum, vsum
         INTEGER(intk), INTENT(in) :: kk, jj, ii
         REAL(realk), INTENT(in) :: u(kk, jj, ii), v(kk, jj, ii), w(kk, jj, ii)
         REAL(realk), INTENT(in) :: dx(ii), dy(jj), dz(kk)
         REAL(realk), INTENT(in) :: ddx(ii), ddy(jj), ddz(kk)
 
         ! Local variables
-        REAL(realk) :: up, vp, wp, vsum, vol
+        REAL(realk) :: up, vp, wp, vol
         INTEGER(intk) :: k, j, i
 
-        esum = 0.0_realk
-        vsum = 0.0_realk
-
-        !$omp parallel do collapse(3) private(i, j, k, up, vp, wp, vol) &
+        !$omp do collapse(3) private(i, j, k, up, vp, wp, vol) &
         !$omp& reduction(+:esum, vsum)
         DO i = 3, ii-2
             DO j = 3, jj-2
@@ -619,29 +671,24 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
-
-        esum = esum/vsum
+        !$omp end do
     END SUBROUTINE enerfg_grid
 
 
-    SUBROUTINE enerfs_grid(esum, kk, jj, ii, g, ddx, ddy, ddz)
+    SUBROUTINE enerfs_grid(esum, vsum, kk, jj, ii, g, ddx, ddy, ddz)
         !$omp declare target
         ! Subroutine arguments
-        REAL(realk), INTENT(out) :: esum
+        REAL(realk), INTENT(inout) :: esum, vsum
         INTEGER(intk), INTENT(in) :: kk, jj, ii
         REAL(realk), INTENT(in) :: g(kk, jj, ii)
         REAL(realk), INTENT(in) :: ddx(ii), ddy(jj), ddz(kk)
 
         ! Local variables
         REAL(realk), PARAMETER :: conv2s = 0.094
-        REAL(realk) :: delta, ener, vsum, vol
+        REAL(realk) :: delta, ener, vol
         INTEGER(intk) :: k, j, i
 
-        esum = 0.0_realk
-        vsum = 0.0_realk
-
-        !$omp parallel do collapse(3) private(i, j, k, delta, ener, vol) &
+        !$omp do collapse(3) private(i, j, k, delta, ener, vol) &
         !$omp& reduction(+:esum, vsum)
         DO i = 3, ii-2
             DO j = 3, jj-2
@@ -655,9 +702,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
-
-        esum = esum/vsum
+        !$omp end do
     END SUBROUTINE enerfs_grid
 
 

--- a/src/ib/ctof/ctof2_mod.F90
+++ b/src/ib/ctof/ctof2_mod.F90
@@ -447,9 +447,7 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: etasks(selftasksize, nselftasks+1)
 
         ! Local variables
-        INTEGER(intk) :: itask, ista, jsta, ksta, isto, jsto, ksto
-        INTEGER(intk) :: iif, jjf, kkf, iic, jjc, kkc
-        INTEGER(intk) :: igridc, igridf, ip3c, ip3f
+        ! none...
 
         ! Leaving immediately if there are no tasks to process
         IF (nselftasks < 1) RETURN
@@ -458,7 +456,30 @@ CONTAINS
         CALL profile_range_push("process_selftasks")
 #endif
 
-        ASSOCIATE(fc => fc%arr, ff => ff%arr)
+        CALL process_selftasks_impl(fc%arr, ff%arr, nselftasks, etasks)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+
+        ! Checking for the dummy entry at position (end+1)
+        IF (etasks(1, nselftasks+1) /= -1) THEN
+            CALL errr(__FILE__, __LINE__)
+        END IF
+        END SUBROUTINE process_selftasks
+
+
+        SUBROUTINE process_selftasks_impl(fc, ff, nselftasks, etasks)
+        ! Subroutine arguments
+        REAL(realk), INTENT(in) :: fc(*)
+        REAL(realk), INTENT(inout) :: ff(*)
+        INTEGER(intk), INTENT(in) :: nselftasks
+        INTEGER(intk), INTENT(in) :: etasks(selftasksize, nselftasks+1)
+
+        ! Local variables
+        INTEGER(intk) :: itask, ista, jsta, ksta, isto, jsto, ksto
+        INTEGER(intk) :: iif, jjf, kkf, iic, jjc, kkc
+        INTEGER(intk) :: igridc, igridf, ip3c, ip3f
 
         !$omp target teams distribute private(itask, igridf, igridc, &
         !$omp&  ista, jsta, ksta, isto, jsto, ksto, ip3f, ip3c, &
@@ -481,22 +502,13 @@ CONTAINS
             CALL get_mgdims(kkf, jjf, iif, igridf)
             CALL get_mgdims(kkc, jjc, iic, igridc)
 
+            !$omp parallel
             CALL copy_kernel(kkf, jjf, iif, kkc, jjc, iic, &
                 ff(ip3f), fc(ip3c), ista, jsta, ksta, isto, jsto, ksto)
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-
-        END ASSOCIATE
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-
-        ! Checking for the dummy entry at position (end+1)
-        IF (etasks(1, nselftasks+1) /= -1) THEN
-            CALL errr(__FILE__, __LINE__)
-        END IF
-    END SUBROUTINE process_selftasks
+    END SUBROUTINE process_selftasks_impl
 
 
     SUBROUTINE copy_kernel(kkf, jjf, iif, kkc, jjc, iic, &
@@ -514,7 +526,7 @@ CONTAINS
         ! Local variables
         INTEGER(intk) :: i, j, k, ic, jc, kc
 
-        !$omp parallel do collapse(3) private(i, j, k, ic, jc, kc)
+        !$omp do collapse(3) private(i, j, k, ic, jc, kc)
         DO i = 1, iif
             DO j = 1, jjf
                 DO k = 1, kkf
@@ -524,10 +536,12 @@ CONTAINS
                     jc = (j-1)/2 + jsta
                     kc = (k-1)/2 + ksta
 
+#ifdef _MGLET_DEBUG_
                     ! Checking that the coarse grid indices are within bounds
                     IF (ic > isto .OR. jc > jsto .OR. kc > ksto) THEN
                         CALL errr(__FILE__, __LINE__)
                     END IF
+#endif
 
                     ! Copying the value from the coarse grid to the fine grid
                     ff(k, j, i) = fc(kc, jc, ic)
@@ -535,7 +549,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE copy_kernel
 
 
@@ -591,8 +605,7 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: stasks(sendtasksize, nstasks+1)
 
         ! Local variables
-        INTEGER(intk) :: igridc, itask, ii, jj, kk, ip3
-        INTEGER(intk) :: ista, jsta, ksta, isto, jsto, ksto, idx1, idx2
+        ! none...
 
         ! Leaving immediately if there are no tasks to process
         IF (nstasks < 1) RETURN
@@ -601,7 +614,23 @@ CONTAINS
         CALL profile_range_push("process_sendtasks")
 #endif
 
-        ASSOCIATE(coarse => fc%arr)
+        CALL process_sendtasks_impl(fc%arr, nstasks, stasks)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+        END SUBROUTINE process_sendtasks
+
+
+        SUBROUTINE process_sendtasks_impl(coarse, nstasks, stasks)
+        ! Subroutine arguments
+        REAL(realk), INTENT(in) :: coarse(*)
+        INTEGER(intk), INTENT(in) :: nstasks
+        INTEGER(intk), INTENT(in) :: stasks(sendtasksize, nstasks+1)
+
+        ! Local variables
+        INTEGER(intk) :: igridc, itask, ii, jj, kk, ip3
+        INTEGER(intk) :: ista, jsta, ksta, isto, jsto, ksto, idx1, idx2
 
         !$omp target teams distribute private(itask, ii, jj, kk, ip3, &
         !$omp&  ista, jsta, ksta, isto, jsto, ksto, idx1, idx2, igridc)
@@ -622,18 +651,13 @@ CONTAINS
             CALL get_ip3(ip3, igridc)
             CALL get_mgdims(kk, jj, ii, igridc)
 
+            !$omp parallel
             CALL write_buffer(kk, jj, ii, sendbuf(idx1:idx2), &
                 coarse(ip3), ista, jsta, ksta, isto, jsto, ksto)
-
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-
-        END ASSOCIATE
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-    END SUBROUTINE process_sendtasks
+    END SUBROUTINE process_sendtasks_impl
 
 
     SUBROUTINE write_buffer(kk, jj, ii, buf, fc, ista, jsta, ksta, &
@@ -642,7 +666,7 @@ CONTAINS
 
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: kk, jj, ii
-        REAL(realk), INTENT(inout) :: buf(:)
+        REAL(realk), INTENT(inout) :: buf(*)
         REAL(realk), INTENT(in) :: fc(kk, jj, ii)
         INTEGER(intk), INTENT(in) :: ista, jsta, ksta
         INTEGER(intk), INTENT(in) :: isto, jsto, ksto
@@ -656,7 +680,7 @@ CONTAINS
         jjc = jsto - jsta + 1
         kkc = ksto - ksta + 1
 
-        !$omp parallel do collapse(3) private(i, j, k, idx)
+        !$omp do collapse(3) private(i, j, k, idx)
         DO i = ista, isto
             DO j = jsta, jsto
                 DO k = ksta, ksto
@@ -665,7 +689,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE write_buffer
 
 
@@ -791,7 +815,7 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: rtasks(recvtasksize, nrtasks+1)
 
         ! Local variables
-        INTEGER(intk) :: igridf, idx, len, itask, ii, jj, kk, ip3
+        ! none...
 
         ! Leaving immediately if there are no tasks to process
         IF (nrtasks < 1) RETURN
@@ -800,7 +824,22 @@ CONTAINS
         CALL profile_range_push("process_recvtasks")
 #endif
 
-        ASSOCIATE(fine => ff%arr)
+        CALL process_recvtasks_impl(ff%arr, nrtasks, rtasks)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+        END SUBROUTINE process_recvtasks
+
+
+        SUBROUTINE process_recvtasks_impl(fine, nrtasks, rtasks)
+        ! Subroutine arguments
+        REAL(realk), INTENT(inout) :: fine(*)
+        INTEGER(intk), INTENT(in) :: nrtasks
+        INTEGER(intk), INTENT(in) :: rtasks(recvtasksize, nrtasks+1)
+
+        ! Local variables
+        INTEGER(intk) :: igridf, idx, len, itask, ii, jj, kk, ip3
 
         !$omp target teams distribute private(itask, ii, jj, kk, ip3, &
         !$omp&  igridf, idx, len)
@@ -815,18 +854,15 @@ CONTAINS
             CALL get_ip3(ip3, igridf)
             len = kk * jj * ii / 8
 
-            ! Copying from buffer to the fine grid
-            CALL write_fine(kk, jj, ii, fine(ip3), len, recvbuf(idx:idx+len-1))
 
+            !$omp parallel
+            ! Copying from buffer to the fine grid
+            CALL write_fine(kk, jj, ii, fine(ip3), len, &
+                recvbuf(idx:idx+len-1))
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-
-        END ASSOCIATE
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-    END SUBROUTINE process_recvtasks
+    END SUBROUTINE process_recvtasks_impl
 
 
     SUBROUTINE write_fine(kk, jj, ii, fff, len, fc)
@@ -847,7 +883,7 @@ CONTAINS
         jjc = jj/2
         iic = ii/2
 
-        !$omp parallel do collapse(3) private(i, j, k, idx, kc, jc, ic)
+        !$omp do collapse(3) private(i, j, k, idx, kc, jc, ic)
         DO i = 1, ii
             DO j = 1, jj
                 DO k = 1, kk
@@ -861,7 +897,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE write_fine
 
 

--- a/src/ib/divcal_mod.F90
+++ b/src/ib/divcal_mod.F90
@@ -15,10 +15,12 @@ CONTAINS
 
         ! Local variables
         TYPE(field_t), POINTER :: rddx_f, rddy_f, rddz_f, bp_f
-        INTEGER(intk) :: i, igrid, ilevel, ip3, ip1x, ip1y, ip1z, kk, jj, ii
+        LOGICAL, ALLOCATABLE :: active_levels(:)
         LOGICAL :: device2
 
         CALL start_timer(240)
+
+        ALLOCATE(active_levels(1:maxlevel-minlevel+1))
 
         IF (PRESENT(device)) THEN
             device2 = device
@@ -31,24 +33,53 @@ CONTAINS
         CALL get_field(rddz_f, "RDDZ")
         CALL get_field(bp_f, "BP")
 
-        ASSOCIATE(div => div_f%arr, u => u_f%arr, v => v_f%arr, w => w_f%arr, &
-                  rddx => rddx_f%arr, rddy => rddy_f%arr, rddz => rddz_f%arr, &
-                  bp => bp_f%arr, active_level => u_f%active_level)
+        active_levels = u_f%active_level(minlevel:maxlevel)
 
-        ! For now, avoid mapping active_level for every field in order not to
-        ! pollute the mapping table. Mapping one array of size minlevel:maxlevel
-        ! per kernel launch is still very cheap.
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("divcal")
+#endif
+
+        CALL divcal_impl(div_f%arr, u_f%arr, v_f%arr, w_f%arr, &
+            rddx_f%arr, rddy_f%arr, rddz_f%arr, bp_f%arr, active_levels, &
+            fak, device2)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+
+        CALL stop_timer(240)
+    END SUBROUTINE divcal
+
+
+    SUBROUTINE divcal_impl(div, u, v, w, rddx, rddy, rddz, bp, &
+            active_levels, fak, device2)
+        ! Subroutine arguments
+        REAL(realk), INTENT(inout) :: div(*)
+        REAL(realk), INTENT(in) :: u(*), v(*), w(*)
+        REAL(realk), INTENT(in) :: rddx(*), rddy(*), rddz(*), bp(*)
+        LOGICAL, INTENT(in) :: active_levels(*)
+        REAL(realk), INTENT(in) :: fak
+        LOGICAL, INTENT(in) :: device2
+
+        ! Local variables
+        INTEGER(intk) :: i, igrid, ilevel, ip3, ip1x, ip1y, ip1z, kk, jj, ii
+
+        ! active_level must be handled specially because it might start at
+        ! minlvl=0 or minlvl=1. If we want to avoid copying descriptors, then
+        ! it should be ensured that active_level always starts at minlvl=1.
+        ! This explains the allocatable array active_levels, which is a copy of
+        ! the active_level array of u_f.
 
         !$omp target teams distribute private(kk, jj, ii, ip3, ip1x, ip1y, &
         !$omp& ip1z, igrid, ilevel) &
-        !$omp& map(to: active_level) &
+        !$omp& map(to: active_levels(1:maxlevel-minlevel+1)) &
         !$omp& if(device2)
         DO i = 1, nmygrids
             igrid = mygrids(i)
             ilevel = level(igrid)
 
             ! Assume that U, V, W and DIV are defined on the same levels!!!
-            IF (.NOT. active_level(ilevel)) CYCLE
+            IF (.NOT. active_levels(ilevel-minlevel+1)) CYCLE
 
             CALL get_mgdims(kk, jj, ii, igrid)
             CALL get_ip3(ip3, igrid)
@@ -56,15 +87,13 @@ CONTAINS
             CALL get_ip1y(ip1y, igrid)
             CALL get_ip1z(ip1z, igrid)
 
+            !$omp parallel
             CALL divcal_grid(kk, jj, ii, div(ip3), u(ip3), v(ip3), w(ip3), &
                 bp(ip3), rddx(ip1x), rddy(ip1y), rddz(ip1z), fak)
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-
-        END ASSOCIATE
-
-        CALL stop_timer(240)
-    END SUBROUTINE divcal
+    END SUBROUTINE divcal_impl
 
 
     SUBROUTINE divcal_grid(kk, jj, ii, div, u, v, w, bp, rddx, rddy, rddz, fak)
@@ -82,7 +111,7 @@ CONTAINS
         ! Local variables
         INTEGER(intk) :: k, j, i
 
-        !$omp parallel do collapse(3) private(k, j, i)
+        !$omp do collapse(3) private(k, j, i)
         DO i = 3, ii-2
             DO j = 3, jj-2
                 DO k = 3, kk-2
@@ -93,6 +122,6 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE divcal_grid
 END MODULE divcal_mod

--- a/src/ib/ftoc/ftoc2_mod.F90
+++ b/src/ib/ftoc/ftoc2_mod.F90
@@ -401,20 +401,38 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: rtasks(recvtasksize, nrtasks+1)
 
         ! Local variables
+        ! none...
+
+        IF (nrtasks == 0) RETURN
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("process_recvtasks")
+#endif
+
+        CALL process_recvtasks_impl(nrtasks, rtasks, f1%arr, f2%arr, &
+            f3%arr, f4%arr, f5%arr, f6%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+
+        CALL check_recvtasks_dummy(nrtasks, rtasks)
+        END SUBROUTINE process_recvtasks
+
+
+        SUBROUTINE process_recvtasks_impl(nrtasks, rtasks, a1, a2, a3, a4, &
+            a5, a6)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nrtasks
+        INTEGER(intk), INTENT(in) :: rtasks(recvtasksize, nrtasks+1)
+        REAL(realk), INTENT(inout) :: a1(*), a2(*), a3(*), a4(*), a5(*), a6(*)
+
+        ! Local variables
         INTEGER(intk) :: itask, fieldid, tasksize, recvidx, igridc
         CHARACTER(len=1) :: flag
         INTEGER(intk) :: kk, jj, ii, ip3
         INTEGER(intk) :: istart, istop, jstart, jstop, kstart, kstop
         INTEGER(intk) :: ipos, jpos, kpos
-
-        IF (nrtasks == 0) RETURN
-
-        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
-                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr)
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_push("process_recvtasks")
-#endif
 
         !$omp target teams distribute private(itask, fieldid, flag, &
         !$omp& tasksize, recvidx, igridc, istart, istop, jstart, jstop, &
@@ -438,6 +456,7 @@ CONTAINS
             CALL get_mgdims(kk, jj, ii, igridc)
             CALL get_ip3(ip3, igridc)
 
+            !$omp parallel
             SELECT CASE(fieldid)
             CASE (1)
                 CALL unpack_restricted_buffer(flag, kk, jj, ii, a1(ip3), &
@@ -468,20 +487,25 @@ CONTAINS
                 CALL errr(__FILE__, __LINE__)
 #endif
             END SELECT
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
+    END SUBROUTINE process_recvtasks_impl
 
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
 
-        END ASSOCIATE
+    SUBROUTINE check_recvtasks_dummy(nrtasks, rtasks)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nrtasks
+        INTEGER(intk), INTENT(in) :: rtasks(recvtasksize, nrtasks+1)
+
+        ! Local variables
+        ! none...
 
         IF (.NOT. ALL(rtasks(:, nrtasks+1) == -1)) THEN
             WRITE(*, *) "Did not encounter the expected dummy task."
             CALL errr(__FILE__, __LINE__)
         END IF
-    END SUBROUTINE process_recvtasks
+    END SUBROUTINE check_recvtasks_dummy
 
 
     SUBROUTINE prepare_recvtasks_all(rtasks, nrtasks, flag, &
@@ -654,20 +678,36 @@ CONTAINS
         TYPE(field_t), INTENT(in) :: ddx, ddy, ddz
 
         ! Local variables
+        ! none...
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("process_selftasks_noib")
+#endif
+
+        CALL process_selftasks_noib_impl(netasks, etasks, f1%arr, f2%arr, &
+            f3%arr, f4%arr, f5%arr, f6%arr, ddx%arr, ddy%arr, ddz%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE process_selftasks_noib
+
+
+    SUBROUTINE process_selftasks_noib_impl(netasks, etasks, a1, a2, a3, a4, &
+            a5, a6, ddx, ddy, ddz)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: netasks
+        INTEGER(intk), INTENT(in) :: etasks(selftasksize, netasks+1)
+        REAL(realk), INTENT(inout) :: a1(*), a2(*), a3(*), a4(*), a5(*), a6(*)
+        REAL(realk), INTENT(in) :: ddx(*), ddy(*), ddz(*)
+
+        ! Local variables
         INTEGER(intk) :: itask, kkf, jjf, iif, kkc, jjc, iic
         INTEGER(intk) :: ip3f, ip3c, ipx, ipy, ipz
         INTEGER(intk) :: fieldid, igridf, igridc, istart, istop, jstart, &
             jstop, kstart, kstop, ipos, jpos, kpos
         INTEGER(int32) :: tasksize, scratchidx
         CHARACTER(len=1) :: flag
-
-        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
-                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr, &
-                  ddx => ddx%arr, ddy => ddy%arr, ddz => ddz%arr)
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_push("process_selftasks_noib")
-#endif
 
         !$omp target teams distribute private(itask, fieldid, flag, &
         !$omp& tasksize, scratchidx, igridf, igridc, istart, istop, jstart, &
@@ -698,6 +738,7 @@ CONTAINS
             CALL get_ip1y(ipy, igridf)
             CALL get_ip1z(ipz, igridf)
 
+            !$omp parallel
             SELECT CASE(fieldid)
             CASE (1)
                 CALL restrict_noib_flag(flag, kkf, jjf, iif, &
@@ -758,15 +799,10 @@ CONTAINS
                 CALL errr(__FILE__, __LINE__)
 #endif
             END SELECT
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-
-        END ASSOCIATE
-    END SUBROUTINE process_selftasks_noib
+    END SUBROUTINE process_selftasks_noib_impl
 
 
     SUBROUTINE process_selftasks_gc(netasks, etasks, ddx_f, ddy_f, ddz_f, &
@@ -777,21 +813,37 @@ CONTAINS
         TYPE(field_t), INTENT(in) :: ddx_f, ddy_f, ddz_f, bp_f, bt_f
 
         ! Local variables
+        ! none...
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("process_selftasks_gc")
+#endif
+
+        CALL process_selftasks_gc_impl(netasks, etasks, f1%arr, f2%arr, &
+            f3%arr, f4%arr, f5%arr, f6%arr, ddx_f%arr, ddy_f%arr, &
+            ddz_f%arr, bp_f%arr, bt_f%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE process_selftasks_gc
+
+
+    SUBROUTINE process_selftasks_gc_impl(netasks, etasks, a1, a2, a3, a4, &
+            a5, a6, ddx, ddy, ddz, bp, bt)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: netasks
+        INTEGER(intk), INTENT(in) :: etasks(selftasksize, netasks+1)
+        REAL(realk), INTENT(inout) :: a1(*), a2(*), a3(*), a4(*), a5(*), a6(*)
+        REAL(realk), INTENT(in) :: ddx(*), ddy(*), ddz(*), bp(*), bt(*)
+
+        ! Local variables
         INTEGER(intk) :: itask, kkf, jjf, iif, kkc, jjc, iic
         INTEGER(intk) :: ip3f, ip3c, ipx, ipy, ipz
         INTEGER(intk) :: fieldid, igridf, igridc, istart, istop, jstart, &
             jstop, kstart, kstop, ipos, jpos, kpos
         INTEGER(int32) :: tasksize, scratchidx
         CHARACTER(len=1) :: flag
-
-        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
-                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr, &
-                  ddx => ddx_f%arr, ddy => ddy_f%arr, ddz => ddz_f%arr, &
-                  bp => bp_f%arr, bt => bt_f%arr)
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_push("process_selftasks_gc")
-#endif
 
         !$omp target teams distribute private(itask, fieldid, flag, &
         !$omp& tasksize, scratchidx, igridf, igridc, istart, istop, jstart, &
@@ -822,6 +874,7 @@ CONTAINS
             CALL get_ip1y(ipy, igridf)
             CALL get_ip1z(ipz, igridf)
 
+            !$omp parallel
             SELECT CASE(fieldid)
             CASE (1)
                 CALL restrict_gc_flag(flag, kkf, jjf, iif, a1(ip3f), &
@@ -880,15 +933,10 @@ CONTAINS
             CASE DEFAULT
                 CALL errr(__FILE__, __LINE__)
             END SELECT
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-
-        END ASSOCIATE
-    END SUBROUTINE process_selftasks_gc
+    END SUBROUTINE process_selftasks_gc_impl
 
 
     SUBROUTINE unpack_restricted_buffer(flag, kk, jj, ii, fc, buffer, &
@@ -946,7 +994,7 @@ CONTAINS
         nj = (jstop - jstart)/2 + 1
         nk = (kstop - kstart)/2 + 1
 
-        !$omp parallel do collapse(3) private(ic, jc, kc, icount)
+        !$omp do collapse(3) private(ic, jc, kc, icount)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
@@ -959,7 +1007,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
 
 #ifdef _MGLET_DEBUG_
         IF (ni*nj*nk /= tasksize) CALL errr(__FILE__, __LINE__)
@@ -985,7 +1033,7 @@ CONTAINS
         nj = (jstop - jstart)/2 + 1
         nk = (kstop - kstart)/2 + 1
 
-        !$omp parallel do collapse(3) private(ic, jc, kc, icount)
+        !$omp do collapse(3) private(ic, jc, kc, icount)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
@@ -1001,7 +1049,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
 
 #ifdef _MGLET_DEBUG_
         IF (ni*nj*nk /= tasksize) CALL errr(__FILE__, __LINE__)
@@ -1094,19 +1142,36 @@ CONTAINS
         TYPE(field_t), INTENT(in) :: ddx_f, ddy_f, ddz_f
 
         ! Local variables
+        ! none...
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("process_sendtasks_noib")
+#endif
+
+        CALL process_sendtasks_noib_impl(nstasks, stasks, f1%arr, f2%arr, &
+            f3%arr, f4%arr, f5%arr, f6%arr, ddx_f%arr, ddy_f%arr, &
+            ddz_f%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE process_sendtasks_noib
+
+
+    SUBROUTINE process_sendtasks_noib_impl(nstasks, stasks, a1, a2, a3, a4, &
+            a5, a6, ddx, ddy, ddz)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nstasks
+        INTEGER(intk), INTENT(in) :: stasks(sendtasksize, nstasks+1)
+        REAL(realk), INTENT(in) :: a1(*), a2(*), a3(*), a4(*), a5(*), a6(*)
+        REAL(realk), INTENT(in) :: ddx(*), ddy(*), ddz(*)
+
+        ! Local variables
         INTEGER(intk) :: itask, kk, jj, ii, ip3, ipx, ipy, ipz
         INTEGER(intk) :: fieldid, igrid, istart, istop, jstart, jstop, kstart, &
             kstop
         INTEGER(int32) :: icount, tasksize
         CHARACTER(len=1) :: flag
-
-        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
-                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr, &
-                  ddx => ddx_f%arr, ddy => ddy_f%arr, ddz => ddz_f%arr)
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_push("process_sendtasks_noib")
-#endif
 
         !$omp target teams distribute private(itask, fieldid, flag, icount, &
         !$omp& tasksize, igrid, istart, istop, jstart, jstop, kstart, kstop, &
@@ -1130,6 +1195,7 @@ CONTAINS
             CALL get_ip1y(ipy, igrid)
             CALL get_ip1z(ipz, igrid)
 
+            !$omp parallel
             SELECT CASE(fieldid)
             CASE (1)
                 CALL restrict_noib_flag(flag, kk, jj, ii, a1(ip3), &
@@ -1160,15 +1226,10 @@ CONTAINS
                 CALL errr(__FILE__, __LINE__)
 #endif
             END SELECT
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-
-        END ASSOCIATE
-    END SUBROUTINE process_sendtasks_noib
+    END SUBROUTINE process_sendtasks_noib_impl
 
 
     SUBROUTINE process_sendtasks_gc(nstasks, stasks, ddx_f, ddy_f, ddz_f, &
@@ -1179,20 +1240,36 @@ CONTAINS
         TYPE(field_t), INTENT(in) :: ddx_f, ddy_f, ddz_f, bp_f, bt_f
 
         ! Local variables
+        ! none...
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_push("process_sendtasks_gc")
+#endif
+
+        CALL process_sendtasks_gc_impl(nstasks, stasks, f1%arr, f2%arr, &
+            f3%arr, f4%arr, f5%arr, f6%arr, ddx_f%arr, ddy_f%arr, &
+            ddz_f%arr, bp_f%arr, bt_f%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE process_sendtasks_gc
+
+
+    SUBROUTINE process_sendtasks_gc_impl(nstasks, stasks, a1, a2, a3, a4, &
+            a5, a6, ddx, ddy, ddz, bp, bt)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nstasks
+        INTEGER(intk), INTENT(in) :: stasks(sendtasksize, nstasks+1)
+        REAL(realk), INTENT(in) :: a1(*), a2(*), a3(*), a4(*), a5(*), a6(*)
+        REAL(realk), INTENT(in) :: ddx(*), ddy(*), ddz(*), bp(*), bt(*)
+
+        ! Local variables
         INTEGER(intk) :: itask, kk, jj, ii, ip3, ipx, ipy, ipz
         INTEGER(intk) :: fieldid, igrid, istart, istop, jstart, jstop, kstart, &
             kstop
         INTEGER(int32) :: icount, tasksize
         CHARACTER(len=1) :: flag
-
-        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
-                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr, &
-                  ddx => ddx_f%arr, ddy => ddy_f%arr, ddz => ddz_f%arr, &
-                  bp => bp_f%arr, bt => bt_f%arr)
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_push("process_sendtasks_gc")
-#endif
 
         !$omp target teams distribute private(itask, fieldid, flag, icount, &
         !$omp& tasksize, igrid, istart, istop, jstart, jstop, kstart, kstop, &
@@ -1216,6 +1293,7 @@ CONTAINS
             CALL get_ip1y(ipy, igrid)
             CALL get_ip1z(ipz, igrid)
 
+            !$omp parallel
             SELECT CASE(fieldid)
             CASE (1)
                 CALL restrict_gc_flag(flag, kk, jj, ii, a1(ip3), &
@@ -1246,15 +1324,10 @@ CONTAINS
                 CALL errr(__FILE__, __LINE__)
 #endif
             END SELECT
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-
-        END ASSOCIATE
-    END SUBROUTINE process_sendtasks_gc
+    END SUBROUTINE process_sendtasks_gc_impl
 
 
     SUBROUTINE process_mpirecv(nmpirtasks, mpirtasks)

--- a/src/ib/gc_restrict_mod.F90
+++ b/src/ib/gc_restrict_mod.F90
@@ -30,7 +30,7 @@ CONTAINS
         ! (not to be confused with kk - these are not the same!!!)
         nk = (kstop-kstart)/2+1
 
-        !$omp parallel do collapse(3) private(i, j, k, vol1, vol2, vol3, vol4, &
+        !$omp do collapse(3) private(i, j, k, vol1, vol2, vol3, vol4, &
         !$omp& vol5, vol6, vol7, vol8, sum_pv, sum_v, idx)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
@@ -86,7 +86,7 @@ CONTAINS
                 ! END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE restrict_gc_p_t
 
 
@@ -112,7 +112,7 @@ CONTAINS
         ! (not to be confused with kk - these are not the same!!!)
         nk = (kstop-kstart)/2+1
 
-        !$omp parallel do collapse(3) private(i, j, k, sum_pv, sum_v, idx)
+        !$omp do collapse(3) private(i, j, k, sum_pv, sum_v, idx)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
@@ -156,7 +156,7 @@ CONTAINS
                 ! END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE restrict_gc_r
 
 
@@ -176,7 +176,7 @@ CONTAINS
         nj = (jstop-jstart)/2+1
         nk = (kstop-kstart)/2+1
 
-        !$omp parallel do collapse(3) private(i, j, k, idx)
+        !$omp do collapse(3) private(i, j, k, idx)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
@@ -186,7 +186,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE restrict_gc_n
 
 
@@ -206,7 +206,7 @@ CONTAINS
         nj = (jstop-jstart)/2+1
         nk = (kstop-kstart)/2+1
 
-        !$omp parallel do collapse(3) private(i, j, k, idx)
+        !$omp do collapse(3) private(i, j, k, idx)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
@@ -225,7 +225,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE restrict_gc_e
 
 
@@ -245,7 +245,7 @@ CONTAINS
         nj = (jstop-jstart)/2+1
         nk = (kstop-kstart)/2+1
 
-        !$omp parallel do collapse(3) private(i, j, k, idx)
+        !$omp do collapse(3) private(i, j, k, idx)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
@@ -262,7 +262,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE restrict_gc_f
 
 
@@ -282,7 +282,7 @@ CONTAINS
         nj = (jstop-jstart)/2+1
         nk = (kstop-kstart)/2+1
 
-        !$omp parallel do collapse(3) private(i, j, k, idx)
+        !$omp do collapse(3) private(i, j, k, idx)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
@@ -311,6 +311,6 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE restrict_gc_i
 END MODULE gc_restrict_mod

--- a/src/ib/noib_restrict_mod.F90
+++ b/src/ib/noib_restrict_mod.F90
@@ -24,7 +24,7 @@ CONTAINS
         nj = (jstop-jstart)/2+1
         nk = (kstop-kstart)/2+1
 
-        !$omp parallel do collapse(3) private(i, j, k, idx, sum_ua, sum_a)
+        !$omp do collapse(3) private(i, j, k, idx, sum_ua, sum_a)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
@@ -41,7 +41,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE restrict_noib_u
 
 
@@ -63,7 +63,7 @@ CONTAINS
         nj = (jstop-jstart)/2+1
         nk = (kstop-kstart)/2+1
 
-        !$omp parallel do collapse(3) private(i, j, k, idx, sum_va, sum_a)
+        !$omp do collapse(3) private(i, j, k, idx, sum_va, sum_a)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
@@ -80,7 +80,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE restrict_noib_v
 
 
@@ -102,7 +102,7 @@ CONTAINS
         nj = (jstop-jstart)/2+1
         nk = (kstop-kstart)/2+1
 
-        !$omp parallel do collapse(3) private(i, j, k, idx, sum_wa, sum_a)
+        !$omp do collapse(3) private(i, j, k, idx, sum_wa, sum_a)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
@@ -119,7 +119,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE restrict_noib_w
 
 
@@ -141,7 +141,7 @@ CONTAINS
         nj = (jstop-jstart)/2+1
         nk = (kstop-kstart)/2+1
 
-        !$omp parallel do collapse(3) private(i, j, k, idx, sum_pv, sum_v)
+        !$omp do collapse(3) private(i, j, k, idx, sum_pv, sum_v)
         DO i = istart, istop, 2
             DO j = jstart, jstop, 2
                 DO k = kstart, kstop, 2
@@ -163,6 +163,6 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE restrict_noib_s
 END MODULE noib_restrict_mod

--- a/src/ib/parent/parent2_mod.F90
+++ b/src/ib/parent/parent2_mod.F90
@@ -402,17 +402,32 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: stasks(sendtasksize, nstasks+1)
 
         ! Local variables
-        INTEGER(intk) :: itask, fieldid, icount, igrid, istart, istop, &
-            jstart, jstop, kstart, kstop, ii, jj, kk, ip3
+        ! none...
 
         IF (nstasks == 0) RETURN
-
-        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
-                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr)
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("process_sendtasks")
 #endif
+
+        CALL process_sendtasks_impl(nstasks, stasks, f1%arr, f2%arr, &
+            f3%arr, f4%arr, f5%arr, f6%arr)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE process_sendtasks
+
+
+    SUBROUTINE process_sendtasks_impl(nstasks, stasks, a1, a2, a3, a4, a5, a6)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nstasks
+        INTEGER(intk), INTENT(in) :: stasks(sendtasksize, nstasks+1)
+        REAL(realk), INTENT(in) :: a1(*), a2(*), a3(*), a4(*), a5(*), a6(*)
+
+        ! Local variables
+        INTEGER(intk) :: itask, fieldid, icount, igrid, istart, istop, &
+            jstart, jstop, kstart, kstop, ii, jj, kk, ip3
 
         !$omp target teams distribute private(itask, fieldid, icount, igrid, &
         !$omp& istart, istop, jstart, jstop, kstart, kstop, ii, jj, kk, ip3)
@@ -430,6 +445,7 @@ CONTAINS
             CALL get_ip3(ip3, igrid)
             CALL get_mgdims(kk, jj, ii, igrid)
 
+            !$omp parallel
             SELECT CASE(fieldid)
             CASE (1)
                 CALL arr_to_sendbuf(kk, jj, ii, a1(ip3), istart, istop, &
@@ -454,15 +470,10 @@ CONTAINS
                 CALL errr(__FILE__, __LINE__)
 #endif
             END SELECT
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-
-        END ASSOCIATE
-    END SUBROUTINE process_sendtasks
+    END SUBROUTINE process_sendtasks_impl
 
 
     SUBROUTINE arr_to_sendbuf(kk, jj, ii, arr, istart, istop, jstart, jstop, &
@@ -480,7 +491,7 @@ CONTAINS
         kkl = kstop - kstart + 1
         jjl = jstop - jstart + 1
 
-        !$omp parallel do collapse(3) private(i, j, k, idx)
+        !$omp do collapse(3) private(i, j, k, idx)
         DO i = istart, istop
             DO j = jstart, jstop
                 DO k = kstart, kstop
@@ -489,7 +500,7 @@ CONTAINS
                 END DO
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE arr_to_sendbuf
 
 
@@ -499,18 +510,34 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: rtasks(recvtasksize, nrtasks+1)
 
         ! Local variables
-        INTEGER(intk) :: itask, fieldid
-        INTEGER(intk) :: jjc2d, ii2d, jj2d, ibb, stag1, stag2
-        INTEGER(int32) :: icount
+        ! none...
 
         IF (nrtasks == 0) RETURN
-
-        ASSOCIATE(a1 => f1%buffers, a2 => f2%buffers, a3 => f3%buffers, &
-                  a4 => f4%buffers, a5 => f5%buffers, a6 => f6%buffers)
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("process_recvtasks")
 #endif
+
+        CALL process_recvtasks_impl(nrtasks, rtasks, f1%buffers, &
+            f2%buffers, f3%buffers, f4%buffers, f5%buffers, f6%buffers)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+    END SUBROUTINE process_recvtasks
+
+
+    SUBROUTINE process_recvtasks_impl(nrtasks, rtasks, a1, a2, a3, a4, &
+            a5, a6)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nrtasks
+        INTEGER(intk), INTENT(in) :: rtasks(recvtasksize, nrtasks+1)
+        REAL(realk), INTENT(inout) :: a1(*), a2(*), a3(*), a4(*), a5(*), a6(*)
+
+        ! Local variables
+        INTEGER(intk) :: itask, fieldid
+        INTEGER(intk) :: jjc2d, ii2d, jj2d, ibb, stag1, stag2
+        INTEGER(int32) :: icount
 
         !$omp target teams distribute private(itask, fieldid, icount, ibb, &
         !$omp& jjc2d, jj2d, ii2d, stag1, stag2)
@@ -524,6 +551,7 @@ CONTAINS
             stag1 = rtasks(7, itask)
             stag2 = rtasks(8, itask)
 
+            !$omp parallel
             SELECT CASE (fieldid)
             CASE (1)
                 CALL recvbuf_to_buffers(a1, icount, ibb, jjc2d, jj2d, ii2d, &
@@ -548,20 +576,16 @@ CONTAINS
                 CALL errr(__FILE__, __LINE__)
 #endif
             END SELECT
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-        END ASSOCIATE
-    END SUBROUTINE process_recvtasks
+    END SUBROUTINE process_recvtasks_impl
 
 
     SUBROUTINE recvbuf_to_buffers(buffers, icount, ibb, jjc2d, jj2d, ii2d, &
             stag1, stag2)
         !$omp declare target
-        REAL(realk), INTENT(inout) :: buffers(:)
+        REAL(realk), INTENT(inout) :: buffers(*)
         INTEGER(int32), INTENT(in) :: icount
         INTEGER(intk), INTENT(in) :: ibb, jjc2d, jj2d, ii2d
         INTEGER(intk), INTENT(in) :: stag1, stag2
@@ -570,7 +594,7 @@ CONTAINS
         REAL(realk) :: val_c, val_jm1, val_i, val_im1, val_out
         LOGICAL :: odd_j, odd_i
 
-        !$omp parallel do collapse(2) private(i, j, jc, ic, idst, val_c, &
+        !$omp do collapse(2) private(i, j, jc, ic, idst, val_c, &
         !$omp& val_jm1, val_i, val_im1, val_out, odd_j, odd_i)
         DO i = 1, ii2d
             DO j = 1, jj2d
@@ -607,7 +631,7 @@ CONTAINS
                 buffers(idst) = val_out
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE recvbuf_to_buffers
 
 
@@ -673,20 +697,36 @@ CONTAINS
         INTEGER(intk), INTENT(in) :: stasks(selftasksize, nstasks+1)
 
         ! Local variables
-        INTEGER(intk) :: itask, fieldid, igridc, ibb, istart, istop, jstart
-        INTEGER(intk) :: jstop, kstart, kstop, jj2d, ii2d
-        INTEGER(intk) :: stag1, stag2, kk, jj, ii, ip3
+        ! none...
 
         IF (nstasks == 0) RETURN
-
-        ASSOCIATE(a1 => f1%arr, a2 => f2%arr, a3 => f3%arr, &
-                  a4 => f4%arr, a5 => f5%arr, a6 => f6%arr, &
-                  b1 => f1%buffers, b2 => f2%buffers, b3 => f3%buffers, &
-                  b4 => f4%buffers, b5 => f5%buffers, b6 => f6%buffers)
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("process_selftasks")
 #endif
+
+        CALL process_selftasks_impl(nstasks, stasks, f1%arr, f2%arr, &
+            f3%arr, f4%arr, f5%arr, f6%arr, f1%buffers, f2%buffers, &
+            f3%buffers, f4%buffers, f5%buffers, f6%buffers)
+
+#ifdef _MGLET_PROFILE_ANNOTATIONS_
+        CALL profile_range_pop()
+#endif
+        END SUBROUTINE process_selftasks
+
+
+        SUBROUTINE process_selftasks_impl(nstasks, stasks, a1, a2, a3, a4, a5, &
+            a6, b1, b2, b3, b4, b5, b6)
+        ! Subroutine arguments
+        INTEGER(intk), INTENT(in) :: nstasks
+        INTEGER(intk), INTENT(in) :: stasks(selftasksize, nstasks+1)
+        REAL(realk), INTENT(in) :: a1(*), a2(*), a3(*), a4(*), a5(*), a6(*)
+        REAL(realk), INTENT(inout) :: b1(*), b2(*), b3(*), b4(*), b5(*), b6(*)
+
+        ! Local variables
+        INTEGER(intk) :: itask, fieldid, igridc, ibb, istart, istop, jstart
+        INTEGER(intk) :: jstop, kstart, kstop, jj2d, ii2d
+        INTEGER(intk) :: stag1, stag2, kk, jj, ii, ip3
 
         !$omp target teams distribute private(itask, fieldid, igridc, ibb, &
         !$omp& istart, istop, jstart, jstop, kstart, kstop, jj2d, ii2d, &
@@ -709,6 +749,7 @@ CONTAINS
             CALL get_ip3(ip3, igridc)
             CALL get_mgdims(kk, jj, ii, igridc)
 
+            !$omp parallel
             SELECT CASE(fieldid)
             CASE (1)
                 CALL arr_to_buffers(kk, jj, ii, a1(ip3), &
@@ -739,14 +780,10 @@ CONTAINS
                 CALL errr(__FILE__, __LINE__)
 #endif
             END SELECT
+            !$omp end parallel
         END DO
         !$omp end target teams distribute
-
-#ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_pop()
-#endif
-        END ASSOCIATE
-    END SUBROUTINE process_selftasks
+    END SUBROUTINE process_selftasks_impl
 
 
     SUBROUTINE arr_to_buffers(kk, jj, ii, arr, buffers, ibb, &
@@ -755,7 +792,7 @@ CONTAINS
         !$omp declare target
         INTEGER(intk), INTENT(in) :: kk, jj, ii
         REAL(realk), INTENT(in) :: arr(kk, jj, ii)
-        REAL(realk), INTENT(inout) :: buffers(:)
+        REAL(realk), INTENT(inout) :: buffers(*)
         INTEGER(intk), INTENT(in) :: ibb, istart, istop, jstart, jstop
         INTEGER(intk), INTENT(in) :: kstart, kstop, jj2d, ii2d, stag1, stag2
 
@@ -763,7 +800,7 @@ CONTAINS
         REAL(realk) :: val_c, val_jm1, val_i, val_im1, val_out
         LOGICAL :: odd_j, odd_i
 
-        !$omp parallel do collapse(2) private(i, j, jc, ic, idst, val_c, &
+        !$omp do collapse(2) private(i, j, jc, ic, idst, val_c, &
         !$omp& val_jm1, val_i, val_im1, val_out, odd_j, odd_i)
         DO i = 1, ii2d
             DO j = 1, jj2d
@@ -790,7 +827,8 @@ CONTAINS
                     stag1, odd_j)
 
                 ! Then, if needed, interpolate the neighboring parent i line
-                ! the same way before combining along the face-local i direction.
+                ! the same way before combining along the face-local i
+                ! direction.
                 val_im1 = val_i
                 IF (stag2 == 1 .AND. odd_i) THEN
                     CALL get_parent_face_value(val_c, kk, jj, ii, arr, &
@@ -812,7 +850,7 @@ CONTAINS
                 buffers(idst) = val_out
             END DO
         END DO
-        !$omp end parallel do
+        !$omp end do
     END SUBROUTINE arr_to_buffers
 
 


### PR DESCRIPTION
- Fixes non-deterministic kernel crashes by using grid-cell loops instead of 1D loops
- Fix memory leaks by (1) reordering `parallel` regions such that `!$omp parallel` always wraps the call to grid functions and (2) using assumed-size arrays that do not carry descriptors