### PR TITLE
Parity test on ftoc2

### DIFF
--- a/src/ib/ftoc/ftoc2_mod.F90
+++ b/src/ib/ftoc/ftoc2_mod.F90
@@ -1945,71 +1945,79 @@ CONTAINS
         ! none...
 
         ! Local variables
-        TYPE(field_t) :: udummy, vdummy, wdummy, pdummy
+        TYPE(field_t) :: udummy1, vdummy1, wdummy1, pdummy1
+        TYPE(field_t) :: udummy2, vdummy2, wdummy2, pdummy2
         INTEGER(intk) :: ilevel
-        REAL(realk), ALLOCATABLE :: uref(:), vref(:), wref(:), pref(:)
 
         is_recording = .TRUE.
 
-        CALL udummy%init("U_DUMMY", istag=1)
-        CALL vdummy%init("V_DUMMY", jstag=1)
-        CALL wdummy%init("W_DUMMY", kstag=1)
-        CALL pdummy%init("P_DUMMY")
+        CALL udummy2%init("U_DUMMY", istag=1)
+        CALL vdummy2%init("V_DUMMY", jstag=1)
+        CALL wdummy2%init("W_DUMMY", kstag=1)
+        CALL pdummy2%init("P_DUMMY")
 
-        CALL init_dummy_fields_cpu(udummy, vdummy, wdummy, pdummy)
-        CALL connect(layers=2, v1=udummy, v2=vdummy, v3=wdummy, s1=pdummy, &
+        CALL init_dummy_fields_cpu(udummy2, vdummy2, wdummy2, pdummy2)
+        CALL connect(layers=2, v1=udummy2, v2=vdummy2, v3=wdummy2, s1=pdummy2, &
             corners=.TRUE.)
 
-        !$omp target enter data map(to: udummy%arr, vdummy%arr, wdummy%arr, &
-        !$omp& pdummy%arr)
+        !$omp target enter data map(to: udummy2%arr, vdummy2%arr, wdummy2%arr, &
+        !$omp& pdummy2%arr)
 
         ! START -- This section defines the record variants of ftoc2 ---
 
         DO ilevel = maxlevel, minlevel, -1
             ! Outer pressuresolver iterations
-            CALL ftoc2(ilevel, pdummy, pdummy, flag='P')
+            CALL ftoc2(ilevel, pdummy2, pdummy2, flag='P')
             ! Pre pressuresolver iterations in mgpoisl
-            CALL ftoc2(ilevel, pdummy, pdummy, flag='R')
+            CALL ftoc2(ilevel, pdummy2, pdummy2, flag='R')
             ! Post pressuresolver iterations in mgpoisl
-            CALL ftoc2(ilevel, udummy, vdummy, wdummy, pdummy)
+            CALL ftoc2(ilevel, udummy2, vdummy2, wdummy2, pdummy2)
         END DO
 
-        !$omp target exit data map(from: udummy%arr, vdummy%arr, wdummy%arr, &
-        !$omp& pdummy%arr)
+        !$omp target exit data map(from: udummy2%arr, vdummy2%arr, wdummy2%arr, &
+        !$omp& pdummy2%arr)
 
-        ! Storing the reference values for later comparison with the CPU version
-        ALLOCATE(uref, source=udummy%arr)
-        ALLOCATE(vref, source=vdummy%arr)
-        ALLOCATE(wref, source=wdummy%arr)
-        ALLOCATE(pref, source=pdummy%arr)
+
+        CALL udummy1%init("U_DUMMY", istag=1)
+        CALL vdummy1%init("V_DUMMY", jstag=1)
+        CALL wdummy1%init("W_DUMMY", kstag=1)
+        CALL pdummy1%init("P_DUMMY")
+
+        CALL init_dummy_fields_cpu(udummy1, vdummy1, wdummy1, pdummy1)
+        CALL connect(layers=2, v1=udummy1, v2=vdummy1, v3=wdummy1, s1=pdummy1, &
+            corners=.TRUE.)
 
         ! Repeating the same calls with the CPU function
         ! ("ftoc1" is already initialized at this point)
 
-        CALL init_dummy_fields_cpu(udummy, vdummy, wdummy, pdummy)
-        CALL connect(layers=2, v1=udummy, v2=vdummy, v3=wdummy, s1=pdummy, &
-            corners=.TRUE.)
-
         DO ilevel = maxlevel, minlevel, -1
             ! Outer pressuresolver iterations
-            CALL ftoc1(ilevel, pdummy, pdummy, flag='P')
+            CALL ftoc1(ilevel, pdummy1, pdummy1, flag='P')
             ! Pre pressuresolver iterations in mgpoisl
-            CALL ftoc1(ilevel, pdummy, pdummy, flag='R')
+            CALL ftoc1(ilevel, pdummy1, pdummy1, flag='R')
             ! Post pressuresolver iterations in mgpoisl
-            CALL ftoc1(ilevel, udummy, vdummy, wdummy, pdummy)
+            CALL ftoc1(ilevel, udummy1, vdummy1, wdummy1, pdummy1)
         END DO
 
         ! END -- This section defines the record variants of ftoc2 ---
 
-        CALL assert_same_field(uref, udummy)
-        CALL assert_same_field(vref, vdummy)
-        CALL assert_same_field(wref, wdummy)
-        CALL assert_same_field(pref, pdummy)
+        CALL assert_same_field(udummy1, udummy2)
+        CALL assert_same_field(vdummy1, vdummy2)
+        CALL assert_same_field(wdummy1, wdummy2)
+        CALL assert_same_field(pdummy1, pdummy2)
 
-        CALL udummy%finish()
-        CALL vdummy%finish()
-        CALL wdummy%finish()
-        CALL pdummy%finish()
+        CALL writevtk(field1=pdummy1, prefix="CPU")
+        CALL writevtk(field1=pdummy2, prefix="GPU")
+
+        CALL udummy1%finish()
+        CALL vdummy1%finish()
+        CALL wdummy1%finish()
+        CALL pdummy1%finish()
+
+        CALL udummy2%finish()
+        CALL vdummy2%finish()
+        CALL wdummy2%finish()
+        CALL pdummy2%finish()
 
         is_recording = .FALSE.
     END SUBROUTINE run_recording_pass
@@ -2039,24 +2047,42 @@ CONTAINS
     END SUBROUTINE init_dummy_fields_cpu
 
 
-    SUBROUTINE assert_same_field(ref, field_f)
+    SUBROUTINE assert_same_field(field1_f, field2_f)
         ! Subroutine arguments
-        REAL(realk), INTENT(in) :: ref(:)
-        TYPE(field_t), INTENT(in) :: field_f
+        TYPE(field_t), INTENT(in) :: field1_f, field2_f
         ! Local variables
         REAL(realk) :: diff_local, diff_global
-        INTEGER(intk) :: ierr
+        INTEGER(intk) :: ierr, i, igrid
+        REAL(realk), POINTER, CONTIGUOUS :: arr1(:, :, :), arr2(:, :, :)
         LOGICAL :: is_same = .TRUE.
 
+
+        DO i = 1, nmygrids
+            igrid = mygrids(i)
+            CALL field1_f%get_ptr(arr1, igrid)
+            CALL field2_f%get_ptr(arr2, igrid)
+
+            ! Compute the maximum absolute difference between the array
+            diff_local = MAXVAL(ABS(arr1 - arr2))
+            IF (diff_local > 3.0 * eps) THEN
+                IF (myid == 0) THEN
+                    WRITE(*, *) "field name: ", TRIM(field1_f%name), &
+                        "  with maxdiff = ", diff_local, " on grid ", igrid
+                END IF
+                is_same = .FALSE.
+            END IF
+        END DO
+
+
         ! Compute the maximum absolute difference between the array
-        diff_local = MAXVAL(ABS(ref - field_f%arr))
+        diff_local = MAXVAL(ABS(field1_f%arr - field2_f%arr))
 
         CALL MPI_Allreduce(diff_local, diff_global, 1, mglet_mpi_real, &
             MPI_MAX, MPI_COMM_WORLD, ierr)
 
         IF (diff_global > 3.0 * eps) THEN
             IF (myid == 0) THEN
-                WRITE(*, *) "field name: ", TRIM(field_f%name), &
+                WRITE(*, *) "field name: ", TRIM(field1_f%name), &
                     "  with maxdiff = ", diff_global
             END IF
             is_same = .FALSE.

--- a/src/ib/ftoc/ftoc2_mod.F90
+++ b/src/ib/ftoc/ftoc2_mod.F90
@@ -1947,6 +1947,7 @@ CONTAINS
         ! Local variables
         TYPE(field_t) :: udummy, vdummy, wdummy, pdummy
         INTEGER(intk) :: ilevel
+        REAL(realk), ALLOCATABLE :: uref(:), vref(:), wref(:), pref(:)
 
         is_recording = .TRUE.
 
@@ -1956,7 +1957,6 @@ CONTAINS
         CALL pdummy%init("P_DUMMY")
 
         CALL init_dummy_fields_cpu(udummy, vdummy, wdummy, pdummy)
-
         CALL connect(layers=2, v1=udummy, v2=vdummy, v3=wdummy, s1=pdummy, &
             corners=.TRUE.)
 
@@ -1974,8 +1974,21 @@ CONTAINS
             CALL ftoc2(ilevel, udummy, vdummy, wdummy, pdummy)
         END DO
 
-        ! Repeating the same calls with the CPU function !
+        !$omp target exit data map(from: udummy%arr, vdummy%arr, wdummy%arr, &
+        !$omp& pdummy%arr)
+
+        ! Storing the reference values for later comparison with the CPU version
+        ALLOCATE(uref, source=udummy%arr)
+        ALLOCATE(vref, source=vdummy%arr)
+        ALLOCATE(wref, source=wdummy%arr)
+        ALLOCATE(pref, source=pdummy%arr)
+
+        ! Repeating the same calls with the CPU function
         ! ("ftoc1" is already initialized at this point)
+
+        CALL init_dummy_fields_cpu(udummy, vdummy, wdummy, pdummy)
+        CALL connect(layers=2, v1=udummy, v2=vdummy, v3=wdummy, s1=pdummy, &
+            corners=.TRUE.)
 
         DO ilevel = maxlevel, minlevel, -1
             ! Outer pressuresolver iterations
@@ -1988,13 +2001,10 @@ CONTAINS
 
         ! END -- This section defines the record variants of ftoc2 ---
 
-        CALL assert_same_field(udummy)
-        CALL assert_same_field(vdummy)
-        CALL assert_same_field(wdummy)
-        CALL assert_same_field(pdummy)
-
-        !$omp target exit data map(delete: udummy%arr, vdummy%arr, wdummy%arr, &
-        !$omp& pdummy%arr)
+        CALL assert_same_field(uref, udummy)
+        CALL assert_same_field(vref, vdummy)
+        CALL assert_same_field(wref, wdummy)
+        CALL assert_same_field(pref, pdummy)
 
         CALL udummy%finish()
         CALL vdummy%finish()
@@ -2029,24 +2039,17 @@ CONTAINS
     END SUBROUTINE init_dummy_fields_cpu
 
 
-    SUBROUTINE assert_same_field(field_f)
+    SUBROUTINE assert_same_field(ref, field_f)
         ! Subroutine arguments
+        REAL(realk), INTENT(in) :: ref(:)
         TYPE(field_t), INTENT(in) :: field_f
         ! Local variables
-        REAL(realk), ALLOCATABLE :: arr(:)
         REAL(realk) :: diff_local, diff_global
         INTEGER(intk) :: ierr
         LOGICAL :: is_same = .TRUE.
 
-        ! Store the field on the host into antoher array
-        ALLOCATE(arr(SIZE(field_f%arr)))
-        arr = field_f%arr
-
-        ! Update the field from the device to the host
-        !$omp target update from(field_f%arr)
-
         ! Compute the maximum absolute difference between the array
-        diff_local = MAXVAL(ABS(arr - field_f%arr))
+        diff_local = MAXVAL(ABS(ref - field_f%arr))
 
         CALL MPI_Allreduce(diff_local, diff_global, 1, mglet_mpi_real, &
             MPI_MAX, MPI_COMM_WORLD, ierr)
@@ -2058,9 +2061,7 @@ CONTAINS
             END IF
             is_same = .FALSE.
         END IF
-        IF (.NOT. is_same) CALL errr(__FILE__, __LINE__)
-
-        DEALLOCATE(arr)
+        ! IF (.NOT. is_same) CALL errr(__FILE__, __LINE__)
 
     END SUBROUTINE assert_same_field
 

--- a/src/ib/ftoc/ftoc2_mod.F90
+++ b/src/ib/ftoc/ftoc2_mod.F90
@@ -1,6 +1,7 @@
 MODULE ftoc2_mod
     USE MPI_f08
     USE core_mod
+    USE ftoc1_mod, ONLY: ftoc1
     USE ftoc_core_mod
     USE ibcore_mod, ONLY: ib
     USE gc_restrict_mod
@@ -1879,7 +1880,9 @@ CONTAINS
         is_init = .TRUE.
 
         ! Record relevant calls for later efficient reuse on device
+        ! (includes a parity check with the CPU version)
         CALL run_recording_pass()
+
     END SUBROUTINE init_ftoc2
 
 
@@ -1940,6 +1943,11 @@ CONTAINS
         CALL wdummy%init("W_DUMMY", kstag=1)
         CALL pdummy%init("P_DUMMY")
 
+        CALL init_dummy_fields_cpu(udummy, vdummy, wdummy, pdummy)
+
+        CALL connect(layers=2, v1=udummy, v2=vdummy, v3=wdummy, s1=pdummy, &
+            corners=.TRUE.)
+
         !$omp target enter data map(to: udummy%arr, vdummy%arr, wdummy%arr, &
         !$omp& pdummy%arr)
 
@@ -1954,7 +1962,24 @@ CONTAINS
             CALL ftoc2(ilevel, udummy, vdummy, wdummy, pdummy)
         END DO
 
+        ! Repeating the same calls with the CPU function !
+        ! ("ftoc1" is already initialized at this point)
+
+        DO ilevel = maxlevel, minlevel, -1
+            ! Outer pressuresolver iterations
+            CALL ftoc1(ilevel, pdummy, pdummy, flag='P')
+            ! Pre pressuresolver iterations in mgpoisl
+            CALL ftoc1(ilevel, pdummy, pdummy, flag='R')
+            ! Post pressuresolver iterations in mgpoisl
+            CALL ftoc1(ilevel, udummy, vdummy, wdummy, pdummy)
+        END DO
+
         ! END -- This section defines the record variants of ftoc2 ---
+
+        CALL assert_same_field(udummy)
+        CALL assert_same_field(vdummy)
+        CALL assert_same_field(wdummy)
+        CALL assert_same_field(pdummy)
 
         !$omp target exit data map(delete: udummy%arr, vdummy%arr, wdummy%arr, &
         !$omp& pdummy%arr)
@@ -1966,6 +1991,66 @@ CONTAINS
 
         is_recording = .FALSE.
     END SUBROUTINE run_recording_pass
+
+
+    SUBROUTINE init_dummy_fields_cpu(u_f, v_f, w_f, p_f)
+        ! Subroutine arguments
+        TYPE(field_t), INTENT(inout) :: u_f, v_f, w_f, p_f
+        ! Local variables
+        INTEGER(intk) :: i
+        DO i = 1, SIZE(u_f%arr)
+            u_f%arr(i) = REAL(MOD(17_intk*i + 11_intk, 997_intk), realk) * &
+                1.0e-3_realk
+        END DO
+        DO i = 1, SIZE(v_f%arr)
+            v_f%arr(i) = REAL(MOD(23_intk*i + 7_intk, 991_intk), realk) * &
+                1.0e-3_realk
+        END DO
+        DO i = 1, SIZE(w_f%arr)
+            w_f%arr(i) = REAL(MOD(31_intk*i + 5_intk, 983_intk), realk) * &
+                1.0e-3_realk
+        END DO
+        DO i = 1, SIZE(p_f%arr)
+            p_f%arr(i) = REAL(MOD(47_intk*i + 3_intk, 977_intk), realk) * &
+                1.0e-3_realk
+        END DO
+    END SUBROUTINE init_dummy_fields_cpu
+
+
+    SUBROUTINE assert_same_field(field_f)
+        ! Subroutine arguments
+        TYPE(field_t), INTENT(in) :: field_f
+        ! Local variables
+        REAL(realk), ALLOCATABLE :: arr(:)
+        REAL(realk) :: diff_local, diff_global
+        INTEGER(intk) :: ierr
+        LOGICAL :: is_same = .TRUE.
+
+        ! Store the field on the host into antoher array
+        ALLOCATE(arr(SIZE(field_f%arr)))
+        arr = field_f%arr
+
+        ! Update the field from the device to the host
+        !$omp target update from(field_f%arr)
+
+        ! Compute the maximum absolute difference between the array
+        diff_local = MAXVAL(ABS(arr - field_f%arr))
+
+        CALL MPI_Allreduce(diff_local, diff_global, 1, mglet_mpi_real, &
+            MPI_MAX, MPI_COMM_WORLD, ierr)
+
+        IF (diff_global > 3.0 * eps) THEN
+            IF (myid == 0) THEN
+                WRITE(*, *) "field name: ", TRIM(field_f%name), &
+                    "  with maxdiff = ", diff_global
+            END IF
+            is_same = .FALSE.
+        END IF
+        IF (.NOT. is_same) CALL errr(__FILE__, __LINE__)
+
+        DEALLOCATE(arr)
+
+    END SUBROUTINE assert_same_field
 
 
     SUBROUTINE count_selftasks(nselfsend, nselfrecv)

--- a/src/ib/ftoc/ftoc2_mod.F90
+++ b/src/ib/ftoc/ftoc2_mod.F90
@@ -882,55 +882,67 @@ CONTAINS
                     ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
                     scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
+                !$omp barrier
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a1(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
                     tasksize, istart, istop, jstart, jstop, kstart, kstop, &
                     ipos, jpos, kpos)
+                !$omp barrier
             CASE (2)
                 CALL restrict_gc_flag(flag, kkf, jjf, iif, a2(ip3f), &
                     ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
                     scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
+                !$omp barrier
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a2(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
                     tasksize, istart, istop, jstart, jstop, kstart, kstop, &
                     ipos, jpos, kpos)
+                !$omp barrier
             CASE (3)
                 CALL restrict_gc_flag(flag, kkf, jjf, iif, a3(ip3f), &
                     ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
                     scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
+                !$omp barrier
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a3(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
                     tasksize, istart, istop, jstart, jstop, kstart, kstop, &
                     ipos, jpos, kpos)
+                !$omp barrier
             CASE (4)
                 CALL restrict_gc_flag(flag, kkf, jjf, iif, a4(ip3f), &
                     ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
                     scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
+                !$omp barrier
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a4(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
                     tasksize, istart, istop, jstart, jstop, kstart, kstop, &
                     ipos, jpos, kpos)
+                !$omp barrier
             CASE (5)
                 CALL restrict_gc_flag(flag, kkf, jjf, iif, a5(ip3f), &
                     ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
                     scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
+                !$omp barrier
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a5(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
                     tasksize, istart, istop, jstart, jstop, kstart, kstop, &
                     ipos, jpos, kpos)
+                !$omp barrier
             CASE (6)
                 CALL restrict_gc_flag(flag, kkf, jjf, iif, a6(ip3f), &
                     ddx(ipx), ddy(ipy), ddz(ipz), bp(ip3f), bt(ip3f), &
                     scratchidx, tasksize, istart, istop, jstart, jstop, &
                     kstart, kstop)
+                !$omp barrier
                 CALL unpack_restricted_buffer(flag, kkc, jjc, iic, &
                     a6(ip3c), sendbuf(scratchidx:scratchidx+tasksize-1), &
                     tasksize, istart, istop, jstart, jstop, kstart, kstop, &
                     ipos, jpos, kpos)
+                !$omp barrier
             CASE DEFAULT
                 CALL errr(__FILE__, __LINE__)
             END SELECT


### PR DESCRIPTION
Dear all,

during my work with LLVM, I took a more careful look at the communication routines, as I could not rely on the compiler to build reasonable device kernels.

One "tool" (see also simon/running-on-spark) was to include "parity checks", I which I compared the results from the offloaded "routine2" to the host-based routine "routine1". In most cases, this approach allowed me to fix bad kernels.

For ftoc2 vs. ftoc1, however, the differences could not be resolved. The test (see this PR) with the steps

- initialize fields and connect (important note here)
- do ftoc operations on host and device
- compare the outcome

fails with different values returned as the maximal difference for different repetitions of the test. To me, that indicates that we have race conditions, where different values are written to the same location. Despite the "heavy connect", this issues seems to remain. It is also observed for the P-field, where the cell responsibilities should be very clear.

I wanted to mention and document this finding, as it could be a symptom of a bug or at least a point we should keep in mind if we consider reproducibility.

Best regards,

Simon 