### PR TITLE
Revert certain workarounds by default, introduce _MGLET_WORKAROUNDS_

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,21 @@ else()
 endif()
 
 option(MGLET_OFFLOAD "Enable OpenMP offloading (experimental)" OFF)
+option(MGLET_WORKAROUNDS "Enable OpenMP offloading workarounds" OFF)
 if(MGLET_OFFLOAD)
     message(STATUS "Enabling OpenMP offloading")
     find_package(OpenMP REQUIRED)
     add_compile_definitions(_MGLET_OFFLOAD_=1)
+else()
+    # Make sure MGLET_WORKAROUNDS is not enabled when MGLET_OFFLOAD is disabled
+    if(MGLET_WORKAROUNDS)
+        message(FATAL_ERROR "MGLET_WORKAROUNDS can only be enabled when MGLET_OFFLOAD is enabled")
+    endif()
+endif()
+
+if (MGLET_WORKAROUNDS)
+    message(STATUS "Enabling OpenMP offloading workarounds")
+    add_compile_definitions(_MGLET_WORKAROUNDS_=1)
 endif()
 
 set(MGLET_PROFILE_ANNOTATIONS "off" CACHE STRING "MGLET profile annotations: off, roctx, nvtx")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,23 @@ if(MGLET_OFFLOAD)
     message(STATUS "Enabling OpenMP offloading")
     find_package(OpenMP REQUIRED)
     add_compile_definitions(_MGLET_OFFLOAD_=1)
+
+    set(MGLET_OFFLOAD_BACKEND "" CACHE STRING
+        "Offload backend (rocm or cuda)")
+    set_property(CACHE MGLET_OFFLOAD_BACKEND PROPERTY STRINGS rocm cuda)
+    if(MGLET_OFFLOAD_BACKEND STREQUAL "rocm")
+        message(STATUS "Enabling ROCm offload backend")
+        find_package(hip REQUIRED CONFIG)
+        find_package(rocblas REQUIRED CONFIG)
+        add_compile_definitions(_MGLET_ROCM_=1)
+    elseif(MGLET_OFFLOAD_BACKEND STREQUAL "cuda")
+        message(STATUS "Enabling CUDA offload backend")
+        find_package(CUDAToolkit REQUIRED)
+        add_compile_definitions(_MGLET_CUDA_=1)
+    else()
+        message(FATAL_ERROR "MGLET_OFFLOAD_BACKEND must be rocm or cuda "
+            "when MGLET_OFFLOAD is enabled")
+    endif()
 else()
     # Make sure MGLET_WORKAROUNDS is not enabled when MGLET_OFFLOAD is disabled
     if(MGLET_WORKAROUNDS)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -231,6 +231,7 @@
             "inherits": "llvm-release",
             "cacheVariables": {
                 "MGLET_OFFLOAD": "ON",
+                "MGLET_OFFLOAD_BACKEND": "cuda",
                 "MGLET_OFFLOAD_COMPILE_FLAGS": "-fopenmp-version=52",
                 "MGLET_OFFLOAD_ARCH_FLAGS": "--offload-arch=sm_121",
                 "MGLET_Fortran_FLAGS_RELEASE": ""
@@ -286,6 +287,7 @@
             "hidden": true,
             "cacheVariables": {
                 "MGLET_OFFLOAD": "ON",
+                "MGLET_OFFLOAD_BACKEND": "rocm",
                 "MGLET_OFFLOAD_COMPILE_FLAGS": "-fopenmp-version=52",
                 "MGLET_OFFLOAD_ARCH_FLAGS": "--offload-arch=gfx942"
             }
@@ -309,6 +311,7 @@
             "hidden": true,
             "cacheVariables": {
                 "MGLET_OFFLOAD": "ON",
+                "MGLET_OFFLOAD_BACKEND": "rocm",
                 "MGLET_OFFLOAD_COMPILE_FLAGS": "-fopenmp-version=52",
                 "MGLET_OFFLOAD_ARCH_FLAGS": "--offload-arch=gfx1201"
             }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(core STATIC
+    blasbind_mod.F90
     bound_mod.F90
     buildinfo_mod.F90
     charfunc_mod.F90
@@ -68,6 +69,10 @@ target_link_libraries(core
     PRIVATE ${HDF5_Fortran_LIBRARIES}
     PRIVATE ZLIB::ZLIB
     PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_Fortran>
+    PRIVATE $<$<STREQUAL:${MGLET_OFFLOAD_BACKEND},rocm>:hip::amdhip64>
+    PRIVATE $<$<STREQUAL:${MGLET_OFFLOAD_BACKEND},rocm>:roc::rocblas>
+    PRIVATE $<$<STREQUAL:${MGLET_OFFLOAD_BACKEND},cuda>:CUDA::cudart>
+    PRIVATE $<$<STREQUAL:${MGLET_OFFLOAD_BACKEND},cuda>:CUDA::cublas>
     PRIVATE $<$<STREQUAL:${MGLET_PROFILE_ANNOTATIONS},roctx>:rocprofiler-sdk-roctx::rocprofiler-sdk-roctx>
     PRIVATE $<$<STREQUAL:${MGLET_PROFILE_ANNOTATIONS},nvtx>:CUDA::nvtx3>
 )

--- a/src/core/blasbind_mod.F90
+++ b/src/core/blasbind_mod.F90
@@ -1,0 +1,260 @@
+MODULE blasbind_mod
+    USE, INTRINSIC :: ISO_C_BINDING, ONLY: c_int, c_loc, c_null_ptr, &
+        c_ptr, c_size_t, c_sizeof
+    USE precision_mod, ONLY: ifk, realk
+
+    IMPLICIT NONE (type, external)
+    PRIVATE
+
+    INTERFACE memset
+        MODULE PROCEDURE memset_realk
+        MODULE PROCEDURE memset_ifk
+    END INTERFACE memset
+
+#ifdef _MGLET_OFFLOAD_
+    TYPE(c_ptr) :: handle = c_null_ptr
+    LOGICAL :: initialized = .FALSE.
+
+    INTERFACE
+#ifdef _MGLET_ROCM_
+        FUNCTION backend_memset(dst, value, num_bytes) &
+                BIND(c, name = 'hipMemset') RESULT(status)
+#else
+        FUNCTION backend_memset(dst, value, num_bytes) &
+                BIND(c, name = 'cudaMemset') RESULT(status)
+#endif
+            IMPORT :: c_int, c_ptr, c_size_t
+            TYPE(c_ptr), VALUE :: dst
+            INTEGER(c_int), VALUE :: value
+            INTEGER(c_size_t), VALUE :: num_bytes
+            INTEGER(c_int) :: status
+        END FUNCTION backend_memset
+
+#ifdef _MGLET_ROCM_
+        FUNCTION backend_synchronize() BIND(c, name = 'hipDeviceSynchronize') &
+                RESULT(status)
+#else
+        FUNCTION backend_synchronize() &
+                BIND(c, name = 'cudaDeviceSynchronize') RESULT(status)
+#endif
+            IMPORT :: c_int
+            INTEGER(c_int) :: status
+        END FUNCTION backend_synchronize
+
+#ifdef _MGLET_ROCM_
+        FUNCTION create_handle(handle) BIND(c, name = 'rocblas_create_handle') &
+                RESULT(status)
+#else
+        FUNCTION create_handle(handle) BIND(c, name = 'cublasCreate_v2') &
+                RESULT(status)
+#endif
+            IMPORT :: c_int, c_ptr
+            TYPE(c_ptr) :: handle
+            INTEGER(c_int) :: status
+        END FUNCTION create_handle
+
+#ifdef _MGLET_ROCM_
+        FUNCTION destroy_handle(handle) &
+                BIND(c, name = 'rocblas_destroy_handle') RESULT(status)
+#else
+        FUNCTION destroy_handle(handle) BIND(c, name = 'cublasDestroy_v2') &
+                RESULT(status)
+#endif
+            IMPORT :: c_int, c_ptr
+            TYPE(c_ptr), VALUE :: handle
+            INTEGER(c_int) :: status
+        END FUNCTION destroy_handle
+
+#ifdef _MGLET_DOUBLE_PRECISION_
+#ifdef _MGLET_ROCM_
+        FUNCTION backend_axpy(handle, n, alpha, x, incx, y, incy) &
+                BIND(c, name = 'rocblas_daxpy') RESULT(status)
+#else
+        FUNCTION backend_axpy(handle, n, alpha, x, incx, y, incy) &
+                BIND(c, name = 'cublasDaxpy_v2') RESULT(status)
+#endif
+#else
+#ifdef _MGLET_ROCM_
+        FUNCTION backend_axpy(handle, n, alpha, x, incx, y, incy) &
+                BIND(c, name = 'rocblas_saxpy') RESULT(status)
+#else
+        FUNCTION backend_axpy(handle, n, alpha, x, incx, y, incy) &
+                BIND(c, name = 'cublasSaxpy_v2') RESULT(status)
+#endif
+#endif
+            IMPORT :: c_int, c_ptr
+            TYPE(c_ptr), VALUE :: handle
+            INTEGER(c_int), VALUE :: n
+            TYPE(c_ptr), VALUE :: alpha, x, y
+            INTEGER(c_int), VALUE :: incx, incy
+            INTEGER(c_int) :: status
+        END FUNCTION backend_axpy
+
+#ifdef _MGLET_DOUBLE_PRECISION_
+#ifdef _MGLET_ROCM_
+        FUNCTION backend_scal(handle, n, alpha, x, incx) &
+                BIND(c, name = 'rocblas_dscal') RESULT(status)
+#else
+        FUNCTION backend_scal(handle, n, alpha, x, incx) &
+                BIND(c, name = 'cublasDscal_v2') RESULT(status)
+#endif
+#else
+#ifdef _MGLET_ROCM_
+        FUNCTION backend_scal(handle, n, alpha, x, incx) &
+                BIND(c, name = 'rocblas_sscal') RESULT(status)
+#else
+        FUNCTION backend_scal(handle, n, alpha, x, incx) &
+                BIND(c, name = 'cublasSscal_v2') RESULT(status)
+#endif
+#endif
+            IMPORT :: c_int, c_ptr
+            TYPE(c_ptr), VALUE :: handle
+            INTEGER(c_int), VALUE :: n
+            TYPE(c_ptr), VALUE :: alpha, x
+            INTEGER(c_int), VALUE :: incx
+            INTEGER(c_int) :: status
+        END FUNCTION backend_scal
+    END INTERFACE
+#endif
+
+    PUBLIC :: init_blasbind, finish_blasbind, axpy, scal, memset, &
+            synchronize
+
+CONTAINS
+    SUBROUTINE init_blasbind()
+#ifdef _MGLET_OFFLOAD_
+        INTEGER(c_int) :: status
+
+        IF (initialized) ERROR STOP "BLAS bindings already initialized"
+        status = create_handle(handle)
+        IF (status /= 0_c_int) ERROR STOP "BLAS handle creation failed"
+        initialized = .TRUE.
+#endif
+    END SUBROUTINE init_blasbind
+
+
+    SUBROUTINE finish_blasbind()
+#ifdef _MGLET_OFFLOAD_
+        INTEGER(c_int) :: status
+
+        IF (.NOT. initialized) ERROR STOP "BLAS bindings not initialized"
+        status = destroy_handle(handle)
+        IF (status /= 0_c_int) ERROR STOP "BLAS handle destruction failed"
+        handle = c_null_ptr
+        initialized = .FALSE.
+#endif
+    END SUBROUTINE finish_blasbind
+
+
+    SUBROUTINE synchronize()
+#ifdef _MGLET_OFFLOAD_
+        INTEGER(c_int) :: status
+
+        status = backend_synchronize()
+        IF (status /= 0_c_int) ERROR STOP "Device synchronization failed"
+#endif
+    END SUBROUTINE synchronize
+
+
+    SUBROUTINE memset_realk(arr)
+        REAL(realk), CONTIGUOUS, TARGET, INTENT(inout) :: arr(:)
+
+#ifdef _MGLET_OFFLOAD_
+        INTEGER(c_int) :: status
+        INTEGER(c_size_t) :: num_bytes
+
+        IF (SIZE(arr) == 0) RETURN
+        num_bytes = SIZE(arr, kind=c_size_t)*c_sizeof(arr(1))
+        !$omp target data use_device_addr(arr)
+        status = backend_memset(c_loc(arr), 0_c_int, num_bytes)
+        !$omp end target data
+        IF (status /= 0_c_int) ERROR STOP "Device memset failed"
+#else
+        INTEGER :: i
+
+        DO i = 1, SIZE(arr)
+            arr(i) = 0.0_realk
+        END DO
+#endif
+    END SUBROUTINE memset_realk
+
+
+    SUBROUTINE memset_ifk(arr)
+        INTEGER(ifk), CONTIGUOUS, TARGET, INTENT(inout) :: arr(:)
+
+#ifdef _MGLET_OFFLOAD_
+        INTEGER(c_int) :: status
+        INTEGER(c_size_t) :: num_bytes
+
+        IF (SIZE(arr) == 0) RETURN
+        num_bytes = SIZE(arr, kind=c_size_t)*c_sizeof(arr(1))
+        !$omp target data use_device_addr(arr)
+        status = backend_memset(c_loc(arr), 0_c_int, num_bytes)
+        !$omp end target data
+        IF (status /= 0_c_int) ERROR STOP "Device memset failed"
+#else
+        INTEGER :: i
+
+        DO i = 1, SIZE(arr)
+            arr(i) = 0_ifk
+        END DO
+#endif
+    END SUBROUTINE memset_ifk
+
+
+    SUBROUTINE axpy(y, alpha, x)
+        REAL(realk), CONTIGUOUS, TARGET, INTENT(inout) :: y(:)
+        REAL(realk), TARGET, INTENT(in) :: alpha
+        REAL(realk), CONTIGUOUS, TARGET, INTENT(in) :: x(:)
+
+#ifdef _MGLET_OFFLOAD_
+        INTEGER(c_int) :: status
+
+        IF (SIZE(x) /= SIZE(y)) ERROR STOP "AXPY array sizes differ"
+        IF (SIZE(x) == 0) RETURN
+        IF (SIZE(x, kind=c_size_t) > HUGE(0_c_int)) &
+            ERROR STOP "AXPY array is too large"
+        IF (.NOT. initialized) ERROR STOP "BLAS bindings not initialized"
+
+        !$omp target data use_device_addr(x, y)
+        status = backend_axpy(handle, INT(SIZE(x), c_int), c_loc(alpha), &
+            c_loc(x), 1_c_int, c_loc(y), 1_c_int)
+        !$omp end target data
+        IF (status /= 0_c_int) ERROR STOP "BLAS AXPY failed"
+#else
+        INTEGER :: i
+
+        IF (SIZE(x) /= SIZE(y)) ERROR STOP "AXPY array sizes differ"
+        DO i = 1, SIZE(x)
+            y(i) = y(i) + alpha*x(i)
+        END DO
+#endif
+    END SUBROUTINE axpy
+
+
+    SUBROUTINE scal(x, alpha)
+        REAL(realk), CONTIGUOUS, TARGET, INTENT(inout) :: x(:)
+        REAL(realk), TARGET, INTENT(in) :: alpha
+
+#ifdef _MGLET_OFFLOAD_
+        INTEGER(c_int) :: status
+
+        IF (SIZE(x) == 0) RETURN
+        IF (SIZE(x, kind=c_size_t) > HUGE(0_c_int)) &
+                ERROR STOP "SCAL array is too large"
+        IF (.NOT. initialized) ERROR STOP "BLAS bindings not initialized"
+
+        !$omp target data use_device_addr(x)
+        status = backend_scal(handle, INT(SIZE(x), c_int), &
+            c_loc(alpha), c_loc(x), 1_c_int)
+        !$omp end target data
+        IF (status /= 0_c_int) ERROR STOP "BLAS SCAL failed"
+#else
+        INTEGER :: i
+
+        DO i = 1, SIZE(x)
+            x(i) = alpha*x(i)
+        END DO
+#endif
+    END SUBROUTINE scal
+END MODULE blasbind_mod

--- a/src/core/core_mod.F90
+++ b/src/core/core_mod.F90
@@ -1,6 +1,7 @@
 MODULE core_mod
     ! Should absolutely NOT 'USE' external modules like MPI and HDF5 here,
     ! because then they will get re-exported from this module!!!
+    USE blasbind_mod
     USE bound_mod
     USE buildinfo_mod
     USE charfunc_mod
@@ -101,6 +102,7 @@ CONTAINS
 #ifdef _MGLET_OFFLOAD_
         CALL init_offload()
 #endif
+        CALL init_blasbind()
         CALL init_timer()
 
         CALL set_timer(1, "MGLET")
@@ -149,6 +151,7 @@ CONTAINS
 
         CALL stop_timer(1)
         CALL finish_timer()
+        CALL finish_blasbind()
         CALL finish_buildinfo()
         CALL finish_precision()
         CALL finish_comms()

--- a/src/core/fieldhelper_mod.F90
+++ b/src/core/fieldhelper_mod.F90
@@ -1,5 +1,6 @@
 
 MODULE fieldhelper_mod
+    USE blasbind_mod, ONLY: memset
     USE err_mod, ONLY: errr
     USE field_mod, ONLY: field_t, intfield_t
     USE grids_mod, ONLY: get_mgdims, mygrids, nmygrids, level, get_imygrid
@@ -38,7 +39,7 @@ CONTAINS
 
         IF (device2) THEN
 #ifdef _MGLET_WORKAROUNDS_
-            CALL zero_field_arr_realk_impl(field%arr)
+            CALL memset(field%arr)
 #else
             BLOCK
                 INTEGER(intk) :: i
@@ -61,37 +62,6 @@ CONTAINS
     END SUBROUTINE zero_field_arr_realk
 
 
-#ifdef _MGLET_WORKAROUNDS_
-    SUBROUTINE zero_field_arr_realk_impl(arr)
-        ! Subroutine arguments
-        REAL(realk), INTENT(inout) :: arr(*)
-
-        ! Local variables
-        INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
-
-        ! This is a 4D loop only because there are random crashes with 1D loops
-        ! using the amd compiler
-        !$omp target teams distribute private(imygrid, igrid, kk, jj, ii, ip3)
-        DO imygrid = 1, nmygrids
-            igrid = mygrids(imygrid)
-            CALL get_mgdims(kk, jj, ii, igrid)
-            CALL get_ip3(ip3, igrid)
-
-            !$omp parallel do collapse(3) private(i, j, k, idx)
-            DO i = 1, ii
-                DO j = 1, jj
-                    DO k = 1, kk
-                        idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj - 1
-                        arr(idx) = 0.0_realk
-                    END DO
-                END DO
-            END DO
-            !$omp end parallel do
-        END DO
-    END SUBROUTINE zero_field_arr_realk_impl
-#endif
-
-
     SUBROUTINE zero_field_arr_ifk(field, device)
         ! Subroutine arguments
         TYPE(intfield_t), INTENT(inout) :: field
@@ -112,7 +82,7 @@ CONTAINS
 
         IF (device2) THEN
 #ifdef _MGLET_WORKAROUNDS_
-            CALL zero_field_arr_ifk_impl(field%arr)
+            CALL memset(field%arr)
 #else
             BLOCK
                 INTEGER(intk) :: i
@@ -133,37 +103,6 @@ CONTAINS
             CALL profile_range_pop()
 #endif
     END SUBROUTINE zero_field_arr_ifk
-
-
-#ifdef _MGLET_WORKAROUNDS_
-    SUBROUTINE zero_field_arr_ifk_impl(arr)
-        ! Subroutine arguments
-        INTEGER(ifk), INTENT(inout) :: arr(*)
-
-        ! Local variables
-        INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
-
-        ! This is a 4D loop only because there are random crashes with 1D loops
-        ! using the amd compiler
-        !$omp target teams distribute private(imygrid, igrid, kk, jj, ii, ip3)
-        DO imygrid = 1, nmygrids
-            igrid = mygrids(imygrid)
-            CALL get_mgdims(kk, jj, ii, igrid)
-            CALL get_ip3(ip3, igrid)
-
-            !$omp parallel do collapse(3) private(i, j, k, idx)
-            DO i = 1, ii
-                DO j = 1, jj
-                    DO k = 1, kk
-                        idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj - 1
-                        arr(idx) = 0_intk
-                    END DO
-                END DO
-            END DO
-            !$omp end parallel do
-        END DO
-    END SUBROUTINE zero_field_arr_ifk_impl
-#endif
 
 
     SUBROUTINE map_arr_to_device(f1, f2, f3, f4, f5, f6, f7, message)

--- a/src/core/fieldhelper_mod.F90
+++ b/src/core/fieldhelper_mod.F90
@@ -10,22 +10,20 @@ MODULE fieldhelper_mod
     IMPLICIT NONE(type, external)
     PRIVATE
 
-    INTERFACE set_field_arr
-        PROCEDURE set_field_arr_realk
-        PROCEDURE set_field_arr_ifk
-    END INTERFACE set_field_arr
+    INTERFACE zero_field_arr
+        PROCEDURE zero_field_arr_realk
+        PROCEDURE zero_field_arr_ifk
+    END INTERFACE zero_field_arr
 
-    PUBLIC :: set_field_arr, map_arr_to_device, map_arr_from_device, &
+    PUBLIC :: zero_field_arr, map_arr_to_device, map_arr_from_device, &
         map_buffers_to_device, map_buffers_from_device
 CONTAINS
-    SUBROUTINE set_field_arr_realk(field, val, device)
+    SUBROUTINE zero_field_arr_realk(field, device)
         ! Subroutine arguments
         TYPE(field_t), INTENT(inout) :: field
-        REAL(realk), INTENT(in) :: val
         LOGICAL, OPTIONAL, INTENT(in) :: device
 
         ! Local variables
-        INTEGER(intk) :: n
         LOGICAL :: device2
 
         IF (PRESENT(device)) THEN
@@ -35,26 +33,38 @@ CONTAINS
         END IF
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
-            CALL profile_range_push("set_field_arr_realk")
+            CALL profile_range_push("zero_field_arr_realk")
 #endif
 
         IF (device2) THEN
-            n = SIZE(field%arr)
-            CALL set_field_arr_realk_impl(field%arr, val)
+#ifdef _MGLET_WORKAROUNDS_
+            CALL zero_field_arr_realk_impl(field%arr)
+#else
+            BLOCK
+                INTEGER(intk) :: i
+                ASSOCIATE(arr => field%arr)
+                    !$omp target teams loop
+                    DO i = 1, SIZE(arr)
+                        arr(i) = 0.0_realk
+                    END DO
+                    !$omp end target teams loop
+                END ASSOCIATE
+            END BLOCK
+#endif
         ELSE
-            field%arr = val
+            field%arr = 0.0_realk
         END IF
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
             CALL profile_range_pop()
 #endif
-    END SUBROUTINE set_field_arr_realk
+    END SUBROUTINE zero_field_arr_realk
 
 
-    SUBROUTINE set_field_arr_realk_impl(arr, val)
+#ifdef _MGLET_WORKAROUNDS_
+    SUBROUTINE zero_field_arr_realk_impl(arr)
         ! Subroutine arguments
         REAL(realk), INTENT(inout) :: arr(*)
-        REAL(realk), INTENT(in) :: val
 
         ! Local variables
         INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
@@ -72,23 +82,22 @@ CONTAINS
                 DO j = 1, jj
                     DO k = 1, kk
                         idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj - 1
-                        arr(idx) = val
+                        arr(idx) = 0.0_realk
                     END DO
                 END DO
             END DO
             !$omp end parallel do
         END DO
-    END SUBROUTINE set_field_arr_realk_impl
+    END SUBROUTINE zero_field_arr_realk_impl
+#endif
 
 
-    SUBROUTINE set_field_arr_ifk(field, val, device)
+    SUBROUTINE zero_field_arr_ifk(field, device)
         ! Subroutine arguments
         TYPE(intfield_t), INTENT(inout) :: field
-        INTEGER(ifk), INTENT(in) :: val
         LOGICAL, OPTIONAL, INTENT(in) :: device
 
         ! Local variables
-        INTEGER(intk) :: n
         LOGICAL :: device2
 
         IF (PRESENT(device)) THEN
@@ -98,26 +107,38 @@ CONTAINS
         END IF
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_push("set_field_arr_ifk")
+        CALL profile_range_push("zero_field_arr_ifk")
 #endif
 
         IF (device2) THEN
-            n = SIZE(field%arr)
-            CALL set_field_arr_ifk_impl(field%arr, val)
+#ifdef _MGLET_WORKAROUNDS_
+            CALL zero_field_arr_ifk_impl(field%arr)
+#else
+            BLOCK
+                INTEGER(intk) :: i
+                ASSOCIATE(arr => field%arr)
+                    !$omp target teams loop
+                    DO i = 1, SIZE(arr)
+                        arr(i) = 0_intk
+                    END DO
+                    !$omp end target teams loop
+                END ASSOCIATE
+            END BLOCK
+#endif
         ELSE
-            field%arr = val
+            field%arr = 0_intk
         END IF
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
             CALL profile_range_pop()
 #endif
-    END SUBROUTINE set_field_arr_ifk
+    END SUBROUTINE zero_field_arr_ifk
 
 
-    SUBROUTINE set_field_arr_ifk_impl(arr, val)
+#ifdef _MGLET_WORKAROUNDS_
+    SUBROUTINE zero_field_arr_ifk_impl(arr)
         ! Subroutine arguments
         INTEGER(ifk), INTENT(inout) :: arr(*)
-        INTEGER(ifk), INTENT(in) :: val
 
         ! Local variables
         INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
@@ -135,13 +156,14 @@ CONTAINS
                 DO j = 1, jj
                     DO k = 1, kk
                         idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj - 1
-                        arr(idx) = val
+                        arr(idx) = 0_intk
                     END DO
                 END DO
             END DO
             !$omp end parallel do
         END DO
-    END SUBROUTINE set_field_arr_ifk_impl
+    END SUBROUTINE zero_field_arr_ifk_impl
+#endif
 
 
     SUBROUTINE map_arr_to_device(f1, f2, f3, f4, f5, f6, f7, message)

--- a/src/core/fieldpool_mod.F90
+++ b/src/core/fieldpool_mod.F90
@@ -2,7 +2,6 @@ MODULE fieldpool_mod
     USE precision_mod
     USE err_mod, ONLY: errr
     USE field_mod, ONLY: basefield_t, field_t, intfield_t, nchar_name
-    USE fieldhelper_mod, ONLY: set_field_arr
 
     IMPLICIT NONE(type, external)
     PRIVATE

--- a/src/core/rungekutta_mod.F90
+++ b/src/core/rungekutta_mod.F90
@@ -318,18 +318,25 @@ CONTAINS
     ! U_j = U_(j-1) + B_j*dU_j
     SUBROUTINE rkstep(p, dp, rhsp, frhs, dtfu)
         ! Subroutine arguments
+#ifdef _MGLET_WORKAROUNDS_
         REAL(realk), INTENT(inout) :: p(*)
         REAL(realk), INTENT(inout) :: dp(*)
         REAL(realk), INTENT(in) :: rhsp(*)
+#else
+        REAL(realk), CONTIGUOUS, INTENT(inout) :: p(:)
+        REAL(realk), CONTIGUOUS, INTENT(inout) :: dp(:)
+        REAL(realk), CONTIGUOUS, INTENT(in) :: rhsp(:)
+#endif
         REAL(realk), INTENT(in) :: frhs
         REAL(realk), INTENT(in) :: dtfu
-
-        ! Local variables
-        INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("rkstep")
 #endif
+
+#ifdef _MGLET_WORKAROUNDS_
+        ! Local variables
+        INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
 
         ! Perform the update in a manually crafted loop is faster than using an
         ! implicit loop, because of cache effects (dp(i) is already in cache
@@ -354,6 +361,17 @@ CONTAINS
             END DO
             !$omp end parallel do
         END DO
+#else
+        ! Local variables
+        INTEGER(intk) :: i
+
+        !$omp target teams loop
+        DO i = 1, SIZE(p)
+            dp(i) = frhs*dp(i) + rhsp(i)
+            p(i) = p(i) + dtfu*dp(i)
+        END DO
+        !$omp end target teams loop
+#endif
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_pop()

--- a/src/core/rungekutta_mod.F90
+++ b/src/core/rungekutta_mod.F90
@@ -1,11 +1,10 @@
 MODULE rungekutta_mod
+    USE blasbind_mod, ONLY: axpy, scal, synchronize
     USE charfunc_mod, ONLY: lower
     USE err_mod, ONLY: errr
     USE grids_mod, ONLY: get_mgdims, mygrids, nmygrids
-    USE pointers_mod, ONLY: get_ip3
     USE precision_mod, ONLY: intk, realk
     USE profile_tools_mod, ONLY: profile_range_push, profile_range_pop
-
 
     IMPLICIT NONE(type, external)
     PRIVATE
@@ -318,15 +317,9 @@ CONTAINS
     ! U_j = U_(j-1) + B_j*dU_j
     SUBROUTINE rkstep(p, dp, rhsp, frhs, dtfu)
         ! Subroutine arguments
-#ifdef _MGLET_WORKAROUNDS_
-        REAL(realk), INTENT(inout) :: p(*)
-        REAL(realk), INTENT(inout) :: dp(*)
-        REAL(realk), INTENT(in) :: rhsp(*)
-#else
         REAL(realk), CONTIGUOUS, INTENT(inout) :: p(:)
         REAL(realk), CONTIGUOUS, INTENT(inout) :: dp(:)
         REAL(realk), CONTIGUOUS, INTENT(in) :: rhsp(:)
-#endif
         REAL(realk), INTENT(in) :: frhs
         REAL(realk), INTENT(in) :: dtfu
 
@@ -335,32 +328,10 @@ CONTAINS
 #endif
 
 #ifdef _MGLET_WORKAROUNDS_
-        ! Local variables
-        INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
-
-        ! Perform the update in a manually crafted loop is faster than using an
-        ! implicit loop, because of cache effects (dp(i) is already in cache
-        ! when p(i) is updated)
-        ! This is a 4D loop only because there are random crashes with 1D loops
-        ! using the amd compiler
-        !$omp target teams distribute private(imygrid, igrid, kk, jj, ii, ip3)
-        DO imygrid = 1, nmygrids
-            igrid = mygrids(imygrid)
-            CALL get_mgdims(kk, jj, ii, igrid)
-            CALL get_ip3(ip3, igrid)
-
-            !$omp parallel do collapse(3) private(i, j, k, idx)
-            DO i = 1, ii
-                DO j = 1, jj
-                    DO k = 1, kk
-                        idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj - 1
-                        dp(idx) = frhs*dp(idx) + rhsp(idx)
-                        p(idx) = p(idx) + dtfu*dp(idx)
-                    END DO
-                END DO
-            END DO
-            !$omp end parallel do
-        END DO
+        CALL scal(dp, frhs)
+        CALL axpy(dp, 1.0_realk, rhsp)
+        CALL axpy(p, dtfu, dp)
+        CALL synchronize()
 #else
         ! Local variables
         INTEGER(intk) :: i

--- a/src/flow/flowstat_mod.F90
+++ b/src/flow/flowstat_mod.F90
@@ -592,7 +592,7 @@ CONTAINS
             units=units)
         CALL push_field(ux_f, name_ux, istag=istag, jstag=jstag, &
             kstag=kstag, units=units_ux)
-        CALL set_field_arr(ux_f, 0.0_realk)
+        CALL zero_field_arr(ux_f)
 
         CALL differentiate(ux_f, u_f, ivar)
 
@@ -688,7 +688,7 @@ CONTAINS
             units=units)
         CALL push_field(ux_f, name_ux, istag=istag, jstag=jstag, &
             kstag=kstag, units=units_ux)
-        CALL set_field_arr(ux_f, 0.0_realk)
+        CALL zero_field_arr(ux_f)
         CALL differentiate(ux_f, u_f, ivar)
 
         field%arr = ux_f%arr**2
@@ -817,8 +817,8 @@ CONTAINS
             kstag=kstag, units=units_ux)
         CALL push_field(vx_f, name_vx, istag=istag, jstag=jstag, &
             kstag=kstag, units=units_ux)
-        CALL set_field_arr(ux_f, 0.0_realk)
-        CALL set_field_arr(vx_f, 0.0_realk)
+        CALL zero_field_arr(ux_f)
+        CALL zero_field_arr(vx_f)
 
         CALL differentiate(ux_f, u_f, ivar1)
         CALL differentiate(vx_f, v_f, ivar2)
@@ -891,9 +891,9 @@ CONTAINS
             kstag=kstag, units=units_ux)
         CALL push_field(temp_f, 'tmp', istag=istag, jstag=jstag, &
             kstag=kstag, units=units_ux)
-        CALL set_field_arr(uy_f, 0.0_realk)
-        CALL set_field_arr(vx_f, 0.0_realk)
-        CALL set_field_arr(temp_f, 0.0_realk)
+        CALL zero_field_arr(uy_f)
+        CALL zero_field_arr(vx_f)
+        CALL zero_field_arr(temp_f)
 
         CALL differentiate(uy_f, u_f, ivar1)
         CALL differentiate(vx_f, v_f, ivar2)

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -914,11 +914,8 @@ CONTAINS
 #endif
 
 #ifdef _MGLET_WORKAROUNDS_
-        BLOCK
-            INTEGER(intk) :: n
-            n = SIZE(dp%arr)
-            CALL accumulate_pcorr_impl(dp%arr, hilf%arr, n)
-        END BLOCK
+        CALL axpy(dp%arr, 1.0_realk, hilf%arr)
+        CALL synchronize()
 #else
         BLOCK
             INTEGER(intk) :: i
@@ -936,38 +933,5 @@ CONTAINS
         CALL profile_range_pop()
 #endif
     END SUBROUTINE accumulate_pcorr
-
-
-#ifdef _MGLET_WORKAROUNDS_
-    SUBROUTINE accumulate_pcorr_impl(dp, hilf, n)
-        ! Subroutine arguments
-        REAL(realk), INTENT(inout) :: dp(*)
-        REAL(realk), INTENT(in) :: hilf(*)
-        INTEGER(intk), INTENT(in) :: n
-
-        ! Local variables
-        INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
-
-        ! This is a 4D loop only because there are random crashes with 1D loops
-        ! using the amd compiler
-        !$omp target teams distribute private(imygrid, igrid, kk, jj, ii, ip3)
-        DO imygrid = 1, nmygrids
-            igrid = mygrids(imygrid)
-            CALL get_mgdims(kk, jj, ii, igrid)
-            CALL get_ip3(ip3, igrid)
-
-            !$omp parallel do collapse(3) private(i, j, k, idx)
-            DO i = 1, ii
-                DO j = 1, jj
-                    DO k = 1, kk
-                        idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj - 1
-                        dp(idx) = dp(idx) + hilf(idx)
-                    END DO
-                END DO
-            END DO
-            !$omp end parallel do
-        END DO
-    END SUBROUTINE accumulate_pcorr_impl
-#endif
 
 END MODULE pressuresolver_mod

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -189,10 +189,10 @@ CONTAINS
         CALL push_field(hilf, "HILF")
         CALL push_field(rhs, "RHS")
         CALL push_field(res, "RES")
-        CALL set_field_arr(dp, 0.0_realk, device=.TRUE.)
-        CALL set_field_arr(hilf, 0.0_realk, device=.TRUE.)
-        CALL set_field_arr(rhs, 0.0_realk, device=.TRUE.)
-        CALL set_field_arr(res, 0.0_realk, device=.TRUE.)
+        CALL zero_field_arr(dp, device=.TRUE.)
+        CALL zero_field_arr(hilf, device=.TRUE.)
+        CALL zero_field_arr(rhs, device=.TRUE.)
+        CALL zero_field_arr(res, device=.TRUE.)
 
         ! laplace(dp) = prefak * div(u) is the underlying equation
         prefak = rho/dt
@@ -265,7 +265,7 @@ CONTAINS
 
             ! dp = dp + hilf
             CALL accumulate_pcorr(dp, hilf)
-            CALL set_field_arr(hilf, 0.0_realk, device=.TRUE.)
+            CALL zero_field_arr(hilf, device=.TRUE.)
             ipc = ipc + ninner
 
             ! Pressure solver debug logging
@@ -907,17 +907,30 @@ CONTAINS
         TYPE(field_t), INTENT(inout) :: dp
         TYPE(field_t), INTENT(in) :: hilf
 
-        ! Local variables
-        INTEGER(intk) :: n
-
         IF (SIZE(dp%arr) /= SIZE(hilf%arr)) CALL errr(__FILE__, __LINE__)
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("accumulate_pcorr")
 #endif
 
-        n = SIZE(dp%arr)
-        CALL accumulate_pcorr_impl(dp%arr, hilf%arr, n)
+#ifdef _MGLET_WORKAROUNDS_
+        BLOCK
+            INTEGER(intk) :: n
+            n = SIZE(dp%arr)
+            CALL accumulate_pcorr_impl(dp%arr, hilf%arr, n)
+        END BLOCK
+#else
+        BLOCK
+            INTEGER(intk) :: i
+            ASSOCIATE (dp_arr => dp%arr, hilf_arr => hilf%arr)
+                !$omp target teams loop
+                DO i = 1, SIZE(dp_arr)
+                    dp_arr(i) = dp_arr(i) + hilf_arr(i)
+                END DO
+                !$omp end target teams loop
+            END ASSOCIATE
+        END BLOCK
+#endif
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_pop()
@@ -925,6 +938,7 @@ CONTAINS
     END SUBROUTINE accumulate_pcorr
 
 
+#ifdef _MGLET_WORKAROUNDS_
     SUBROUTINE accumulate_pcorr_impl(dp, hilf, n)
         ! Subroutine arguments
         REAL(realk), INTENT(inout) :: dp(*)
@@ -954,4 +968,6 @@ CONTAINS
             !$omp end parallel do
         END DO
     END SUBROUTINE accumulate_pcorr_impl
+#endif
+
 END MODULE pressuresolver_mod

--- a/src/flow/sip_hyperplane_mod.F90
+++ b/src/flow/sip_hyperplane_mod.F90
@@ -29,8 +29,8 @@ CONTAINS
         ! Setting up the hyperplane traversal infrastructure
         CALL mip_hp_f%init("SIP_MIP_HP")
         CALL idx_hp_f%init("SIP_IDX_HP")
-        CALL set_field_arr(mip_hp_f, 0_ifk, device=.FALSE.)
-        CALL set_field_arr(idx_hp_f, -1_ifk, device=.FALSE.)
+        CALL zero_field_arr(mip_hp_f)
+        CALL zero_field_arr(idx_hp_f)
 
         ASSOCIATE (mip => mip_hp_f%arr, idx => idx_hp_f%arr)
 

--- a/src/flow/tstle4_mod.F90
+++ b/src/flow/tstle4_mod.F90
@@ -31,9 +31,9 @@ CONTAINS
         TYPE(field_t), POINTER :: wcu_f, wcv_f, wcw_f
         CALL start_timer(310)
 
-        CALL set_field_arr(uo_f, 0.0_realk, device=.TRUE.)
-        CALL set_field_arr(vo_f, 0.0_realk, device=.TRUE.)
-        CALL set_field_arr(wo_f, 0.0_realk, device=.TRUE.)
+        CALL zero_field_arr(uo_f, device=.TRUE.)
+        CALL zero_field_arr(vo_f, device=.TRUE.)
+        CALL zero_field_arr(wo_f, device=.TRUE.)
 
         CALL get_field(dx_f, "DX")
         CALL get_field(dy_f, "DY")

--- a/src/ib/gc_blockbp_mod.F90
+++ b/src/ib/gc_blockbp_mod.F90
@@ -79,20 +79,20 @@ CONTAINS
         CALL push_field(au, "AU", istag=1)
         CALL push_field(av, "AV", jstag=1)
         CALL push_field(aw, "AW", kstag=1)
-        CALL set_field_arr(au, 0.0_realk)
-        CALL set_field_arr(av, 0.0_realk)
-        CALL set_field_arr(aw, 0.0_realk)
+        CALL zero_field_arr(au)
+        CALL zero_field_arr(av)
+        CALL zero_field_arr(aw)
 
         CALL push_field(kanteu, "KANTEU", jstag=1, kstag=1)
         CALL push_field(kantev, "KANTEV", istag=1, kstag=1)
         CALL push_field(kantew, "KANTEW", istag=1, jstag=1)
-        CALL set_field_arr(kanteu, 0.0_realk)
-        CALL set_field_arr(kantev, 0.0_realk)
-        CALL set_field_arr(kantew, 0.0_realk)
+        CALL zero_field_arr(kanteu)
+        CALL zero_field_arr(kantev)
+        CALL zero_field_arr(kantew)
 
         ! Important with proper staggering for parent to work
         CALL push_field(knoten, "KNOTEN", istag=1, jstag=1, kstag=1)
-        CALL set_field_arr(knoten, 0.0_realk)
+        CALL zero_field_arr(knoten)
 
         IF (myid == 0) THEN
             WRITE (*, '("BLOCKING: ", A40, ", WTIME:", F16.3)') &
@@ -323,7 +323,7 @@ CONTAINS
         TYPE(field_t), POINTER :: bodyid_3d_f
 
         CALL push_field(bodyid_3d_f, "BODYID")
-        CALL set_field_arr(bodyid_3d_f, 0.0_realk)
+        CALL zero_field_arr(bodyid_3d_f)
 
         ! Copy from list to 3D field
         DO ilevel = minlevel, maxlevel

--- a/src/ib/ib_mod.F90
+++ b/src/ib/ib_mod.F90
@@ -88,7 +88,7 @@ CONTAINS
         finecell%arr = 1.0
 
         CALL push_field(hilf, "HILF")
-        CALL set_field_arr(hilf, 0.0_realk)
+        CALL zero_field_arr(hilf)
 
         DO ilevel = maxlevel, minlevel, -1
             CALL ftoc(ilevel, hilf, finecell, 'P')

--- a/src/scalar/blockbt_mod.F90
+++ b/src/scalar/blockbt_mod.F90
@@ -30,7 +30,7 @@ CONTAINS
 
         CALL get_field(bp_f, "BP")
         CALL push_field(hilf_f, "HILF")
-        CALL set_field_arr(hilf_f, 0.0_realk)
+        CALL zero_field_arr(hilf_f)
 
         ! Checking if any neighboring cell (shared face) has bp=1
         ! [only those cells can have a flux stencil associated with them]

--- a/src/scalar/scastat_mod.F90
+++ b/src/scalar/scastat_mod.F90
@@ -125,7 +125,7 @@ CONTAINS
             units=units_txtx)
         CALL push_field(tx_f, 'tmp', istag=istag, jstag=jstag, kstag=kstag, &
             units=units_tx)
-        CALL set_field_arr(tx_f, 0.0_realk)
+        CALL zero_field_arr(tx_f)
 
         ! central difference on scalar (= no staggering)
         CALL differentiate(tx_f, t_f, ivar)

--- a/src/scalar/timeintegrate_scalar_mod.F90
+++ b/src/scalar/timeintegrate_scalar_mod.F90
@@ -38,10 +38,10 @@ CONTAINS
         CALL push_field(qtu, "QTU", istag=1)
         CALL push_field(qtv, "QTV", jstag=1)
         CALL push_field(qtw, "QTW", kstag=1)
-        CALL set_field_arr(qtt, 0.0_realk)
-        CALL set_field_arr(qtu, 0.0_realk)
-        CALL set_field_arr(qtv, 0.0_realk)
-        CALL set_field_arr(qtw, 0.0_realk)
+        CALL zero_field_arr(qtt)
+        CALL zero_field_arr(qtu)
+        CALL zero_field_arr(qtv)
+        CALL zero_field_arr(qtw)
 
         CALL stop_timer(401)
 


### PR DESCRIPTION
This will use the original code on CPU-only builds and allow the usage of the workarounds as neccesary when offloading. By default the workarounds are not enabled.