### PR TITLE
Separate files for stencil type operations (for llvm 24.0.0)

### DIFF
--- a/src/flow/CMakeLists.txt
+++ b/src/flow/CMakeLists.txt
@@ -8,7 +8,8 @@ add_library(flow STATIC
     flowstat_mod.F90
     gc_compbodyforce_mod.F90
     gc_flowstencils_mod.F90
-    gc_flowstencils.cxx
+    gc_flowstencils_wmxpolquad.cxx
+    gc_flowstencils_wmxpolquadfcorr.cxx
     sip_classic_mod.F90
     sip_hyperplane_mod.F90
     laplacephi_mod.F90

--- a/src/flow/gc_flowstencils_wmxpolquad.cxx
+++ b/src/flow/gc_flowstencils_wmxpolquad.cxx
@@ -1,0 +1,48 @@
+#include "mglet_precision.h"
+
+#include <cstdlib>
+
+constexpr mgletint nvelpts = 6;
+
+struct flowstencil_t {
+    mgletint icell;
+    mgletint npts;
+    mgletint pts[nvelpts];
+    mgletreal coeff[nvelpts];
+    mgletreal acoeff;
+    mgletreal oldsol;
+};
+
+extern "C" void wmxpolquad_c(int iop, size_t first, size_t count,
+        flowstencil_t* stencils, mgletreal* var) {
+    if (count == 0) {
+        return;
+    }
+
+    if (iop == 'F' || iop == 'X') {
+        #pragma omp target teams loop
+        for (size_t i = first; i < first + count; ++i) {
+            auto flux = mgletreal{0.0};
+            for (mgletint j = 0; j < stencils[i].npts; ++j) {
+                const auto pt = stencils[i].pts[j] - 1;
+                flux += var[pt] * stencils[i].coeff[j];
+            }
+            const auto icell = stencils[i].icell - 1;
+            var[icell] = flux + stencils[i].acoeff;
+        }
+    } else if (iop == 'R' || iop == 'Y') {
+        #pragma omp target teams loop
+        for (size_t i = first; i < first + count; ++i) {
+            const auto icell = stencils[i].icell - 1;
+            var[icell] = stencils[i].oldsol;
+        }
+    } else if (iop == 'S' || iop == 'Z') {
+        #pragma omp target teams loop
+        for (size_t i = first; i < first + count; ++i) {
+            const auto icell = stencils[i].icell - 1;
+            stencils[i].oldsol = var[icell];
+        }
+    } else {
+        std::abort();
+    }
+}

--- a/src/flow/gc_flowstencils_wmxpolquadfcorr.cxx
+++ b/src/flow/gc_flowstencils_wmxpolquadfcorr.cxx
@@ -3,17 +3,6 @@
 #include <cstdlib>
 #include <limits>
 
-constexpr mgletint nvelpts = 6;
-
-struct flowstencil_t {
-    mgletint icell;
-    mgletint npts;
-    mgletint pts[nvelpts];
-    mgletreal coeff[nvelpts];
-    mgletreal acoeff;
-    mgletreal oldsol;
-};
-
 struct fcorrstencil_t {
     mgletint pts[6];
     mgletreal area[6];
@@ -21,42 +10,6 @@ struct fcorrstencil_t {
     mgletreal dvol;
     mgletreal acoeff;
 };
-
-
-extern "C" void wmxpolquad_c(int iop, size_t first, size_t count,
-        flowstencil_t* stencils, mgletreal* var) {
-    if (count == 0) {
-        return;
-    }
-
-    if (iop == 'F' || iop == 'X') {
-        #pragma omp target teams loop
-        for (size_t i = first; i < first + count; ++i) {
-            auto flux = mgletreal{0.0};
-            for (mgletint j = 0; j < stencils[i].npts; ++j) {
-                const auto pt = stencils[i].pts[j] - 1;
-                flux += var[pt] * stencils[i].coeff[j];
-            }
-            const auto icell = stencils[i].icell - 1;
-            var[icell] = flux + stencils[i].acoeff;
-        }
-    } else if (iop == 'R' || iop == 'Y') {
-        #pragma omp target teams loop
-        for (size_t i = first; i < first + count; ++i) {
-            const auto icell = stencils[i].icell - 1;
-            var[icell] = stencils[i].oldsol;
-        }
-    } else if (iop == 'S' || iop == 'Z') {
-        #pragma omp target teams loop
-        for (size_t i = first; i < first + count; ++i) {
-            const auto icell = stencils[i].icell - 1;
-            stencils[i].oldsol = var[icell];
-        }
-    } else {
-        std::abort();
-    }
-}
-
 
 extern "C" void wmxpolquadfcorr_c(size_t first, size_t count,
         const fcorrstencil_t* stencils, mgletreal* u, mgletreal* v,


### PR DESCRIPTION
@hakostra 

In the end, I observed that commenting one function (nay of the two) solved the linking error. So the only thing that helped to compile with flang version 24.0.0git was to separate the two functions into different files...

After even C does no longer seem to be save terrain for this compiler, I am considering giving up for now...

Best regards,

Simon
