### PR TITLE
Add Parent Guard for minlevel

### DIFF
--- a/src/ib/parent/parent_mod.F90
+++ b/src/ib/parent/parent_mod.F90
@@ -25,6 +25,9 @@ CONTAINS
         LOGICAL :: device2
 #endif
 
+        ! The coarsest level cannot receive values from a parent grid
+        IF (ilevel == minlevel) RETURN
+
         IF (.NOT. is_parent_core_init) CALL errr(__FILE__, __LINE__)
 
         CALL start_timer(210)


### PR DESCRIPTION
Avoids tiny blocks in the profiling that do not do any actual work.