### PR TITLE
Hakostra/rework workarounds v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,16 @@ else()
 endif()
 
 option(MGLET_OFFLOAD "Enable OpenMP offloading (experimental)" OFF)
+option(MGLET_WORKAROUNDS "Enable OpenMP offloading workarounds" OFF)
 if(MGLET_OFFLOAD)
     message(STATUS "Enabling OpenMP offloading")
     find_package(OpenMP REQUIRED)
     add_compile_definitions(_MGLET_OFFLOAD_=1)
+endif()
+
+if (MGLET_WORKAROUNDS)
+    message(STATUS "Enabling OpenMP offloading workarounds")
+    add_compile_definitions(_MGLET_WORKAROUNDS_=1)
 endif()
 
 set(MGLET_PROFILE_ANNOTATIONS "off" CACHE STRING "MGLET profile annotations: off, roctx, nvtx")

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(core STATIC
     corefields_mod.F90
     core_mod.F90
     create_directory.c
+    device_workarounds.cxx
     envvars_mod.F90
     err_mod.F90
     expression_mod.F90
@@ -63,11 +64,20 @@ target_include_directories(core
     PRIVATE ${HDF5_Fortran_INCLUDE_DIRS}
 )
 
+target_compile_options(core
+    PRIVATE "$<$<AND:$<BOOL:${MGLET_OFFLOAD}>,$<COMPILE_LANGUAGE:C>>:${MGLET_OFFLOAD_COMPILE_FLAGS}>"
+    PRIVATE "$<$<AND:$<BOOL:${MGLET_OFFLOAD}>,$<COMPILE_LANGUAGE:C>>:${MGLET_OFFLOAD_ARCH_FLAGS}>"
+    PRIVATE "$<$<AND:$<BOOL:${MGLET_OFFLOAD}>,$<COMPILE_LANGUAGE:CXX>>:${MGLET_OFFLOAD_COMPILE_FLAGS}>"
+    PRIVATE "$<$<AND:$<BOOL:${MGLET_OFFLOAD}>,$<COMPILE_LANGUAGE:CXX>>:${MGLET_OFFLOAD_ARCH_FLAGS}>"
+)
+
 target_link_libraries(core
     PRIVATE ${MPI_Fortran_LIBRARIES}
     PRIVATE ${HDF5_Fortran_LIBRARIES}
     PRIVATE ZLIB::ZLIB
     PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_Fortran>
+    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_C>
+    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_CXX>
     PRIVATE $<$<STREQUAL:${MGLET_PROFILE_ANNOTATIONS},roctx>:rocprofiler-sdk-roctx::rocprofiler-sdk-roctx>
     PRIVATE $<$<STREQUAL:${MGLET_PROFILE_ANNOTATIONS},nvtx>:CUDA::nvtx3>
 )
@@ -81,6 +91,10 @@ set_source_files_properties(jsoncpp_wrapper.cxx PROPERTIES INCLUDE_DIRECTORIES
 )
 
 set_property(TARGET core PROPERTY CXX_STANDARD 17)
+
+set_source_files_properties(device_workarounds.cxx PROPERTIES COMPILE_FLAGS
+    $<$<STREQUAL:"${CMAKE_CXX_COMPILER_ID}","GNU">:-Wno-unknown-pragmas>
+)
 
 # Other neccesary compile flags
 set_source_files_properties(exprtk_wrapper.cxx PROPERTIES COMPILE_FLAGS

--- a/src/core/device_workarounds.cxx
+++ b/src/core/device_workarounds.cxx
@@ -1,0 +1,55 @@
+#include "mglet_precision.h"
+
+
+extern "C" void setzero_real_c(size_t n, mgletreal* arr) {
+    if (n == 0) return;
+
+    #pragma omp target teams loop
+    for (size_t i = 0; i < n; ++i) {
+        arr[i] = 0.0;
+    }
+}
+
+
+extern "C" void setzero_ifk_c(size_t n, mgletifk* arr) {
+    if (n == 0) return;
+
+    #pragma omp target teams loop
+    for (size_t i = 0; i < n; ++i) {
+        arr[i] = 0;
+    }
+}
+
+
+extern "C" void copyarr_real_c(size_t n, mgletreal* dest,
+        const mgletreal* src) {
+    if (n == 0) return;
+
+    #pragma omp target teams loop
+    for (size_t i = 0; i < n; ++i) {
+        dest[i] = src[i];
+    }
+}
+
+
+extern "C" void rkstep_c(const size_t n, mgletreal* p, mgletreal* dp,
+        const mgletreal* rhsp, mgletreal frhs, mgletreal dtfu) {
+    if (n == 0) return;
+
+    #pragma omp target teams loop
+    for (size_t i = 0; i < n; ++i) {
+        dp[i] = frhs*dp[i] + rhsp[i];
+        p[i] = p[i] + dtfu*dp[i];
+    }
+}
+
+
+extern "C" void accumulate_pcorr_c(size_t n, mgletreal* dp,
+        const mgletreal* hilf) {
+    if (n == 0) return;
+
+    #pragma omp target teams loop
+    for (size_t i = 0; i < n; ++i) {
+        dp[i] = dp[i] + hilf[i];
+    }
+}

--- a/src/core/fieldhelper_mod.F90
+++ b/src/core/fieldhelper_mod.F90
@@ -1,10 +1,11 @@
 
 MODULE fieldhelper_mod
+    USE, INTRINSIC :: ISO_C_BINDING, ONLY: c_size_t
     USE err_mod, ONLY: errr
     USE field_mod, ONLY: field_t, intfield_t
     USE grids_mod, ONLY: get_mgdims, mygrids, nmygrids, level, get_imygrid
     USE pointers_mod, ONLY: get_ipbb, get_ip3
-    USE precision_mod, ONLY: realk, intk, ifk
+    USE precision_mod, ONLY: realk, intk, ifk, c_realk, c_ifk
     USE profile_tools_mod, ONLY: profile_range_push, profile_range_pop
 
     IMPLICIT NONE(type, external)
@@ -16,7 +17,29 @@ MODULE fieldhelper_mod
     END INTERFACE zero_field_arr
 
     PUBLIC :: zero_field_arr, map_arr_to_device, map_arr_from_device, &
-        map_buffers_to_device, map_buffers_from_device
+        map_buffers_to_device, map_buffers_from_device, copy_arr
+
+    INTERFACE
+        SUBROUTINE setzero_real_c(n, arr) BIND(C)
+            IMPORT :: c_size_t, c_realk
+            INTEGER(c_size_t), INTENT(in), VALUE :: n
+            REAL(c_realk), INTENT(inout) :: arr(*)
+        END SUBROUTINE setzero_real_c
+
+        SUBROUTINE setzero_ifk_c(n, arr) BIND(C)
+            IMPORT :: c_size_t, c_ifk
+            INTEGER(c_size_t), INTENT(in), VALUE :: n
+            INTEGER(c_ifk), INTENT(inout) :: arr(*)
+        END SUBROUTINE setzero_ifk_c
+
+        SUBROUTINE copyarr_real_c(n, dest, source) BIND(C)
+            IMPORT :: c_size_t, c_realk
+            INTEGER(c_size_t), INTENT(in), VALUE :: n
+            REAL(c_realk), INTENT(inout) :: dest(*)
+            REAL(c_realk), INTENT(in) :: source(*)
+        END SUBROUTINE copyarr_real_c
+    END INTERFACE
+
 CONTAINS
     SUBROUTINE zero_field_arr_realk(field, device)
         ! Subroutine arguments
@@ -38,7 +61,7 @@ CONTAINS
 
         IF (device2) THEN
 #ifdef _MGLET_WORKAROUNDS_
-            CALL zero_field_arr_realk_impl(field%arr)
+            CALL setzero_real_c(SIZE(field%arr, kind=c_size_t), field%arr)
 #else
             BLOCK
                 INTEGER(intk) :: i
@@ -61,37 +84,6 @@ CONTAINS
     END SUBROUTINE zero_field_arr_realk
 
 
-#ifdef _MGLET_WORKAROUNDS_
-    SUBROUTINE zero_field_arr_realk_impl(arr)
-        ! Subroutine arguments
-        REAL(realk), INTENT(inout) :: arr(*)
-
-        ! Local variables
-        INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
-
-        ! This is a 4D loop only because there are random crashes with 1D loops
-        ! using the amd compiler
-        !$omp target teams distribute private(imygrid, igrid, kk, jj, ii, ip3)
-        DO imygrid = 1, nmygrids
-            igrid = mygrids(imygrid)
-            CALL get_mgdims(kk, jj, ii, igrid)
-            CALL get_ip3(ip3, igrid)
-
-            !$omp parallel do collapse(3) private(i, j, k, idx)
-            DO i = 1, ii
-                DO j = 1, jj
-                    DO k = 1, kk
-                        idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj - 1
-                        arr(idx) = 0.0_realk
-                    END DO
-                END DO
-            END DO
-            !$omp end parallel do
-        END DO
-    END SUBROUTINE zero_field_arr_realk_impl
-#endif
-
-
     SUBROUTINE zero_field_arr_ifk(field, device)
         ! Subroutine arguments
         TYPE(intfield_t), INTENT(inout) :: field
@@ -112,7 +104,7 @@ CONTAINS
 
         IF (device2) THEN
 #ifdef _MGLET_WORKAROUNDS_
-            CALL zero_field_arr_ifk_impl(field%arr)
+            CALL setzero_ifk_c(SIZE(field%arr, kind=c_size_t), field%arr)
 #else
             BLOCK
                 INTEGER(intk) :: i
@@ -135,35 +127,24 @@ CONTAINS
     END SUBROUTINE zero_field_arr_ifk
 
 
-#ifdef _MGLET_WORKAROUNDS_
-    SUBROUTINE zero_field_arr_ifk_impl(arr)
+    SUBROUTINE copy_arr(dest, source)
         ! Subroutine arguments
-        INTEGER(ifk), INTENT(inout) :: arr(*)
+        REAL(realk), INTENT(inout) :: dest(:)
+        REAL(realk), INTENT(in) :: source(:)
 
-        ! Local variables
-        INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
-
-        ! This is a 4D loop only because there are random crashes with 1D loops
-        ! using the amd compiler
-        !$omp target teams distribute private(imygrid, igrid, kk, jj, ii, ip3)
-        DO imygrid = 1, nmygrids
-            igrid = mygrids(imygrid)
-            CALL get_mgdims(kk, jj, ii, igrid)
-            CALL get_ip3(ip3, igrid)
-
-            !$omp parallel do collapse(3) private(i, j, k, idx)
-            DO i = 1, ii
-                DO j = 1, jj
-                    DO k = 1, kk
-                        idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj - 1
-                        arr(idx) = 0_intk
-                    END DO
-                END DO
+#ifdef _MGLET_WORKAROUNDS_
+        CALL copyarr_real_c(SIZE(dest, kind=c_size_t), dest, source)
+#else
+        BLOCK
+            INTEGER(intk) :: i
+            !$omp target teams loop
+            DO i = 1, SIZE(dest)
+                dest(i) = source(i)
             END DO
-            !$omp end parallel do
-        END DO
-    END SUBROUTINE zero_field_arr_ifk_impl
+            !$omp end target teams loop
+        END BLOCK
 #endif
+    END SUBROUTINE copy_arr
 
 
     SUBROUTINE map_arr_to_device(f1, f2, f3, f4, f5, f6, f7, message)

--- a/src/core/fieldhelper_mod.F90
+++ b/src/core/fieldhelper_mod.F90
@@ -10,22 +10,20 @@ MODULE fieldhelper_mod
     IMPLICIT NONE(type, external)
     PRIVATE
 
-    INTERFACE set_field_arr
-        PROCEDURE set_field_arr_realk
-        PROCEDURE set_field_arr_ifk
-    END INTERFACE set_field_arr
+    INTERFACE zero_field_arr
+        PROCEDURE zero_field_arr_realk
+        PROCEDURE zero_field_arr_ifk
+    END INTERFACE zero_field_arr
 
-    PUBLIC :: set_field_arr, map_arr_to_device, map_arr_from_device, &
+    PUBLIC :: zero_field_arr, map_arr_to_device, map_arr_from_device, &
         map_buffers_to_device, map_buffers_from_device
 CONTAINS
-    SUBROUTINE set_field_arr_realk(field, val, device)
+    SUBROUTINE zero_field_arr_realk(field, device)
         ! Subroutine arguments
         TYPE(field_t), INTENT(inout) :: field
-        REAL(realk), INTENT(in) :: val
         LOGICAL, OPTIONAL, INTENT(in) :: device
 
         ! Local variables
-        INTEGER(intk) :: n
         LOGICAL :: device2
 
         IF (PRESENT(device)) THEN
@@ -35,26 +33,38 @@ CONTAINS
         END IF
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
-            CALL profile_range_push("set_field_arr_realk")
+            CALL profile_range_push("zero_field_arr_realk")
 #endif
 
         IF (device2) THEN
-            n = SIZE(field%arr)
-            CALL set_field_arr_realk_impl(field%arr, val)
+#ifdef _MGLET_WORKAROUNDS_
+            CALL zero_field_arr_realk_impl(field%arr)
+#else
+            BLOCK
+                INTEGER(intk) :: i
+                ASSOCIATE(arr => field%arr)
+                    !$omp target teams loop
+                    DO i = 1, SIZE(arr)
+                        arr(i) = 0.0_realk
+                    END DO
+                    !$omp end target teams loop
+                END ASSOCIATE
+            END BLOCK
+#endif
         ELSE
-            field%arr = val
+            field%arr = 0.0_realk
         END IF
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
             CALL profile_range_pop()
 #endif
-    END SUBROUTINE set_field_arr_realk
+    END SUBROUTINE zero_field_arr_realk
 
 
-    SUBROUTINE set_field_arr_realk_impl(arr, val)
+#ifdef _MGLET_WORKAROUNDS_
+    SUBROUTINE zero_field_arr_realk_impl(arr)
         ! Subroutine arguments
         REAL(realk), INTENT(inout) :: arr(*)
-        REAL(realk), INTENT(in) :: val
 
         ! Local variables
         INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
@@ -72,23 +82,22 @@ CONTAINS
                 DO j = 1, jj
                     DO k = 1, kk
                         idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj - 1
-                        arr(idx) = val
+                        arr(idx) = 0.0_realk
                     END DO
                 END DO
             END DO
             !$omp end parallel do
         END DO
-    END SUBROUTINE set_field_arr_realk_impl
+    END SUBROUTINE zero_field_arr_realk_impl
+#endif
 
 
-    SUBROUTINE set_field_arr_ifk(field, val, device)
+    SUBROUTINE zero_field_arr_ifk(field, device)
         ! Subroutine arguments
         TYPE(intfield_t), INTENT(inout) :: field
-        INTEGER(ifk), INTENT(in) :: val
         LOGICAL, OPTIONAL, INTENT(in) :: device
 
         ! Local variables
-        INTEGER(intk) :: n
         LOGICAL :: device2
 
         IF (PRESENT(device)) THEN
@@ -98,26 +107,38 @@ CONTAINS
         END IF
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
-        CALL profile_range_push("set_field_arr_ifk")
+        CALL profile_range_push("zero_field_arr_ifk")
 #endif
 
         IF (device2) THEN
-            n = SIZE(field%arr)
-            CALL set_field_arr_ifk_impl(field%arr, val)
+#ifdef _MGLET_WORKAROUNDS_
+            CALL zero_field_arr_ifk_impl(field%arr)
+#else
+            BLOCK
+                INTEGER(intk) :: i
+                ASSOCIATE(arr => field%arr)
+                    !$omp target teams loop
+                    DO i = 1, SIZE(arr)
+                        arr(i) = 0_intk
+                    END DO
+                    !$omp end target teams loop
+                END ASSOCIATE
+            END BLOCK
+#endif
         ELSE
-            field%arr = val
+            field%arr = 0_intk
         END IF
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
             CALL profile_range_pop()
 #endif
-    END SUBROUTINE set_field_arr_ifk
+    END SUBROUTINE zero_field_arr_ifk
 
 
-    SUBROUTINE set_field_arr_ifk_impl(arr, val)
+#ifdef _MGLET_WORKAROUNDS_
+    SUBROUTINE zero_field_arr_ifk_impl(arr)
         ! Subroutine arguments
         INTEGER(ifk), INTENT(inout) :: arr(*)
-        INTEGER(ifk), INTENT(in) :: val
 
         ! Local variables
         INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
@@ -135,13 +156,14 @@ CONTAINS
                 DO j = 1, jj
                     DO k = 1, kk
                         idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj - 1
-                        arr(idx) = val
+                        arr(idx) = 0_intk
                     END DO
                 END DO
             END DO
             !$omp end parallel do
         END DO
-    END SUBROUTINE set_field_arr_ifk_impl
+    END SUBROUTINE zero_field_arr_ifk_impl
+#endif
 
 
     SUBROUTINE map_arr_to_device(f1, f2, f3, f4, f5, f6, f7, message)

--- a/src/core/fieldpool_mod.F90
+++ b/src/core/fieldpool_mod.F90
@@ -2,7 +2,6 @@ MODULE fieldpool_mod
     USE precision_mod
     USE err_mod, ONLY: errr
     USE field_mod, ONLY: basefield_t, field_t, intfield_t, nchar_name
-    USE fieldhelper_mod, ONLY: set_field_arr
 
     IMPLICIT NONE(type, external)
     PRIVATE

--- a/src/core/mglet_precision.h
+++ b/src/core/mglet_precision.h
@@ -17,6 +17,12 @@ typedef float mgletreal;
 #define CFI_type_mgletreal CFI_type_float
 #endif
 
+#ifdef _MGLET_IFK64_
+typedef long long mgletifk;
+#else
+typedef int mgletifk;
+#endif
+
 #ifdef _MGLET_INT64_
 typedef long long mgletint;
 

--- a/src/core/precision_mod.F90
+++ b/src/core/precision_mod.F90
@@ -33,9 +33,11 @@ MODULE precision_mod
 #ifdef _MGLET_IFK64_
     INTEGER(int32), PARAMETER :: ifk = int64
     INTEGER(int32), PARAMETER :: ifk_bytes = 8
+    INTEGER(int32), PARAMETER :: c_ifk = c_long_long
 #else
     INTEGER(int32), PARAMETER :: ifk = int32
     INTEGER(int32), PARAMETER :: ifk_bytes = 4
+    INTEGER(int32), PARAMETER :: c_ifk = c_int
 #endif
 
     ! MPI data types for REAL and INTEGER
@@ -69,7 +71,7 @@ MODULE precision_mod
         c_realk, mglet_hdf5_real, mglet_hdf5_int, pi, eps, int8, int16, &
         int32, int64, real32, real64, real_bytes, int_bytes, &
         mglet_filename_max, neps, ifk, ifk_bytes, mglet_mpi_ifk, &
-        mglet_hdf5_ifk
+        mglet_hdf5_ifk, c_ifk
 
     PUBLIC :: mglet_mpi_real, mglet_mpi_int, mglet_mpi_hsize_t
 

--- a/src/core/rungekutta_mod.F90
+++ b/src/core/rungekutta_mod.F90
@@ -1,9 +1,8 @@
 MODULE rungekutta_mod
+    USE, INTRINSIC :: ISO_C_BINDING, ONLY: c_size_t
     USE charfunc_mod, ONLY: lower
     USE err_mod, ONLY: errr
-    USE grids_mod, ONLY: get_mgdims, mygrids, nmygrids
-    USE pointers_mod, ONLY: get_ip3
-    USE precision_mod, ONLY: intk, realk
+    USE precision_mod, ONLY: intk, realk, c_realk
     USE profile_tools_mod, ONLY: profile_range_push, profile_range_pop
 
 
@@ -48,6 +47,19 @@ MODULE rungekutta_mod
     END TYPE rk_2n_t
 
     PUBLIC :: rk_2n_t, rkstep
+
+    INTERFACE
+        SUBROUTINE rkstep_c(n, p, dp, rhsp, frhs, dtfu) BIND(C)
+            IMPORT :: c_size_t, c_realk
+            INTEGER(c_size_t), INTENT(in), VALUE :: n
+            REAL(c_realk), INTENT(inout) :: p(*)
+            REAL(c_realk), INTENT(inout) :: dp(*)
+            REAL(c_realk), INTENT(in) :: rhsp(*)
+            REAL(c_realk), INTENT(in), VALUE :: frhs
+            REAL(c_realk), INTENT(in), VALUE :: dtfu
+        END SUBROUTINE rkstep_c
+    END INTERFACE
+
 CONTAINS
 
     SUBROUTINE init_2n(this, ctyp)
@@ -318,15 +330,9 @@ CONTAINS
     ! U_j = U_(j-1) + B_j*dU_j
     SUBROUTINE rkstep(p, dp, rhsp, frhs, dtfu)
         ! Subroutine arguments
-#ifdef _MGLET_WORKAROUNDS_
-        REAL(realk), INTENT(inout) :: p(*)
-        REAL(realk), INTENT(inout) :: dp(*)
-        REAL(realk), INTENT(in) :: rhsp(*)
-#else
         REAL(realk), CONTIGUOUS, INTENT(inout) :: p(:)
         REAL(realk), CONTIGUOUS, INTENT(inout) :: dp(:)
         REAL(realk), CONTIGUOUS, INTENT(in) :: rhsp(:)
-#endif
         REAL(realk), INTENT(in) :: frhs
         REAL(realk), INTENT(in) :: dtfu
 
@@ -335,35 +341,7 @@ CONTAINS
 #endif
 
 #ifdef _MGLET_WORKAROUNDS_
-        BLOCK
-            ! Local variables
-            INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
-
-            ! Perform the update in a manually crafted loop is faster than
-            ! using an implicit loop, because of cache effects (dp(i) is
-            ! already in cache when p(i) is updated)
-            ! This is a 4D loop only because there are random crashes with
-            ! 1D loops using the amd compiler
-            !$omp target teams distribute private(imygrid, igrid, kk, jj, &
-            !$omp& ii, ip3)
-            DO imygrid = 1, nmygrids
-                igrid = mygrids(imygrid)
-                CALL get_mgdims(kk, jj, ii, igrid)
-                CALL get_ip3(ip3, igrid)
-
-                !$omp parallel do collapse(3) private(i, j, k, idx)
-                DO i = 1, ii
-                    DO j = 1, jj
-                        DO k = 1, kk
-                            idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj - 1
-                            dp(idx) = frhs*dp(idx) + rhsp(idx)
-                            p(idx) = p(idx) + dtfu*dp(idx)
-                        END DO
-                    END DO
-                END DO
-                !$omp end parallel do
-            END DO
-        END BLOCK
+        CALL rkstep_c(SIZE(p, kind=c_size_t), p, dp, rhsp, frhs, dtfu)
 #else
         BLOCK
             ! Local variables
@@ -382,4 +360,5 @@ CONTAINS
         CALL profile_range_pop()
 #endif
     END SUBROUTINE rkstep
+
 END MODULE rungekutta_mod

--- a/src/core/rungekutta_mod.F90
+++ b/src/core/rungekutta_mod.F90
@@ -318,42 +318,65 @@ CONTAINS
     ! U_j = U_(j-1) + B_j*dU_j
     SUBROUTINE rkstep(p, dp, rhsp, frhs, dtfu)
         ! Subroutine arguments
+#ifdef _MGLET_WORKAROUNDS_
         REAL(realk), INTENT(inout) :: p(*)
         REAL(realk), INTENT(inout) :: dp(*)
         REAL(realk), INTENT(in) :: rhsp(*)
+#else
+        REAL(realk), CONTIGUOUS, INTENT(inout) :: p(:)
+        REAL(realk), CONTIGUOUS, INTENT(inout) :: dp(:)
+        REAL(realk), CONTIGUOUS, INTENT(in) :: rhsp(:)
+#endif
         REAL(realk), INTENT(in) :: frhs
         REAL(realk), INTENT(in) :: dtfu
-
-        ! Local variables
-        INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("rkstep")
 #endif
 
-        ! Perform the update in a manually crafted loop is faster than using an
-        ! implicit loop, because of cache effects (dp(i) is already in cache
-        ! when p(i) is updated)
-        ! This is a 4D loop only because there are random crashes with 1D loops
-        ! using the amd compiler
-        !$omp target teams distribute private(imygrid, igrid, kk, jj, ii, ip3)
-        DO imygrid = 1, nmygrids
-            igrid = mygrids(imygrid)
-            CALL get_mgdims(kk, jj, ii, igrid)
-            CALL get_ip3(ip3, igrid)
+#ifdef _MGLET_WORKAROUNDS_
+        BLOCK
+            ! Local variables
+            INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
 
-            !$omp parallel do collapse(3) private(i, j, k, idx)
-            DO i = 1, ii
-                DO j = 1, jj
-                    DO k = 1, kk
-                        idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj - 1
-                        dp(idx) = frhs*dp(idx) + rhsp(idx)
-                        p(idx) = p(idx) + dtfu*dp(idx)
+            ! Perform the update in a manually crafted loop is faster than
+            ! using an implicit loop, because of cache effects (dp(i) is
+            ! already in cache when p(i) is updated)
+            ! This is a 4D loop only because there are random crashes with
+            ! 1D loops using the amd compiler
+            !$omp target teams distribute private(imygrid, igrid, kk, jj, &
+            !$omp& ii, ip3)
+            DO imygrid = 1, nmygrids
+                igrid = mygrids(imygrid)
+                CALL get_mgdims(kk, jj, ii, igrid)
+                CALL get_ip3(ip3, igrid)
+
+                !$omp parallel do collapse(3) private(i, j, k, idx)
+                DO i = 1, ii
+                    DO j = 1, jj
+                        DO k = 1, kk
+                            idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj - 1
+                            dp(idx) = frhs*dp(idx) + rhsp(idx)
+                            p(idx) = p(idx) + dtfu*dp(idx)
+                        END DO
                     END DO
                 END DO
+                !$omp end parallel do
             END DO
-            !$omp end parallel do
-        END DO
+        END BLOCK
+#else
+        BLOCK
+            ! Local variables
+            INTEGER(intk) :: i
+
+            !$omp target teams loop
+            DO i = 1, SIZE(p)
+                dp(i) = frhs*dp(i) + rhsp(i)
+                p(i) = p(i) + dtfu*dp(i)
+            END DO
+            !$omp end target teams loop
+        END BLOCK
+#endif
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_pop()

--- a/src/flow/flowstat_mod.F90
+++ b/src/flow/flowstat_mod.F90
@@ -592,7 +592,7 @@ CONTAINS
             units=units)
         CALL push_field(ux_f, name_ux, istag=istag, jstag=jstag, &
             kstag=kstag, units=units_ux)
-        CALL set_field_arr(ux_f, 0.0_realk)
+        CALL zero_field_arr(ux_f)
 
         CALL differentiate(ux_f, u_f, ivar)
 
@@ -688,7 +688,7 @@ CONTAINS
             units=units)
         CALL push_field(ux_f, name_ux, istag=istag, jstag=jstag, &
             kstag=kstag, units=units_ux)
-        CALL set_field_arr(ux_f, 0.0_realk)
+        CALL zero_field_arr(ux_f)
         CALL differentiate(ux_f, u_f, ivar)
 
         field%arr = ux_f%arr**2
@@ -817,8 +817,8 @@ CONTAINS
             kstag=kstag, units=units_ux)
         CALL push_field(vx_f, name_vx, istag=istag, jstag=jstag, &
             kstag=kstag, units=units_ux)
-        CALL set_field_arr(ux_f, 0.0_realk)
-        CALL set_field_arr(vx_f, 0.0_realk)
+        CALL zero_field_arr(ux_f)
+        CALL zero_field_arr(vx_f)
 
         CALL differentiate(ux_f, u_f, ivar1)
         CALL differentiate(vx_f, v_f, ivar2)
@@ -891,9 +891,9 @@ CONTAINS
             kstag=kstag, units=units_ux)
         CALL push_field(temp_f, 'tmp', istag=istag, jstag=jstag, &
             kstag=kstag, units=units_ux)
-        CALL set_field_arr(uy_f, 0.0_realk)
-        CALL set_field_arr(vx_f, 0.0_realk)
-        CALL set_field_arr(temp_f, 0.0_realk)
+        CALL zero_field_arr(uy_f)
+        CALL zero_field_arr(vx_f)
+        CALL zero_field_arr(temp_f)
 
         CALL differentiate(uy_f, u_f, ivar1)
         CALL differentiate(vx_f, v_f, ivar2)

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -1,4 +1,5 @@
 MODULE pressuresolver_mod
+    USE, INTRINSIC :: ISO_C_BINDING, ONLY: c_size_t
     USE bound_flow_mod
     USE bound_pressure_mod
     USE core_mod
@@ -10,6 +11,7 @@ MODULE pressuresolver_mod
     USE sip_hyperplane_mod, sipiter1_hp => sipiter1, sipiter2_hp => sipiter2
     USE sip_classic_mod, sipiter1_cl => sipiter1, sipiter2_cl => sipiter2
     USE sor_mod
+    USE precision_mod, ONLY: c_realk
 
     IMPLICIT NONE (type, external)
     PRIVATE
@@ -43,6 +45,15 @@ MODULE pressuresolver_mod
     INTEGER(intk), PROTECTED :: loglevel = 0
 
     PUBLIC :: init_pressuresolver, finish_pressuresolver, mgpoisl
+
+    INTERFACE
+        SUBROUTINE accumulate_pcorr_c(n, dp, hilf) BIND(C)
+            IMPORT :: c_size_t, c_realk
+            INTEGER(c_size_t), INTENT(in), VALUE :: n
+            REAL(c_realk), INTENT(inout) :: dp(*)
+            REAL(c_realk), INTENT(in) :: hilf(*)
+        END SUBROUTINE accumulate_pcorr_c
+    END INTERFACE
 CONTAINS
     SUBROUTINE init_pressuresolver()
         ! Subroutine arguments
@@ -914,11 +925,7 @@ CONTAINS
 #endif
 
 #ifdef _MGLET_WORKAROUNDS_
-        BLOCK
-            INTEGER(intk) :: n
-            n = SIZE(dp%arr)
-            CALL accumulate_pcorr_impl(dp%arr, hilf%arr, n)
-        END BLOCK
+        CALL accumulate_pcorr_c(SIZE(dp%arr, kind=c_size_t), dp%arr, hilf%arr)
 #else
         BLOCK
             INTEGER(intk) :: i
@@ -936,38 +943,5 @@ CONTAINS
         CALL profile_range_pop()
 #endif
     END SUBROUTINE accumulate_pcorr
-
-
-#ifdef _MGLET_WORKAROUNDS_
-    SUBROUTINE accumulate_pcorr_impl(dp, hilf, n)
-        ! Subroutine arguments
-        REAL(realk), INTENT(inout) :: dp(*)
-        REAL(realk), INTENT(in) :: hilf(*)
-        INTEGER(intk), INTENT(in) :: n
-
-        ! Local variables
-        INTEGER(intk) :: imygrid, igrid, kk, jj, ii, ip3, i, j, k, idx
-
-        ! This is a 4D loop only because there are random crashes with 1D loops
-        ! using the amd compiler
-        !$omp target teams distribute private(imygrid, igrid, kk, jj, ii, ip3)
-        DO imygrid = 1, nmygrids
-            igrid = mygrids(imygrid)
-            CALL get_mgdims(kk, jj, ii, igrid)
-            CALL get_ip3(ip3, igrid)
-
-            !$omp parallel do collapse(3) private(i, j, k, idx)
-            DO i = 1, ii
-                DO j = 1, jj
-                    DO k = 1, kk
-                        idx = ip3 + k + (j-1)*kk + (i-1)*kk*jj - 1
-                        dp(idx) = dp(idx) + hilf(idx)
-                    END DO
-                END DO
-            END DO
-            !$omp end parallel do
-        END DO
-    END SUBROUTINE accumulate_pcorr_impl
-#endif
 
 END MODULE pressuresolver_mod

--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -189,10 +189,10 @@ CONTAINS
         CALL push_field(hilf, "HILF")
         CALL push_field(rhs, "RHS")
         CALL push_field(res, "RES")
-        CALL set_field_arr(dp, 0.0_realk, device=.TRUE.)
-        CALL set_field_arr(hilf, 0.0_realk, device=.TRUE.)
-        CALL set_field_arr(rhs, 0.0_realk, device=.TRUE.)
-        CALL set_field_arr(res, 0.0_realk, device=.TRUE.)
+        CALL zero_field_arr(dp, device=.TRUE.)
+        CALL zero_field_arr(hilf, device=.TRUE.)
+        CALL zero_field_arr(rhs, device=.TRUE.)
+        CALL zero_field_arr(res, device=.TRUE.)
 
         ! laplace(dp) = prefak * div(u) is the underlying equation
         prefak = rho/dt
@@ -265,7 +265,7 @@ CONTAINS
 
             ! dp = dp + hilf
             CALL accumulate_pcorr(dp, hilf)
-            CALL set_field_arr(hilf, 0.0_realk, device=.TRUE.)
+            CALL zero_field_arr(hilf, device=.TRUE.)
             ipc = ipc + ninner
 
             ! Pressure solver debug logging
@@ -907,17 +907,30 @@ CONTAINS
         TYPE(field_t), INTENT(inout) :: dp
         TYPE(field_t), INTENT(in) :: hilf
 
-        ! Local variables
-        INTEGER(intk) :: n
-
         IF (SIZE(dp%arr) /= SIZE(hilf%arr)) CALL errr(__FILE__, __LINE__)
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_push("accumulate_pcorr")
 #endif
 
-        n = SIZE(dp%arr)
-        CALL accumulate_pcorr_impl(dp%arr, hilf%arr, n)
+#ifdef _MGLET_WORKAROUNDS_
+        BLOCK
+            INTEGER(intk) :: n
+            n = SIZE(dp%arr)
+            CALL accumulate_pcorr_impl(dp%arr, hilf%arr, n)
+        END BLOCK
+#else
+        BLOCK
+            INTEGER(intk) :: i
+            ASSOCIATE (dp_arr => dp%arr, hilf_arr => hilf%arr)
+                !$omp target teams loop
+                DO i = 1, SIZE(dp_arr)
+                    dp_arr(i) = dp_arr(i) + hilf_arr(i)
+                END DO
+                !$omp end target teams loop
+            END ASSOCIATE
+        END BLOCK
+#endif
 
 #ifdef _MGLET_PROFILE_ANNOTATIONS_
         CALL profile_range_pop()
@@ -925,6 +938,7 @@ CONTAINS
     END SUBROUTINE accumulate_pcorr
 
 
+#ifdef _MGLET_WORKAROUNDS_
     SUBROUTINE accumulate_pcorr_impl(dp, hilf, n)
         ! Subroutine arguments
         REAL(realk), INTENT(inout) :: dp(*)
@@ -954,4 +968,6 @@ CONTAINS
             !$omp end parallel do
         END DO
     END SUBROUTINE accumulate_pcorr_impl
+#endif
+
 END MODULE pressuresolver_mod

--- a/src/flow/sip_hyperplane_mod.F90
+++ b/src/flow/sip_hyperplane_mod.F90
@@ -29,8 +29,8 @@ CONTAINS
         ! Setting up the hyperplane traversal infrastructure
         CALL mip_hp_f%init("SIP_MIP_HP")
         CALL idx_hp_f%init("SIP_IDX_HP")
-        CALL set_field_arr(mip_hp_f, 0_ifk, device=.FALSE.)
-        CALL set_field_arr(idx_hp_f, -1_ifk, device=.FALSE.)
+        CALL zero_field_arr(mip_hp_f)
+        CALL zero_field_arr(idx_hp_f)
 
         ASSOCIATE (mip => mip_hp_f%arr, idx => idx_hp_f%arr)
 

--- a/src/flow/tstle4_mod.F90
+++ b/src/flow/tstle4_mod.F90
@@ -31,9 +31,9 @@ CONTAINS
         TYPE(field_t), POINTER :: wcu_f, wcv_f, wcw_f
         CALL start_timer(310)
 
-        CALL set_field_arr(uo_f, 0.0_realk, device=.TRUE.)
-        CALL set_field_arr(vo_f, 0.0_realk, device=.TRUE.)
-        CALL set_field_arr(wo_f, 0.0_realk, device=.TRUE.)
+        CALL zero_field_arr(uo_f, device=.TRUE.)
+        CALL zero_field_arr(vo_f, device=.TRUE.)
+        CALL zero_field_arr(wo_f, device=.TRUE.)
 
         CALL get_field(dx_f, "DX")
         CALL get_field(dy_f, "DY")

--- a/src/ib/gc_blockbp_mod.F90
+++ b/src/ib/gc_blockbp_mod.F90
@@ -79,20 +79,20 @@ CONTAINS
         CALL push_field(au, "AU", istag=1)
         CALL push_field(av, "AV", jstag=1)
         CALL push_field(aw, "AW", kstag=1)
-        CALL set_field_arr(au, 0.0_realk)
-        CALL set_field_arr(av, 0.0_realk)
-        CALL set_field_arr(aw, 0.0_realk)
+        CALL zero_field_arr(au)
+        CALL zero_field_arr(av)
+        CALL zero_field_arr(aw)
 
         CALL push_field(kanteu, "KANTEU", jstag=1, kstag=1)
         CALL push_field(kantev, "KANTEV", istag=1, kstag=1)
         CALL push_field(kantew, "KANTEW", istag=1, jstag=1)
-        CALL set_field_arr(kanteu, 0.0_realk)
-        CALL set_field_arr(kantev, 0.0_realk)
-        CALL set_field_arr(kantew, 0.0_realk)
+        CALL zero_field_arr(kanteu)
+        CALL zero_field_arr(kantev)
+        CALL zero_field_arr(kantew)
 
         ! Important with proper staggering for parent to work
         CALL push_field(knoten, "KNOTEN", istag=1, jstag=1, kstag=1)
-        CALL set_field_arr(knoten, 0.0_realk)
+        CALL zero_field_arr(knoten)
 
         IF (myid == 0) THEN
             WRITE (*, '("BLOCKING: ", A40, ", WTIME:", F16.3)') &
@@ -323,7 +323,7 @@ CONTAINS
         TYPE(field_t), POINTER :: bodyid_3d_f
 
         CALL push_field(bodyid_3d_f, "BODYID")
-        CALL set_field_arr(bodyid_3d_f, 0.0_realk)
+        CALL zero_field_arr(bodyid_3d_f)
 
         ! Copy from list to 3D field
         DO ilevel = minlevel, maxlevel

--- a/src/ib/ib_mod.F90
+++ b/src/ib/ib_mod.F90
@@ -88,7 +88,7 @@ CONTAINS
         finecell%arr = 1.0
 
         CALL push_field(hilf, "HILF")
-        CALL set_field_arr(hilf, 0.0_realk)
+        CALL zero_field_arr(hilf)
 
         DO ilevel = maxlevel, minlevel, -1
             CALL ftoc(ilevel, hilf, finecell, 'P')

--- a/src/scalar/blockbt_mod.F90
+++ b/src/scalar/blockbt_mod.F90
@@ -30,7 +30,7 @@ CONTAINS
 
         CALL get_field(bp_f, "BP")
         CALL push_field(hilf_f, "HILF")
-        CALL set_field_arr(hilf_f, 0.0_realk)
+        CALL zero_field_arr(hilf_f)
 
         ! Checking if any neighboring cell (shared face) has bp=1
         ! [only those cells can have a flux stencil associated with them]

--- a/src/scalar/scastat_mod.F90
+++ b/src/scalar/scastat_mod.F90
@@ -125,7 +125,7 @@ CONTAINS
             units=units_txtx)
         CALL push_field(tx_f, 'tmp', istag=istag, jstag=jstag, kstag=kstag, &
             units=units_tx)
-        CALL set_field_arr(tx_f, 0.0_realk)
+        CALL zero_field_arr(tx_f)
 
         ! central difference on scalar (= no staggering)
         CALL differentiate(tx_f, t_f, ivar)

--- a/src/scalar/timeintegrate_scalar_mod.F90
+++ b/src/scalar/timeintegrate_scalar_mod.F90
@@ -38,10 +38,10 @@ CONTAINS
         CALL push_field(qtu, "QTU", istag=1)
         CALL push_field(qtv, "QTV", jstag=1)
         CALL push_field(qtw, "QTW", kstag=1)
-        CALL set_field_arr(qtt, 0.0_realk)
-        CALL set_field_arr(qtu, 0.0_realk)
-        CALL set_field_arr(qtv, 0.0_realk)
-        CALL set_field_arr(qtw, 0.0_realk)
+        CALL zero_field_arr(qtt)
+        CALL zero_field_arr(qtu)
+        CALL zero_field_arr(qtv)
+        CALL zero_field_arr(qtw)
 
         CALL stop_timer(401)
 


### PR DESCRIPTION
This PR replaces PR #231

The first commit of these PR's is identical - it introduce the `-DMGLET_WORKAROUNDS=ON` CMake option to selectively enable the neccesary workarounds for the 1-D kernel launch bugs.

Where the PR's differ is the follow-up - where PR #231 introuce BLAS and HIP to do the 1-D kernels this PR use C/C++. This is in my opinion a better choice.