### PR TITLE
Make All Data Sharing Attributes Explicit

### DIFF
--- a/src/flow/pressuresolver_mod.F90
+++ b/src/flow/pressuresolver_mod.F90
@@ -865,7 +865,7 @@ CONTAINS
         ! Local variables
         INTEGER(intk) :: k, j, i
 
-        !$omp do collapse(3)
+        !$omp do collapse(3) private(i, j, k)
         DO i = 2, ii-1
             DO j = 2, jj-1
                 DO k = 2, kk-1
@@ -875,7 +875,7 @@ CONTAINS
         END DO
         !$omp end do
 
-        !$omp do collapse(3)
+        !$omp do collapse(3) private(i, j, k)
         DO i = 2, ii-2
             DO j = 3, jj-2
                 DO k = 3, kk-2
@@ -887,7 +887,7 @@ CONTAINS
         END DO
         !$omp end do
 
-        !$omp do collapse(3)
+        !$omp do collapse(3) private(i, j, k)
         DO i = 3, ii-2
             DO j = 2, jj - 2
                 DO k = 3, kk-2
@@ -899,7 +899,7 @@ CONTAINS
         END DO
         !$omp end do
 
-        !$omp do collapse(3)
+        !$omp do collapse(3) private(i, j, k)
         DO i = 3, ii-2
             DO j = 3, jj-2
                 DO k = 2, kk-2

--- a/src/flow/sip_hyperplane_mod.F90
+++ b/src/flow/sip_hyperplane_mod.F90
@@ -466,7 +466,6 @@ CONTAINS
         ! Subroutine body
         n3dmin = 3 + 3 + 3
         n3dmax = (ii-2) + (jj-2) + (kk-2)
-        iacc = -1
 
         ! Iterating over the hyperplanes H(k, j, i) = m
         DO m = n3dmin, n3dmax
@@ -475,7 +474,7 @@ CONTAINS
             lp = INT(mip(m+1), intk) - lm
 
             ! > Parallel operations on the hyperplane (k, j, i) = m
-            !$omp do
+            !$omp do private(ip, idx, idx_km, idx_jm, idx_im, iacc)
             DO ip = 1, lp
 
                 ! Computing the contiguous access index
@@ -529,7 +528,6 @@ CONTAINS
         ! Subroutine body
         n3dmin = 3 + 3 + 3
         n3dmax = (ii-2) + (jj-2) + (kk-2)
-        iacc = -1
 
         ! Iterating (REVERSE) over the hyperplanes H(k, j, i) = m
         DO m = n3dmax, n3dmin, -1
@@ -538,7 +536,7 @@ CONTAINS
             lp = INT(mip(m+1), intk) - lm
 
             ! > Parallel operations on the hyperplane (k, j, i) = m
-            !$omp do
+            !$omp do private(ip, idx, idx_kp, idx_jp, idx_ip, iacc)
             DO ip = 1, lp
 
                 ! Computing the contiguous access index

--- a/src/ib/divcal_mod.F90
+++ b/src/ib/divcal_mod.F90
@@ -70,7 +70,7 @@ CONTAINS
         ! This explains the allocatable array active_levels, which is a copy of
         ! the active_level array of u_f.
 
-        !$omp target teams distribute private(kk, jj, ii, ip3, ip1x, ip1y, &
+        !$omp target teams distribute private(i, kk, jj, ii, ip3, ip1x, ip1y, &
         !$omp& ip1z, igrid, ilevel) &
         !$omp& map(to: active_levels(1:maxlevel-minlevel+1)) &
         !$omp& if(device2)


### PR DESCRIPTION
Add explicit data sharing attributes to places where they are not yet explicit.

Now there should be no remaining loops that use implicit behavior.