### PR TITLE
Improve OpenMP CMake Integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ option(MGLET_OFFLOAD "Enable OpenMP offloading (experimental)" OFF)
 option(MGLET_WORKAROUNDS "Enable OpenMP offloading workarounds" OFF)
 if(MGLET_OFFLOAD)
     message(STATUS "Enabling OpenMP offloading")
-    find_package(OpenMP REQUIRED)
+    find_package(OpenMP REQUIRED COMPONENTS C CXX Fortran)
     add_compile_definitions(_MGLET_OFFLOAD_=1)
 endif()
 
@@ -115,6 +115,23 @@ set(MGLET_Fortran_FLAGS_DEBUG "" CACHE STRING "MGLET Fortran flags (debug)")
 if(MGLET_OFFLOAD)
     set(MGLET_OFFLOAD_COMPILE_FLAGS "" CACHE STRING "MGLET Offload compile flags")
     set(MGLET_OFFLOAD_ARCH_FLAGS "" CACHE STRING "MGLET Offload architecture flags")
+
+    add_library(mglet_openmp INTERFACE)
+    target_link_libraries(mglet_openmp INTERFACE
+        OpenMP::OpenMP_C
+        OpenMP::OpenMP_CXX
+        OpenMP::OpenMP_Fortran
+    )
+    target_compile_options(mglet_openmp INTERFACE
+        ${MGLET_OFFLOAD_COMPILE_FLAGS}
+        ${MGLET_OFFLOAD_ARCH_FLAGS}
+    )
+    target_link_options(mglet_openmp INTERFACE
+        "$<$<LINK_LANGUAGE:C>:SHELL:${OpenMP_C_FLAGS}>"
+        "$<$<LINK_LANGUAGE:CXX>:SHELL:${OpenMP_CXX_FLAGS}>"
+        "$<$<LINK_LANGUAGE:Fortran>:SHELL:${OpenMP_Fortran_FLAGS}>"
+        ${MGLET_OFFLOAD_ARCH_FLAGS}
+    )
 endif()
 
 add_compile_options("$<$<COMPILE_LANGUAGE:C>:${MGLET_C_FLAGS}>"
@@ -138,20 +155,11 @@ add_compile_options("$<$<COMPILE_LANGUAGE:C>:${MGLET_C_FLAGS}>"
     # as soon as a Fortran 2023 compiler is available.
     "$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<STREQUAL:${CMAKE_Fortran_COMPILER_ID},GNU>>:-ffree-line-length-none>"
     "$<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<STREQUAL:${CMAKE_Fortran_COMPILER_ID},IntelLLVM>>:-diag-disable 5268>"
-)
 
-if (MGLET_OFFLOAD)
-    # All libraries get Fortran offloading support. C/CXX offloading support
-    # is only added selectively to individual libraries that need it.
-    # Otherwise clang/clang++ complain about being given offload flags when
-    # no pragmas are actually used in any c/cxx files e.g. in core.
-    add_compile_options("$<$<COMPILE_LANGUAGE:Fortran>:${MGLET_OFFLOAD_COMPILE_FLAGS}>"
-        "$<$<COMPILE_LANGUAGE:Fortran>:${MGLET_OFFLOAD_ARCH_FLAGS}>"
-    )
-    add_link_options("$<$<LINK_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}>"
-        "$<$<LINK_LANGUAGE:Fortran>:${MGLET_OFFLOAD_ARCH_FLAGS}>"
-    )
-endif()
+    # GCC warns about ignored OpenMP pragmas when OpenMP is disabled.
+    "$<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-unknown-pragmas>"
+    "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-unknown-pragmas>"
+)
 
 # nlohman JSON parser library
 include(FetchContent)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,7 @@ target_link_libraries(mgletlib
     PUBLIC plugins
     PUBLIC scalar
     PRIVATE ${MPI_Fortran_LIBRARIES}
-    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_Fortran>
+    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:mglet_openmp>
 )
 
 # Executable
@@ -38,7 +38,7 @@ target_link_libraries(mglet
     PUBLIC mgletlib
     PRIVATE ${HDF5_Fortran_LIBRARIES}
     PRIVATE ${MPI_Fortran_LIBRARIES}
-    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_Fortran>
+    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:mglet_openmp>
 )
 
 # When using the NAG Fortran compiler, use the CXX linker (usually GCC),

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -64,20 +64,11 @@ target_include_directories(core
     PRIVATE ${HDF5_Fortran_INCLUDE_DIRS}
 )
 
-target_compile_options(core
-    PRIVATE "$<$<AND:$<BOOL:${MGLET_OFFLOAD}>,$<COMPILE_LANGUAGE:C>>:${MGLET_OFFLOAD_COMPILE_FLAGS}>"
-    PRIVATE "$<$<AND:$<BOOL:${MGLET_OFFLOAD}>,$<COMPILE_LANGUAGE:C>>:${MGLET_OFFLOAD_ARCH_FLAGS}>"
-    PRIVATE "$<$<AND:$<BOOL:${MGLET_OFFLOAD}>,$<COMPILE_LANGUAGE:CXX>>:${MGLET_OFFLOAD_COMPILE_FLAGS}>"
-    PRIVATE "$<$<AND:$<BOOL:${MGLET_OFFLOAD}>,$<COMPILE_LANGUAGE:CXX>>:${MGLET_OFFLOAD_ARCH_FLAGS}>"
-)
-
 target_link_libraries(core
     PRIVATE ${MPI_Fortran_LIBRARIES}
     PRIVATE ${HDF5_Fortran_LIBRARIES}
     PRIVATE ZLIB::ZLIB
-    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_Fortran>
-    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_C>
-    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_CXX>
+    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:mglet_openmp>
     PRIVATE $<$<STREQUAL:${MGLET_PROFILE_ANNOTATIONS},roctx>:rocprofiler-sdk-roctx::rocprofiler-sdk-roctx>
     PRIVATE $<$<STREQUAL:${MGLET_PROFILE_ANNOTATIONS},nvtx>:CUDA::nvtx3>
 )
@@ -91,10 +82,6 @@ set_source_files_properties(jsoncpp_wrapper.cxx PROPERTIES INCLUDE_DIRECTORIES
 )
 
 set_property(TARGET core PROPERTY CXX_STANDARD 17)
-
-set_source_files_properties(device_workarounds.cxx PROPERTIES COMPILE_FLAGS
-    $<$<STREQUAL:"${CMAKE_CXX_COMPILER_ID}","GNU">:-Wno-unknown-pragmas>
-)
 
 # Other neccesary compile flags
 set_source_files_properties(exprtk_wrapper.cxx PROPERTIES COMPILE_FLAGS

--- a/src/flow/CMakeLists.txt
+++ b/src/flow/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(flow
     PRIVATE core
     PRIVATE ib
     PRIVATE ${MPI_Fortran_LIBRARIES}
-    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_Fortran>
+    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:mglet_openmp>
 )
 
 set_source_files_properties(pressuresolver_mod.F90 PROPERTIES COMPILE_FLAGS

--- a/src/ib/CMakeLists.txt
+++ b/src/ib/CMakeLists.txt
@@ -66,7 +66,7 @@ target_include_directories(ib
 target_link_libraries(ib
     PRIVATE core
     PRIVATE ${MPI_Fortran_LIBRARIES}
-    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_Fortran>
+    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:mglet_openmp>
 )
 
 set_source_files_properties(checkzelle_mod.F90 PROPERTIES COMPILE_FLAGS

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -16,5 +16,5 @@ target_link_libraries(plugins
     PRIVATE ib
     PRIVATE ${MPI_Fortran_LIBRARIES}
     PRIVATE ${HDF5_Fortran_LIBRARIES}
-    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_Fortran>
+    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:mglet_openmp>
 )

--- a/src/scalar/CMakeLists.txt
+++ b/src/scalar/CMakeLists.txt
@@ -22,19 +22,5 @@ target_link_libraries(scalar
     PRIVATE ib
     PRIVATE flow
     PRIVATE ${MPI_Fortran_LIBRARIES}
-    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_Fortran>
-    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_C>
-    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:OpenMP::OpenMP_CXX>
-)
-
-target_compile_options(scalar
-    PRIVATE "$<$<AND:$<BOOL:${MGLET_OFFLOAD}>,$<COMPILE_LANGUAGE:C>>:${MGLET_OFFLOAD_COMPILE_FLAGS}>"
-    PRIVATE "$<$<AND:$<BOOL:${MGLET_OFFLOAD}>,$<COMPILE_LANGUAGE:C>>:${MGLET_OFFLOAD_ARCH_FLAGS}>"
-    PRIVATE "$<$<AND:$<BOOL:${MGLET_OFFLOAD}>,$<COMPILE_LANGUAGE:CXX>>:${MGLET_OFFLOAD_COMPILE_FLAGS}>"
-    PRIVATE "$<$<AND:$<BOOL:${MGLET_OFFLOAD}>,$<COMPILE_LANGUAGE:CXX>>:${MGLET_OFFLOAD_ARCH_FLAGS}>"
-)
-
-# GCC complains about unknown pragmas if we compile without -fopenmp
-set_source_files_properties(gc_scastencils.cxx PROPERTIES COMPILE_FLAGS
-    $<$<STREQUAL:"${CMAKE_CXX_COMPILER_ID}","GNU">:-Wno-unknown-pragmas>
+    PRIVATE $<$<BOOL:${MGLET_OFFLOAD}>:mglet_openmp>
 )


### PR DESCRIPTION
No more hacks and warning suppression required

GNU is quite strict and does not allow `#pragma omp` if OpenMP is not linked against. I think we should just silence this.