### PR TITLE
Bugfix wrong INTENT

### DIFF
--- a/src/core/fieldhelper_mod.F90
+++ b/src/core/fieldhelper_mod.F90
@@ -233,8 +233,8 @@ CONTAINS
 
     SUBROUTINE map_arr_from_device(f1, f2, f3, f4, f5, f6, f7, message)
         ! Subroutine arguments
-        TYPE(field_t), INTENT(in) :: f1
-        TYPE(field_t), INTENT(in), OPTIONAL :: f2, f3, f4, f5, f6, f7
+        TYPE(field_t), INTENT(inout) :: f1
+        TYPE(field_t), INTENT(inout), OPTIONAL :: f2, f3, f4, f5, f6, f7
         CHARACTER(*), INTENT(in), OPTIONAL :: message
 
         ! Local variables
@@ -281,8 +281,8 @@ CONTAINS
 
     SUBROUTINE map_buffers_from_device(f1, f2, f3, message)
         ! Subroutine arguments
-        TYPE(field_t), INTENT(in) :: f1
-        TYPE(field_t), INTENT(in), OPTIONAL :: f2, f3
+        TYPE(field_t), INTENT(inout) :: f1
+        TYPE(field_t), INTENT(inout), OPTIONAL :: f2, f3
         CHARACTER(*), INTENT(in), OPTIONAL :: message
 
         ! Local variables


### PR DESCRIPTION
Found this by compiling with `ifx` and offloading enabled. For reference, the error is:

```
[  9%] Building Fortran object src/core/CMakeFiles/core.dir/fieldhelper_mod.F90.o
/home/hakostra/MGLET/mglet-base/src/core/fieldhelper_mod.F90(250): error #8627: The FROM map-type is ignored for INTENT(IN) dummy arguments.   [F1]
!$omp target update from(f1%arr)
-------------------------^
```

I need a few more fixes before MGLET compiles, but this seems to be an obvious bug. The other fixes I am not so sure about (I will check and discuss with one of you).

I am also open to declare the `INTENT(inout)` on the `_to_device` - some memory that sits somewhere is changing, so it would not be wrong. But the compiler does not complain.

Running immediately result is a segmentation fault that I have not yet debugged.