### PR TITLE
Conform with LLVM compiler

### DIFF
--- a/src/core/connect/conn2_mod.F90
+++ b/src/core/connect/conn2_mod.F90
@@ -1573,7 +1573,7 @@ CONTAINS
     END SUBROUTINE process_selftasks_impl
 
 
-    PURE SUBROUTINE arr_to_arr(kk, jj, ii, dst_rarr, src_rarr, &
+    SUBROUTINE arr_to_arr(kk, jj, ii, dst_rarr, src_rarr, &
             istart, istop, jstart, jstop, kstart, kstop, &
             istart_d, istop_d, jstart_d, jstop_d, kstart_d, kstop_d)
         !$omp declare target

--- a/src/flow/laplacephi_mod.F90
+++ b/src/flow/laplacephi_mod.F90
@@ -134,7 +134,7 @@ CONTAINS
     END SUBROUTINE laplacephi_level_impl
 
 
-    PURE SUBROUTINE laplacephi_grid(kk, jj, ii, res, phi, aw, ae, an, as, &
+    SUBROUTINE laplacephi_grid(kk, jj, ii, res, phi, aw, ae, an, as, &
             at, ab, ap, bp)
         !$omp declare target
         ! Subroutine arguments

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -695,7 +695,7 @@ CONTAINS
     END SUBROUTINE maxabscal_impl
 
 
-    PURE SUBROUTINE maxabscal_grid(kk, jj, ii, maxabs, phi)
+    SUBROUTINE maxabscal_grid(kk, jj, ii, maxabs, phi)
         ! Subroutine arguments
         !$omp declare target
         INTEGER(intk), INTENT(in) :: kk, jj, ii
@@ -760,7 +760,7 @@ CONTAINS
     END SUBROUTINE rescal_impl
 
 
-    PURE SUBROUTINE rescal_grid(kk, jj, ii, rhs, res)
+    SUBROUTINE rescal_grid(kk, jj, ii, rhs, res)
         !$omp declare target
         ! Subroutine arguments
         INTEGER(intk), INTENT(in) :: kk, jj, ii
@@ -840,7 +840,7 @@ CONTAINS
     END SUBROUTINE mgpcorr_impl
 
 
-    PURE SUBROUTINE mgpcorr_grid(kk, jj, ii, u, v, w, p, dp, bp, rdx, rdy, &
+    SUBROUTINE mgpcorr_grid(kk, jj, ii, u, v, w, p, dp, bp, rdx, rdy, &
             rdz, rfak)
         !$omp declare target
         ! Subroutine arguments


### PR DESCRIPTION
Remove `PURE` from some subroutines that use OpenMP to allow to compile with LLVM.